### PR TITLE
Ship sinks into water + add click-to-move controls

### DIFF
--- a/js/enemy.js
+++ b/js/enemy.js
@@ -1,0 +1,65 @@
+// enemy.js — simple enemy ships for hit detection targets
+import * as THREE from "three";
+
+var WATER_Y = 0.3;
+
+function buildEnemyMesh() {
+  var group = new THREE.Group();
+
+  // hull — simpler red-tinted ship
+  var hullShape = new THREE.Shape();
+  hullShape.moveTo(0, 1.8);
+  hullShape.lineTo(0.5, 0.6);
+  hullShape.lineTo(0.6, -0.5);
+  hullShape.lineTo(0.5, -1.4);
+  hullShape.lineTo(-0.5, -1.4);
+  hullShape.lineTo(-0.6, -0.5);
+  hullShape.lineTo(-0.5, 0.6);
+  hullShape.lineTo(0, 1.8);
+
+  var hullGeo = new THREE.ExtrudeGeometry(hullShape, { depth: 0.4, bevelEnabled: false });
+  var hullMat = new THREE.MeshLambertMaterial({ color: 0x774444 });
+  var hull = new THREE.Mesh(hullGeo, hullMat);
+  hull.rotation.x = -Math.PI / 2;
+  hull.position.y = -0.1;
+  group.add(hull);
+
+  // deck
+  var deckGeo = new THREE.PlaneGeometry(0.9, 2.6);
+  var deckMat = new THREE.MeshLambertMaterial({ color: 0x885555 });
+  var deck = new THREE.Mesh(deckGeo, deckMat);
+  deck.rotation.x = -Math.PI / 2;
+  deck.position.y = 0.3;
+  group.add(deck);
+
+  // bridge
+  var bridgeGeo = new THREE.BoxGeometry(0.5, 0.5, 0.6);
+  var bridgeMat = new THREE.MeshLambertMaterial({ color: 0x996666 });
+  var bridge = new THREE.Mesh(bridgeGeo, bridgeMat);
+  bridge.position.set(0, 0.55, -0.4);
+  group.add(bridge);
+
+  return group;
+}
+
+export function createEnemies(count) {
+  var enemies = [];
+  for (var i = 0; i < count; i++) {
+    var mesh = buildEnemyMesh();
+    // spread enemies in a ring around origin
+    var angle = (i / count) * Math.PI * 2;
+    var radius = 40 + Math.random() * 30;
+    var x = Math.sin(angle) * radius;
+    var z = Math.cos(angle) * radius;
+    mesh.position.set(x, WATER_Y, z);
+    mesh.rotation.y = Math.random() * Math.PI * 2;
+
+    enemies.push({
+      mesh: mesh,
+      hp: 3,
+      alive: true,
+      hitRadius: 2.0
+    });
+  }
+  return enemies;
+}

--- a/js/hud.js
+++ b/js/hud.js
@@ -1,9 +1,10 @@
-// hud.js — speed indicator and compass overlay
+// hud.js — speed indicator, compass, and ammo counter overlay
 
 var container = null;
 var speedBar = null;
 var speedLabel = null;
 var compassLabel = null;
+var ammoLabel = null;
 
 export function createHUD() {
   container = document.createElement("div");
@@ -55,10 +56,18 @@ export function createHUD() {
   compassLabel.style.color = "#667788";
   container.appendChild(compassLabel);
 
+  // ammo counter
+  ammoLabel = document.createElement("div");
+  ammoLabel.textContent = "AMMO: --";
+  ammoLabel.style.marginTop = "8px";
+  ammoLabel.style.fontSize = "13px";
+  ammoLabel.style.color = "#8899aa";
+  container.appendChild(ammoLabel);
+
   document.body.appendChild(container);
 }
 
-export function updateHUD(speedRatio, displaySpeed, heading) {
+export function updateHUD(speedRatio, displaySpeed, heading, ammo, maxAmmo) {
   if (!container) return;
 
   var pct = Math.min(1, speedRatio) * 100;
@@ -70,4 +79,10 @@ export function updateHUD(speedRatio, displaySpeed, heading) {
   var dirs = ["N", "NE", "E", "SE", "S", "SW", "W", "NW"];
   var idx = Math.round(deg / 45) % 8;
   compassLabel.textContent = dirs[idx] + " " + Math.round(deg) + "\u00B0";
+
+  // ammo counter
+  if (ammo !== undefined) {
+    ammoLabel.textContent = "AMMO: " + ammo + " / " + maxAmmo;
+    ammoLabel.style.color = ammo <= 5 ? "#cc6644" : "#8899aa";
+  }
 }

--- a/js/input.js
+++ b/js/input.js
@@ -1,10 +1,17 @@
-// input.js — keyboard input handler for ship controls
+// input.js — keyboard, mouse, and touch input handler
 
 var keys = {
   forward: false,
   backward: false,
   left: false,
   right: false
+};
+
+var mouse = {
+  x: 0,
+  y: 0,
+  firePressed: false,
+  fireConsumed: false
 };
 
 function onKeyDown(e) {
@@ -22,11 +29,50 @@ function setKey(code, down) {
   if (code === "KeyD" || code === "ArrowRight")  keys.right    = down;
 }
 
+function onMouseMove(e) {
+  mouse.x = e.clientX;
+  mouse.y = e.clientY;
+}
+
+function onMouseDown(e) {
+  if (e.button === 0) {
+    mouse.firePressed = true;
+    mouse.fireConsumed = false;
+  }
+}
+
+function onTouchStart(e) {
+  var touch = e.touches[0];
+  mouse.x = touch.clientX;
+  mouse.y = touch.clientY;
+  mouse.firePressed = true;
+  mouse.fireConsumed = false;
+}
+
+function onTouchMove(e) {
+  var touch = e.touches[0];
+  mouse.x = touch.clientX;
+  mouse.y = touch.clientY;
+}
+
 export function initInput() {
   window.addEventListener("keydown", onKeyDown);
   window.addEventListener("keyup", onKeyUp);
+  window.addEventListener("mousemove", onMouseMove);
+  window.addEventListener("mousedown", onMouseDown);
+  window.addEventListener("touchstart", onTouchStart, { passive: true });
+  window.addEventListener("touchmove", onTouchMove, { passive: true });
 }
 
 export function getInput() {
   return keys;
+}
+
+export function getMouse() {
+  return mouse;
+}
+
+export function consumeFire() {
+  mouse.firePressed = false;
+  mouse.fireConsumed = true;
 }

--- a/js/nav.js
+++ b/js/nav.js
@@ -1,0 +1,114 @@
+// nav.js — click/tap-to-move navigation + destination marker
+import * as THREE from "three";
+import { setNavTarget } from "./ship.js";
+import { getWaveHeight } from "./ocean.js";
+
+var raycaster = new THREE.Raycaster();
+var pointer = new THREE.Vector2();
+var oceanPlane = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0); // y=0 plane
+var intersectPoint = new THREE.Vector3();
+
+var marker = null;
+var markerActive = false;
+var markerTargetX = 0;
+var markerTargetZ = 0;
+
+// --- build destination marker (pulsing ring on water) ---
+function buildMarker() {
+  var group = new THREE.Group();
+
+  var ringGeo = new THREE.RingGeometry(1.0, 1.4, 24);
+  var ringMat = new THREE.MeshBasicMaterial({
+    color: 0x44aaff,
+    side: THREE.DoubleSide,
+    transparent: true,
+    opacity: 0.6,
+    depthWrite: false
+  });
+  var ring = new THREE.Mesh(ringGeo, ringMat);
+  ring.rotation.x = -Math.PI / 2;
+  group.add(ring);
+
+  // inner dot
+  var dotGeo = new THREE.CircleGeometry(0.3, 12);
+  var dotMat = new THREE.MeshBasicMaterial({
+    color: 0x66ccff,
+    side: THREE.DoubleSide,
+    transparent: true,
+    opacity: 0.8,
+    depthWrite: false
+  });
+  var dot = new THREE.Mesh(dotGeo, dotMat);
+  dot.rotation.x = -Math.PI / 2;
+  dot.position.y = 0.05;
+  group.add(dot);
+
+  group.visible = false;
+  return group;
+}
+
+function projectToOcean(clientX, clientY, camera) {
+  pointer.x = (clientX / window.innerWidth) * 2 - 1;
+  pointer.y = -(clientY / window.innerHeight) * 2 + 1;
+
+  raycaster.setFromCamera(pointer, camera);
+  return raycaster.ray.intersectPlane(oceanPlane, intersectPoint);
+}
+
+// --- init click/tap handler ---
+export function initNav(camera, ship, scene) {
+  marker = buildMarker();
+  scene.add(marker);
+
+  function handleNav(clientX, clientY) {
+    var hit = projectToOcean(clientX, clientY, camera);
+    if (hit) {
+      markerTargetX = intersectPoint.x;
+      markerTargetZ = intersectPoint.z;
+      markerActive = true;
+      marker.visible = true;
+      setNavTarget(ship, intersectPoint.x, intersectPoint.z);
+    }
+  }
+
+  // prevent context menu on right-click so nav works
+  window.addEventListener("contextmenu", function (e) {
+    e.preventDefault();
+  });
+
+  // desktop: right-click to set navigation target
+  window.addEventListener("mousedown", function (e) {
+    if (e.button !== 2) return;
+    if (e.target !== document.querySelector("canvas")) return;
+    handleNav(e.clientX, e.clientY);
+  });
+
+  // mobile: tap sets both fire target and navigation
+  window.addEventListener("touchstart", function (e) {
+    if (e.touches.length !== 1) return;
+    var touch = e.touches[0];
+    handleNav(touch.clientX, touch.clientY);
+  }, { passive: true });
+}
+
+// --- update marker position (bob on waves, pulse) ---
+export function updateNav(ship, elapsed) {
+  if (!marker) return;
+
+  // hide marker when ship has no nav target (arrived or WASD override)
+  if (!ship.navTarget) {
+    if (markerActive) {
+      markerActive = false;
+      marker.visible = false;
+    }
+    return;
+  }
+
+  // position marker on water surface at target
+  var waveY = getWaveHeight(markerTargetX, markerTargetZ, elapsed);
+  marker.position.set(markerTargetX, waveY + 0.3, markerTargetZ);
+
+  // pulse effect
+  var pulse = 1.0 + Math.sin(elapsed * 3) * 0.15;
+  marker.scale.set(pulse, 1, pulse);
+}

--- a/js/ocean.js
+++ b/js/ocean.js
@@ -74,3 +74,24 @@ export function createOcean() {
 export function updateOcean(uniforms, elapsed) {
   uniforms.uTime.value = elapsed;
 }
+
+// mirror the vertex shader wave function on the CPU
+// the plane is rotated -PI/2 around X, so shader pos.x = worldX, shader pos.y = worldZ
+export function getWaveHeight(worldX, worldZ, time) {
+  var x = worldX;
+  var y = worldZ;
+  var h = 0;
+
+  // layer 1 — broad swells
+  h += Math.sin(x * 0.3 + time * 0.8) * 1.2;
+  h += Math.sin(y * 0.2 + time * 0.6) * 1.0;
+
+  // layer 2 — medium chop
+  h += Math.sin(x * 0.8 + y * 0.6 + time * 1.4) * 0.5;
+
+  // layer 3 — small ripples
+  h += Math.sin(x * 2.0 + time * 2.0) * 0.15;
+  h += Math.sin(y * 2.5 + time * 1.8) * 0.12;
+
+  return h;
+}

--- a/js/turret.js
+++ b/js/turret.js
@@ -1,0 +1,296 @@
+// turret.js — turret aiming, firing, projectile physics, hit detection, visual effects
+import * as THREE from "three";
+
+// --- tuning ---
+var PROJECTILE_SPEED = 60;
+var GRAVITY = 9.8;
+var MAX_RANGE = 120;
+var FIRE_COOLDOWN = 0.4;        // seconds between shots
+var AMMO_PER_WAVE = 50;
+var MUZZLE_FLASH_DURATION = 0.08;
+var TRAIL_SEGMENT_LIFE = 0.3;
+var SPLASH_DURATION = 0.3;
+
+// --- shared geometry / materials ---
+var projectileGeo = null;
+var projectileMat = null;
+var trailMat = null;
+var flashGeo = null;
+var flashMat = null;
+var splashGeo = null;
+var splashMat = null;
+var aimRaycaster = null;
+var aimNdc = null;
+var waterPlane = null;
+
+function ensureMaterials() {
+  if (projectileGeo) return;
+  projectileGeo = new THREE.SphereGeometry(0.12, 6, 4);
+  projectileMat = new THREE.MeshBasicMaterial({ color: 0xffcc44 });
+  trailMat = new THREE.MeshBasicMaterial({ color: 0xffcc44, transparent: true, opacity: 0.6 });
+  flashGeo = new THREE.SphereGeometry(0.3, 6, 4);
+  flashMat = new THREE.MeshBasicMaterial({ color: 0xffee88, transparent: true, opacity: 0.9 });
+  splashGeo = new THREE.RingGeometry(0.1, 0.6, 8);
+  splashMat = new THREE.MeshBasicMaterial({
+    color: 0x88aacc, transparent: true, opacity: 0.7, side: THREE.DoubleSide
+  });
+  aimRaycaster = new THREE.Raycaster();
+  aimNdc = new THREE.Vector2();
+  waterPlane = new THREE.Plane(new THREE.Vector3(0, 1, 0), -0.3);
+}
+
+// --- turret state ---
+export function createTurretSystem(ship) {
+  ensureMaterials();
+  var turretGroups = ship.mesh.userData.turrets || [];
+  return {
+    ship: ship,
+    turretGroups: turretGroups,
+    projectiles: [],       // active projectiles in scene
+    effects: [],           // muzzle flashes, splashes
+    ammo: AMMO_PER_WAVE,
+    maxAmmo: AMMO_PER_WAVE,
+    cooldown: 0,
+    aimWorldPos: new THREE.Vector3(0, 0, 0)
+  };
+}
+
+// --- aim turrets toward a world-space target ---
+export function aimTurrets(turretState, worldTarget) {
+  turretState.aimWorldPos.copy(worldTarget);
+  var ship = turretState.ship;
+
+  for (var i = 0; i < turretState.turretGroups.length; i++) {
+    var turret = turretState.turretGroups[i];
+
+    // get turret world position
+    var turretWorld = new THREE.Vector3();
+    turret.getWorldPosition(turretWorld);
+
+    // direction from turret to target in world space
+    var dx = worldTarget.x - turretWorld.x;
+    var dz = worldTarget.z - turretWorld.z;
+
+    // angle in world space
+    var worldAngle = Math.atan2(dx, dz);
+
+    // subtract ship heading to get local rotation
+    var localAngle = worldAngle - ship.heading;
+
+    turret.rotation.y = localAngle;
+  }
+}
+
+// --- fire projectile from first available turret ---
+export function fire(turretState, scene) {
+  if (turretState.cooldown > 0) return;
+  if (turretState.ammo <= 0) return;
+
+  turretState.ammo--;
+  turretState.cooldown = FIRE_COOLDOWN;
+
+  // alternate turrets
+  var turretIdx = (turretState.maxAmmo - turretState.ammo) % turretState.turretGroups.length;
+  var turret = turretState.turretGroups[turretIdx];
+
+  // get barrel tip world position (barrel is at local z=0.35, plus half barrel length ~0.35)
+  var barrelTip = new THREE.Vector3(0, 0.1, 0.7);
+  turret.localToWorld(barrelTip);
+
+  // direction toward aim point
+  var dir = new THREE.Vector3();
+  dir.subVectors(turretState.aimWorldPos, barrelTip);
+  dir.y = 0; // keep horizontal for initial direction
+  dir.normalize();
+
+  // slight upward arc for gravity
+  var velocity = new THREE.Vector3(
+    dir.x * PROJECTILE_SPEED,
+    PROJECTILE_SPEED * 0.08,  // slight loft
+    dir.z * PROJECTILE_SPEED
+  );
+
+  // create projectile mesh
+  var projMesh = new THREE.Mesh(projectileGeo, projectileMat);
+  projMesh.position.copy(barrelTip);
+  scene.add(projMesh);
+
+  // trail segments
+  var trail = [];
+
+  var proj = {
+    mesh: projMesh,
+    velocity: velocity,
+    origin: barrelTip.clone(),
+    age: 0,
+    trail: trail
+  };
+  turretState.projectiles.push(proj);
+
+  // muzzle flash
+  spawnFlash(turretState, scene, barrelTip);
+
+  // sound placeholder
+  console.log("[SFX] FIRE turret " + turretIdx);
+}
+
+// --- muzzle flash ---
+function spawnFlash(turretState, scene, position) {
+  var mesh = new THREE.Mesh(flashGeo, flashMat.clone());
+  mesh.position.copy(position);
+  scene.add(mesh);
+  turretState.effects.push({
+    type: "flash",
+    mesh: mesh,
+    life: MUZZLE_FLASH_DURATION
+  });
+}
+
+// --- impact splash ---
+function spawnSplash(turretState, scene, position) {
+  var mesh = new THREE.Mesh(splashGeo, splashMat.clone());
+  mesh.position.copy(position);
+  mesh.position.y = 0.4; // just above water
+  mesh.rotation.x = -Math.PI / 2;
+  scene.add(mesh);
+  turretState.effects.push({
+    type: "splash",
+    mesh: mesh,
+    life: SPLASH_DURATION,
+    maxLife: SPLASH_DURATION
+  });
+  console.log("[SFX] SPLASH at", position.x.toFixed(1), position.z.toFixed(1));
+}
+
+// --- update projectiles, effects, cooldown ---
+export function updateTurrets(turretState, dt, scene, enemies) {
+  // cooldown
+  turretState.cooldown = Math.max(0, turretState.cooldown - dt);
+
+  // update projectiles
+  var alive = [];
+  for (var i = 0; i < turretState.projectiles.length; i++) {
+    var p = turretState.projectiles[i];
+    p.age += dt;
+
+    // apply gravity
+    p.velocity.y -= GRAVITY * dt;
+
+    // move
+    p.mesh.position.x += p.velocity.x * dt;
+    p.mesh.position.y += p.velocity.y * dt;
+    p.mesh.position.z += p.velocity.z * dt;
+
+    // trail segment (uses transparent material so opacity fading works)
+    var trailMesh = new THREE.Mesh(projectileGeo, trailMat.clone());
+    trailMesh.scale.setScalar(0.5);
+    trailMesh.position.copy(p.mesh.position);
+    scene.add(trailMesh);
+    p.trail.push({ mesh: trailMesh, life: TRAIL_SEGMENT_LIFE });
+
+    // update trail
+    var aliveTrail = [];
+    for (var t = 0; t < p.trail.length; t++) {
+      p.trail[t].life -= dt;
+      if (p.trail[t].life <= 0) {
+        scene.remove(p.trail[t].mesh);
+      } else {
+        p.trail[t].mesh.material.opacity = p.trail[t].life / TRAIL_SEGMENT_LIFE;
+        aliveTrail.push(p.trail[t]);
+      }
+    }
+    p.trail = aliveTrail;
+
+    // distance check
+    var dx = p.mesh.position.x - p.origin.x;
+    var dz = p.mesh.position.z - p.origin.z;
+    var dist = Math.sqrt(dx * dx + dz * dz);
+
+    // hit water (below surface)
+    var hitWater = p.mesh.position.y < 0.2;
+    // hit max range
+    var outOfRange = dist > MAX_RANGE;
+    // hit enemy
+    var hitEnemy = checkEnemyHit(p, enemies);
+
+    if (hitWater || outOfRange || hitEnemy) {
+      // splash on water hit or enemy hit
+      if (hitWater || hitEnemy) {
+        spawnSplash(turretState, scene, p.mesh.position);
+      }
+      if (hitEnemy) {
+        console.log("[SFX] HIT enemy!");
+      }
+      // clean up trail
+      for (var t = 0; t < p.trail.length; t++) {
+        scene.remove(p.trail[t].mesh);
+      }
+      scene.remove(p.mesh);
+    } else {
+      alive.push(p);
+    }
+  }
+  turretState.projectiles = alive;
+
+  // update effects
+  var aliveEffects = [];
+  for (var i = 0; i < turretState.effects.length; i++) {
+    var e = turretState.effects[i];
+    e.life -= dt;
+    if (e.life <= 0) {
+      scene.remove(e.mesh);
+    } else {
+      if (e.type === "flash") {
+        e.mesh.material.opacity = e.life / MUZZLE_FLASH_DURATION;
+        e.mesh.scale.setScalar(1 + (1 - e.life / MUZZLE_FLASH_DURATION) * 2);
+      } else if (e.type === "splash") {
+        var progress = 1 - e.life / e.maxLife;
+        e.mesh.material.opacity = 0.7 * (1 - progress);
+        e.mesh.scale.setScalar(1 + progress * 3);
+      }
+      aliveEffects.push(e);
+    }
+  }
+  turretState.effects = aliveEffects;
+}
+
+// --- enemy hit detection (bounding sphere) ---
+function checkEnemyHit(projectile, enemies) {
+  if (!enemies) return false;
+  var pp = projectile.mesh.position;
+  for (var i = 0; i < enemies.length; i++) {
+    var enemy = enemies[i];
+    if (!enemy.alive) continue;
+    var ex = enemy.mesh.position.x;
+    var ez = enemy.mesh.position.z;
+    var dx = pp.x - ex;
+    var dz = pp.z - ez;
+    var distSq = dx * dx + dz * dz;
+    var hitRadius = enemy.hitRadius || 2.0;
+    if (distSq < hitRadius * hitRadius) {
+      enemy.hp--;
+      if (enemy.hp <= 0) {
+        enemy.alive = false;
+        enemy.mesh.visible = false;
+        console.log("[SFX] ENEMY DESTROYED");
+      }
+      return true;
+    }
+  }
+  return false;
+}
+
+// --- project screen coords to world XZ plane (for aiming) ---
+export function screenToWorld(screenX, screenY, camera) {
+  ensureMaterials();
+  aimNdc.set(
+    (screenX / window.innerWidth) * 2 - 1,
+    -(screenY / window.innerHeight) * 2 + 1
+  );
+  aimRaycaster.setFromCamera(aimNdc, camera);
+
+  var target = new THREE.Vector3();
+  aimRaycaster.ray.intersectPlane(waterPlane, target);
+
+  return target || new THREE.Vector3(0, 0.3, 0);
+}


### PR DESCRIPTION
Closes #23

## Summary
- Ship now floats above the water surface with dynamic wave height sampling
- Added CPU-side `getWaveHeight()` that mirrors the GLSL vertex shader wave function
- Ship bobs with waves (pitch/roll from wave slope) and never submerges
- Right-click (desktop) or tap (mobile) sets a navigation target on the ocean
- Ship auto-rotates toward target, accelerates, then decelerates and stops on arrival
- Pulsing ring marker shows destination point on water surface
- WASD keys override and cancel auto-navigation instantly

## Acceptance Criteria
- [x] Ship floats visibly above water surface (hull above wave peaks)
- [x] Ship bobs with waves but never submerges
- [x] Click/tap on ocean sets navigation target
- [x] Ship auto-rotates toward target and sails there
- [x] Ship decelerates and stops at destination
- [x] Visual marker shows destination point
- [x] Works on both desktop (click) and mobile (tap)
- [x] WASD still works as override on desktop

## Technical Details
- `getWaveHeight(worldX, worldZ, time)` in ocean.js mirrors all 5 wave layers from the GLSL shader
- `FLOAT_OFFSET = 1.2` ensures hull sits above wave peaks
- Wave slope sampling at ±1.5 units for gentle pitch/roll animation
- Raycaster onto y=0 plane for click targeting
- Auto-nav: `NAV_ARRIVE_RADIUS = 3`, `NAV_SLOW_RADIUS = 15` for smooth deceleration
- Desktop: right-click navigates (left-click reserved for turret firing)
- Mobile: tap navigates + fires (both make gameplay sense)

🤖 Generated with [Claude Code](https://claude.com/claude-code)