### PR TITLE
Phase 3B: Resource drops, ammo management, repair between waves

### DIFF
--- a/js/hud.js
+++ b/js/hud.js
@@ -1,13 +1,18 @@
-// hud.js — speed indicator, compass, and ammo counter overlay
+// hud.js — speed indicator, compass, ammo counter, fuel gauge, parts count, wave info
 
 var container = null;
 var speedBar = null;
 var speedLabel = null;
 var compassLabel = null;
 var ammoLabel = null;
+var fuelBarBg = null;
+var fuelBar = null;
+var fuelLabel = null;
+var partsLabel = null;
 var hpBarBg = null;
 var hpBar = null;
 var hpLabel = null;
+var waveLabel = null;
 
 export function createHUD() {
   container = document.createElement("div");
@@ -67,6 +72,44 @@ export function createHUD() {
   ammoLabel.style.color = "#8899aa";
   container.appendChild(ammoLabel);
 
+  // fuel gauge
+  fuelLabel = document.createElement("div");
+  fuelLabel.textContent = "FUEL";
+  fuelLabel.style.marginTop = "8px";
+  fuelLabel.style.fontSize = "12px";
+  fuelLabel.style.color = "#667788";
+  container.appendChild(fuelLabel);
+
+  fuelBarBg = document.createElement("div");
+  fuelBarBg.style.cssText = [
+    "width: 120px",
+    "height: 8px",
+    "background: rgba(20, 30, 50, 0.7)",
+    "border: 1px solid rgba(80, 100, 130, 0.4)",
+    "border-radius: 4px",
+    "overflow: hidden",
+    "margin-top: 3px"
+  ].join(";");
+
+  fuelBar = document.createElement("div");
+  fuelBar.style.cssText = [
+    "width: 100%",
+    "height: 100%",
+    "background: #2288cc",
+    "border-radius: 3px",
+    "transition: width 0.2s"
+  ].join(";");
+  fuelBarBg.appendChild(fuelBar);
+  container.appendChild(fuelBarBg);
+
+  // parts count
+  partsLabel = document.createElement("div");
+  partsLabel.textContent = "PARTS: 0";
+  partsLabel.style.marginTop = "6px";
+  partsLabel.style.fontSize = "13px";
+  partsLabel.style.color = "#8899aa";
+  container.appendChild(partsLabel);
+
   // player HP bar
   hpLabel = document.createElement("div");
   hpLabel.textContent = "HP";
@@ -97,10 +140,19 @@ export function createHUD() {
   hpBarBg.appendChild(hpBar);
   container.appendChild(hpBarBg);
 
+  // wave indicator
+  waveLabel = document.createElement("div");
+  waveLabel.textContent = "WAVE 1";
+  waveLabel.style.marginTop = "10px";
+  waveLabel.style.fontSize = "14px";
+  waveLabel.style.color = "#8899aa";
+  waveLabel.style.fontWeight = "bold";
+  container.appendChild(waveLabel);
+
   document.body.appendChild(container);
 }
 
-export function updateHUD(speedRatio, displaySpeed, heading, ammo, maxAmmo, hp, maxHp) {
+export function updateHUD(speedRatio, displaySpeed, heading, ammo, maxAmmo, hp, maxHp, fuel, maxFuel, parts, wave, waveActive) {
   if (!container) return;
 
   var pct = Math.min(1, speedRatio) * 100;
@@ -116,7 +168,22 @@ export function updateHUD(speedRatio, displaySpeed, heading, ammo, maxAmmo, hp, 
   // ammo counter
   if (ammo !== undefined) {
     ammoLabel.textContent = "AMMO: " + ammo + " / " + maxAmmo;
-    ammoLabel.style.color = ammo <= 5 ? "#cc6644" : "#8899aa";
+    ammoLabel.style.color = ammo <= 5 ? "#cc6644" : ammo === 0 ? "#cc2222" : "#8899aa";
+  }
+
+  // fuel gauge
+  if (fuel !== undefined && fuelBar) {
+    var fuelPct = Math.max(0, fuel / maxFuel) * 100;
+    fuelBar.style.width = fuelPct + "%";
+    fuelBar.style.background = fuelPct > 30 ? "#2288cc" : fuelPct > 15 ? "#cc8822" : "#cc4444";
+    fuelLabel.textContent = "FUEL: " + Math.round(fuel) + "%";
+    fuelLabel.style.color = fuelPct > 15 ? "#667788" : "#cc4444";
+  }
+
+  // parts count
+  if (parts !== undefined && partsLabel) {
+    partsLabel.textContent = "PARTS: " + parts;
+    partsLabel.style.color = parts > 0 ? "#44dd66" : "#8899aa";
   }
 
   // player HP
@@ -126,5 +193,16 @@ export function updateHUD(speedRatio, displaySpeed, heading, ammo, maxAmmo, hp, 
     hpBar.style.background = hpPct > 50 ? "#44aa66" : hpPct > 25 ? "#aaaa44" : "#cc4444";
     hpLabel.textContent = "HP: " + hp + " / " + maxHp;
     hpLabel.style.color = hpPct > 25 ? "#667788" : "#cc4444";
+  }
+
+  // wave indicator
+  if (wave !== undefined && waveLabel) {
+    if (waveActive) {
+      waveLabel.textContent = "WAVE " + wave;
+      waveLabel.style.color = "#8899aa";
+    } else {
+      waveLabel.textContent = "REPAIRING...";
+      waveLabel.style.color = "#44dd66";
+    }
   }
 }

--- a/js/pickup.js
+++ b/js/pickup.js
@@ -1,0 +1,174 @@
+// pickup.js — resource pickups: floating crates/barrels dropped by enemies
+import * as THREE from "three";
+import { addAmmo, addFuel, addParts } from "./resource.js";
+
+// --- tuning ---
+var PICKUP_FLOAT_OFFSET = 0.8;
+var PICKUP_BOB_AMP = 0.3;
+var PICKUP_BOB_SPEED = 2.0;
+var PICKUP_SPIN_SPEED = 1.2;
+var PICKUP_COLLECT_RADIUS = 3.5;
+var PICKUP_LIFETIME = 30;         // seconds before pickup despawns
+var GLOW_PULSE_SPEED = 3.0;
+var GLOW_PULSE_MIN = 0.5;
+
+// drop amounts
+var AMMO_DROP_AMOUNT = 8;
+var FUEL_DROP_AMOUNT = 15;
+var PARTS_DROP_AMOUNT = 1;
+
+// drop chances (must sum to 1)
+var DROP_CHANCE_AMMO = 0.45;
+var DROP_CHANCE_FUEL = 0.35;
+// remainder = parts
+
+// --- shared geometry ---
+var crateGeo = null;
+var barrelGeo = null;
+
+function ensureGeo() {
+  if (crateGeo) return;
+  crateGeo = new THREE.BoxGeometry(0.6, 0.6, 0.6);
+  barrelGeo = new THREE.CylinderGeometry(0.25, 0.3, 0.7, 8);
+}
+
+// --- color by type ---
+var TYPE_COLORS = {
+  ammo: 0xffaa22,
+  fuel: 0x22aaff,
+  parts: 0x44dd66
+};
+
+var GLOW_COLORS = {
+  ammo: 0xffdd66,
+  fuel: 0x66ccff,
+  parts: 0x88ff99
+};
+
+// --- build pickup mesh ---
+function buildPickupMesh(type) {
+  ensureGeo();
+  var group = new THREE.Group();
+
+  var color = TYPE_COLORS[type] || 0xffffff;
+  var mat = new THREE.MeshLambertMaterial({ color: color });
+
+  var mesh;
+  if (type === "fuel") {
+    mesh = new THREE.Mesh(barrelGeo, mat);
+  } else {
+    mesh = new THREE.Mesh(crateGeo, mat);
+  }
+  group.add(mesh);
+
+  // glow point light
+  var glowColor = GLOW_COLORS[type] || 0xffffff;
+  var light = new THREE.PointLight(glowColor, 1.0, 6);
+  light.position.set(0, 0.5, 0);
+  group.add(light);
+
+  group.userData.light = light;
+  return group;
+}
+
+// --- pickup manager ---
+export function createPickupManager() {
+  return {
+    pickups: []
+  };
+}
+
+// --- spawn a pickup at position ---
+export function spawnPickup(manager, x, y, z, scene) {
+  var roll = Math.random();
+  var type;
+  if (roll < DROP_CHANCE_AMMO) {
+    type = "ammo";
+  } else if (roll < DROP_CHANCE_AMMO + DROP_CHANCE_FUEL) {
+    type = "fuel";
+  } else {
+    type = "parts";
+  }
+
+  var mesh = buildPickupMesh(type);
+  mesh.position.set(x, y + PICKUP_FLOAT_OFFSET, z);
+  scene.add(mesh);
+
+  manager.pickups.push({
+    mesh: mesh,
+    type: type,
+    posX: x,
+    posZ: z,
+    age: 0,
+    collected: false
+  });
+}
+
+// --- update pickups: bob, glow, check proximity, despawn ---
+export function updatePickups(manager, ship, resources, dt, elapsed, getWaveHeight, scene) {
+  var alive = [];
+
+  for (var i = 0; i < manager.pickups.length; i++) {
+    var p = manager.pickups[i];
+    p.age += dt;
+
+    // despawn old pickups
+    if (p.age > PICKUP_LIFETIME) {
+      scene.remove(p.mesh);
+      continue;
+    }
+
+    // proximity collection
+    var dx = ship.posX - p.posX;
+    var dz = ship.posZ - p.posZ;
+    var distSq = dx * dx + dz * dz;
+
+    if (distSq < PICKUP_COLLECT_RADIUS * PICKUP_COLLECT_RADIUS) {
+      collectPickup(p, resources);
+      scene.remove(p.mesh);
+      continue;
+    }
+
+    // bob on waves
+    var waveY = getWaveHeight(p.posX, p.posZ, elapsed);
+    var bob = Math.sin(elapsed * PICKUP_BOB_SPEED + p.posX * 0.5) * PICKUP_BOB_AMP;
+    p.mesh.position.y = waveY + PICKUP_FLOAT_OFFSET + bob;
+
+    // spin
+    p.mesh.rotation.y += PICKUP_SPIN_SPEED * dt;
+
+    // glow pulse
+    var light = p.mesh.userData.light;
+    if (light) {
+      var pulse = GLOW_PULSE_MIN + (1 - GLOW_PULSE_MIN) * (0.5 + 0.5 * Math.sin(elapsed * GLOW_PULSE_SPEED));
+      light.intensity = pulse;
+    }
+
+    // fade out near end of life
+    if (p.age > PICKUP_LIFETIME - 3) {
+      var fade = (PICKUP_LIFETIME - p.age) / 3;
+      p.mesh.traverse(function (child) {
+        if (child.isMesh && child.material) {
+          child.material.transparent = true;
+          child.material.opacity = fade;
+        }
+      });
+    }
+
+    alive.push(p);
+  }
+
+  manager.pickups = alive;
+}
+
+// --- apply pickup to resources ---
+function collectPickup(pickup, resources) {
+  if (pickup.type === "ammo") {
+    addAmmo(resources, AMMO_DROP_AMOUNT);
+  } else if (pickup.type === "fuel") {
+    addFuel(resources, FUEL_DROP_AMOUNT);
+  } else if (pickup.type === "parts") {
+    addParts(resources, PARTS_DROP_AMOUNT);
+  }
+  console.log("[PICKUP] Collected " + pickup.type);
+}

--- a/js/resource.js
+++ b/js/resource.js
@@ -1,0 +1,118 @@
+// resource.js — resource state management: ammo, fuel, repair parts, wave tracking
+
+// --- balance tuning ---
+var STARTING_AMMO = 50;
+var MAX_AMMO = 80;
+var STARTING_FUEL = 100;
+var MAX_FUEL = 100;
+var FUEL_BURN_RATE = 1.5;        // fuel per second at full throttle
+var LOW_FUEL_SPEED_MULT = 0.35;  // min speed multiplier at zero fuel
+var REPAIR_PER_PART = 2;         // HP restored per repair part between waves
+var WAVE_ENEMY_COUNT_BASE = 3;   // enemies in wave 1
+var WAVE_ENEMY_INCREMENT = 2;    // extra enemies per wave
+var WAVE_PAUSE_DURATION = 4;     // seconds between waves (repair phase)
+
+// --- create resource state ---
+export function createResources() {
+  return {
+    ammo: STARTING_AMMO,
+    maxAmmo: MAX_AMMO,
+    fuel: STARTING_FUEL,
+    maxFuel: MAX_FUEL,
+    parts: 0,
+
+    // wave tracking
+    wave: 1,
+    waveEnemiesRemaining: WAVE_ENEMY_COUNT_BASE,
+    waveActive: true,
+    wavePauseTimer: 0,
+    repairing: false
+  };
+}
+
+// --- consume fuel based on current throttle ---
+export function consumeFuel(res, speedRatio, dt) {
+  if (res.fuel <= 0) return;
+  var burn = FUEL_BURN_RATE * speedRatio * dt;
+  res.fuel = Math.max(0, res.fuel - burn);
+}
+
+// --- get speed multiplier from fuel level ---
+export function getFuelSpeedMult(res) {
+  if (res.fuel <= 0) return LOW_FUEL_SPEED_MULT;
+  // smooth ramp: below 20% fuel starts reducing speed
+  var ratio = res.fuel / res.maxFuel;
+  if (ratio > 0.2) return 1.0;
+  // lerp from LOW_FUEL_SPEED_MULT to 1.0 over 0-20% range
+  var t = ratio / 0.2;
+  return LOW_FUEL_SPEED_MULT + (1.0 - LOW_FUEL_SPEED_MULT) * t;
+}
+
+// --- try to spend ammo; returns true if ammo available ---
+export function spendAmmo(res) {
+  if (res.ammo <= 0) return false;
+  res.ammo--;
+  return true;
+}
+
+// --- add resource from pickup ---
+export function addAmmo(res, amount) {
+  res.ammo = Math.min(res.maxAmmo, res.ammo + amount);
+}
+
+export function addFuel(res, amount) {
+  res.fuel = Math.min(res.maxFuel, res.fuel + amount);
+}
+
+export function addParts(res, amount) {
+  res.parts += amount;
+}
+
+// --- wave management ---
+// waveEnemiesRemaining tracks enemies yet to spawn; activeEnemyCount = living enemies on field
+export function updateWave(res, activeEnemyCount, playerHp, playerMaxHp, dt) {
+  if (res.waveActive) {
+    // wave complete when all enemies spawned AND all on-field enemies dead
+    if (res.waveEnemiesRemaining <= 0 && activeEnemyCount === 0) {
+      res.waveActive = false;
+      res.wavePauseTimer = WAVE_PAUSE_DURATION;
+      res.repairing = true;
+    }
+    return null;
+  }
+
+  // between waves — repair phase
+  res.wavePauseTimer -= dt;
+  if (res.repairing && res.parts > 0 && playerHp < playerMaxHp) {
+    // auto-repair: consume parts at start of pause
+    var repaired = doRepair(res, playerHp, playerMaxHp);
+    if (repaired !== null) return repaired;
+  }
+
+  if (res.wavePauseTimer <= 0) {
+    // start next wave
+    res.wave++;
+    res.waveEnemiesRemaining = WAVE_ENEMY_COUNT_BASE + WAVE_ENEMY_INCREMENT * (res.wave - 1);
+    res.waveActive = true;
+    res.repairing = false;
+  }
+
+  return null;
+}
+
+// --- consume parts for repair, return new HP or null ---
+function doRepair(res, playerHp, playerMaxHp) {
+  if (res.parts <= 0 || playerHp >= playerMaxHp) {
+    res.repairing = false;
+    return null;
+  }
+  // repair all at once at start of pause
+  var hpNeeded = playerMaxHp - playerHp;
+  var hpFromParts = res.parts * REPAIR_PER_PART;
+  var hpRestored = Math.min(hpNeeded, hpFromParts);
+  var partsUsed = Math.ceil(hpRestored / REPAIR_PER_PART);
+  res.parts -= partsUsed;
+  res.repairing = false;
+  return playerHp + hpRestored;
+}
+

--- a/js/ship.js
+++ b/js/ship.js
@@ -130,7 +130,9 @@ function normalizeAngle(a) {
 }
 
 // --- update ship physics ---
-export function updateShip(ship, input, dt, getWaveHeight, elapsed) {
+// fuelMult: 0-1 multiplier on max speed from fuel level (optional, defaults to 1)
+export function updateShip(ship, input, dt, getWaveHeight, elapsed, fuelMult) {
+  var effectiveMaxSpeed = MAX_SPEED * (fuelMult !== undefined ? fuelMult : 1);
   var wasdActive = input.forward || input.backward || input.left || input.right;
 
   // WASD overrides auto-nav
@@ -163,7 +165,7 @@ export function updateShip(ship, input, dt, getWaveHeight, elapsed) {
 
       // throttle — full speed far away, decelerate near target
       var speedFactor = Math.min(1, dist / NAV_SLOW_RADIUS);
-      var desiredSpeed = MAX_SPEED * speedFactor;
+      var desiredSpeed = effectiveMaxSpeed * speedFactor;
       // only accelerate when roughly facing target
       if (Math.abs(angleDiff) < Math.PI * 0.5) {
         if (ship.speed < desiredSpeed) {
@@ -199,7 +201,7 @@ export function updateShip(ship, input, dt, getWaveHeight, elapsed) {
     }
 
     // turning — interpolate turn rate based on speed ratio
-    var speedRatio = Math.abs(ship.speed) / MAX_SPEED;
+    var speedRatio = Math.abs(ship.speed) / effectiveMaxSpeed;
     var turnRate = TURN_SPEED_LOW + (TURN_SPEED_HIGH - TURN_SPEED_LOW) * speedRatio;
     var turnMult = Math.max(0.1, Math.min(1, Math.abs(ship.speed) / 5));
 
@@ -208,8 +210,8 @@ export function updateShip(ship, input, dt, getWaveHeight, elapsed) {
   }
 
   // clamp speed
-  var maxReverse = MAX_SPEED * 0.3;
-  ship.speed = Math.max(-maxReverse, Math.min(MAX_SPEED, ship.speed));
+  var maxReverse = effectiveMaxSpeed * 0.3;
+  ship.speed = Math.max(-maxReverse, Math.min(effectiveMaxSpeed, ship.speed));
 
   // movement
   ship.posX += Math.sin(ship.heading) * ship.speed * dt;


### PR DESCRIPTION
Closes #7

## Acceptance Criteria
- [x] Destroyed enemies drop pickups (float on water): ammo, fuel, repair parts
- [x] Player collects by sailing over them (proximity trigger)
- [x] Ammo is finite — running out means no shooting until pickup
- [x] Fuel affects max speed (low fuel = slower, not immobile)
- [x] Between waves: repair screen or auto-repair using collected parts
- [x] HUD shows: ammo count, fuel gauge, parts count
- [x] Pickup visual: glowing floating crate or barrel

## Changes
- **js/resource.js** (new): Central resource state — ammo, fuel, parts, wave tracking, fuel speed multiplier, repair logic
- **js/pickup.js** (new): Pickup meshes (colored crates/barrels with point lights), bobbing animation, proximity collection, fade-out on despawn
- **js/enemy.js**: Death callback for pickup spawning, wave-gated enemy spawning, player HP setter for repair
- **js/turret.js**: Ammo consumption through resource system (`spendAmmo`)
- **js/ship.js**: Fuel speed multiplier parameter caps effective max speed
- **js/hud.js**: Fuel gauge bar, parts counter, wave indicator with repair phase display
- **js/main.js**: Wires all new systems — resources, pickups, fuel, wave management, repair