### PR TITLE
Phase 3A: Wave system — survive X enemies, escalating difficulty

### DIFF
--- a/js/resource.js
+++ b/js/resource.js
@@ -1,4 +1,4 @@
-// resource.js — resource state management: ammo, fuel, repair parts, wave tracking
+// resource.js — resource state management: ammo, fuel, repair parts
 
 // --- balance tuning ---
 var STARTING_AMMO = 50;
@@ -7,10 +7,6 @@ var STARTING_FUEL = 100;
 var MAX_FUEL = 100;
 var FUEL_BURN_RATE = 1.5;        // fuel per second at full throttle
 var LOW_FUEL_SPEED_MULT = 0.35;  // min speed multiplier at zero fuel
-var REPAIR_PER_PART = 2;         // HP restored per repair part between waves
-var WAVE_ENEMY_COUNT_BASE = 3;   // enemies in wave 1
-var WAVE_ENEMY_INCREMENT = 2;    // extra enemies per wave
-var WAVE_PAUSE_DURATION = 4;     // seconds between waves (repair phase)
 
 // --- create resource state ---
 export function createResources() {
@@ -19,15 +15,17 @@ export function createResources() {
     maxAmmo: MAX_AMMO,
     fuel: STARTING_FUEL,
     maxFuel: MAX_FUEL,
-    parts: 0,
-
-    // wave tracking
-    wave: 1,
-    waveEnemiesRemaining: WAVE_ENEMY_COUNT_BASE,
-    waveActive: true,
-    wavePauseTimer: 0,
-    repairing: false
+    parts: 0
   };
+}
+
+// --- reset resources for restart ---
+export function resetResources(res) {
+  res.ammo = STARTING_AMMO;
+  res.maxAmmo = MAX_AMMO;
+  res.fuel = STARTING_FUEL;
+  res.maxFuel = MAX_FUEL;
+  res.parts = 0;
 }
 
 // --- consume fuel based on current throttle ---
@@ -67,52 +65,3 @@ export function addFuel(res, amount) {
 export function addParts(res, amount) {
   res.parts += amount;
 }
-
-// --- wave management ---
-// waveEnemiesRemaining tracks enemies yet to spawn; activeEnemyCount = living enemies on field
-export function updateWave(res, activeEnemyCount, playerHp, playerMaxHp, dt) {
-  if (res.waveActive) {
-    // wave complete when all enemies spawned AND all on-field enemies dead
-    if (res.waveEnemiesRemaining <= 0 && activeEnemyCount === 0) {
-      res.waveActive = false;
-      res.wavePauseTimer = WAVE_PAUSE_DURATION;
-      res.repairing = true;
-    }
-    return null;
-  }
-
-  // between waves — repair phase
-  res.wavePauseTimer -= dt;
-  if (res.repairing && res.parts > 0 && playerHp < playerMaxHp) {
-    // auto-repair: consume parts at start of pause
-    var repaired = doRepair(res, playerHp, playerMaxHp);
-    if (repaired !== null) return repaired;
-  }
-
-  if (res.wavePauseTimer <= 0) {
-    // start next wave
-    res.wave++;
-    res.waveEnemiesRemaining = WAVE_ENEMY_COUNT_BASE + WAVE_ENEMY_INCREMENT * (res.wave - 1);
-    res.waveActive = true;
-    res.repairing = false;
-  }
-
-  return null;
-}
-
-// --- consume parts for repair, return new HP or null ---
-function doRepair(res, playerHp, playerMaxHp) {
-  if (res.parts <= 0 || playerHp >= playerMaxHp) {
-    res.repairing = false;
-    return null;
-  }
-  // repair all at once at start of pause
-  var hpNeeded = playerMaxHp - playerHp;
-  var hpFromParts = res.parts * REPAIR_PER_PART;
-  var hpRestored = Math.min(hpNeeded, hpFromParts);
-  var partsUsed = Math.ceil(hpRestored / REPAIR_PER_PART);
-  res.parts -= partsUsed;
-  res.repairing = false;
-  return playerHp + hpRestored;
-}
-

--- a/js/wave.js
+++ b/js/wave.js
@@ -1,0 +1,182 @@
+// wave.js — wave state machine with escalating difficulty
+
+// --- wave config ---
+var MAX_WAVE = 10;              // victory after surviving this wave
+var BASE_ENEMIES = 3;           // enemies in wave 1
+var ENEMIES_PER_WAVE = 2;       // extra enemies each wave
+var PAUSE_DURATION = 4;         // seconds between waves
+var REPAIR_PER_PART = 2;        // HP restored per part during pause
+
+// --- states ---
+var STATE_WAITING   = "WAITING";
+var STATE_SPAWNING  = "SPAWNING";
+var STATE_ACTIVE    = "ACTIVE";
+var STATE_COMPLETE  = "WAVE_COMPLETE";
+var STATE_GAME_OVER = "GAME_OVER";
+var STATE_VICTORY   = "VICTORY";
+
+// --- build wave config table ---
+function buildWaveConfigs() {
+  var configs = [];
+  for (var i = 1; i <= MAX_WAVE; i++) {
+    configs.push({
+      wave: i,
+      enemies: BASE_ENEMIES + ENEMIES_PER_WAVE * (i - 1),
+      hpMult: 1.0 + (i - 1) * 0.15,
+      speedMult: 1.0 + (i - 1) * 0.08,
+      fireRateMult: 1.0 + (i - 1) * 0.1
+    });
+  }
+  return configs;
+}
+
+// --- create wave manager ---
+export function createWaveManager() {
+  var configs = buildWaveConfigs();
+  return {
+    configs: configs,
+    maxWave: MAX_WAVE,
+    wave: 1,
+    state: STATE_WAITING,
+    pauseTimer: 3,              // initial countdown before wave 1
+    enemiesToSpawn: 0,          // enemies yet to spawn this wave
+    enemiesAlive: 0,            // living enemies on field
+    repairDone: false,
+    // expose current config for enemy spawning
+    currentConfig: configs[0]
+  };
+}
+
+// --- get current wave config ---
+export function getWaveConfig(mgr) {
+  return mgr.currentConfig;
+}
+
+// --- update wave state machine ---
+// returns an event string when state transitions happen, or null
+export function updateWaveState(mgr, activeEnemyCount, playerHp, playerMaxHp, resources, dt) {
+  mgr.enemiesAlive = activeEnemyCount;
+
+  // game over / victory are terminal
+  if (mgr.state === STATE_GAME_OVER || mgr.state === STATE_VICTORY) {
+    return null;
+  }
+
+  // check player death at any time
+  if (playerHp <= 0) {
+    mgr.state = STATE_GAME_OVER;
+    return "game_over";
+  }
+
+  // --- WAITING: countdown before wave starts ---
+  if (mgr.state === STATE_WAITING) {
+    mgr.pauseTimer -= dt;
+
+    // auto-repair during pause
+    if (!mgr.repairDone && resources.parts > 0 && playerHp < playerMaxHp) {
+      var result = doRepair(resources, playerHp, playerMaxHp);
+      mgr.repairDone = true;
+      if (result !== null) return "repair:" + result;
+    }
+
+    if (mgr.pauseTimer <= 0) {
+      mgr.state = STATE_SPAWNING;
+      var cfg = mgr.configs[mgr.wave - 1];
+      mgr.currentConfig = cfg;
+      mgr.enemiesToSpawn = cfg.enemies;
+      return "wave_start";
+    }
+    return null;
+  }
+
+  // --- SPAWNING: enemies still need to spawn ---
+  if (mgr.state === STATE_SPAWNING) {
+    if (mgr.enemiesToSpawn <= 0) {
+      mgr.state = STATE_ACTIVE;
+      return null;
+    }
+    return null;
+  }
+
+  // --- ACTIVE: waiting for all enemies to die ---
+  if (mgr.state === STATE_ACTIVE) {
+    // also check if there are still enemies to spawn (late stragglers)
+    if (mgr.enemiesToSpawn > 0) {
+      mgr.state = STATE_SPAWNING;
+      return null;
+    }
+    if (activeEnemyCount === 0) {
+      mgr.state = STATE_COMPLETE;
+      return "wave_complete";
+    }
+    return null;
+  }
+
+  // --- WAVE_COMPLETE: transition to next wave or victory ---
+  if (mgr.state === STATE_COMPLETE) {
+    if (mgr.wave >= mgr.maxWave) {
+      mgr.state = STATE_VICTORY;
+      return "victory";
+    }
+    // next wave
+    mgr.wave++;
+    mgr.pauseTimer = PAUSE_DURATION;
+    mgr.repairDone = false;
+    mgr.state = STATE_WAITING;
+    return null;
+  }
+
+  return null;
+}
+
+// --- consume an enemy spawn slot (called by enemy spawner) ---
+export function consumeSpawn(mgr) {
+  if (mgr.enemiesToSpawn > 0) {
+    mgr.enemiesToSpawn--;
+    // transition to ACTIVE when all spawned
+    if (mgr.enemiesToSpawn <= 0) {
+      mgr.state = STATE_ACTIVE;
+    }
+    return true;
+  }
+  return false;
+}
+
+// --- can we spawn more enemies this wave? ---
+export function canSpawn(mgr) {
+  return (mgr.state === STATE_SPAWNING || mgr.state === STATE_ACTIVE) && mgr.enemiesToSpawn > 0;
+}
+
+// --- is wave actively running (enemies fighting)? ---
+export function isWaveActive(mgr) {
+  return mgr.state === STATE_SPAWNING || mgr.state === STATE_ACTIVE;
+}
+
+// --- get state for HUD ---
+export function getWaveState(mgr) {
+  return mgr.state;
+}
+
+// --- reset for restart ---
+export function resetWaveManager(mgr) {
+  var configs = buildWaveConfigs();
+  mgr.configs = configs;
+  mgr.wave = 1;
+  mgr.state = STATE_WAITING;
+  mgr.pauseTimer = 3;
+  mgr.enemiesToSpawn = 0;
+  mgr.enemiesAlive = 0;
+  mgr.repairDone = false;
+  mgr.currentConfig = configs[0];
+}
+
+// --- repair logic (moved from resource.js) ---
+function doRepair(res, playerHp, playerMaxHp) {
+  if (res.parts <= 0 || playerHp >= playerMaxHp) return null;
+  var hpNeeded = playerMaxHp - playerHp;
+  var hpFromParts = res.parts * REPAIR_PER_PART;
+  var hpRestored = Math.min(hpNeeded, hpFromParts);
+  var partsUsed = Math.ceil(hpRestored / REPAIR_PER_PART);
+  res.parts -= partsUsed;
+  return playerHp + hpRestored;
+}


### PR DESCRIPTION
Closes #6

## Acceptance Criteria
- [x] Wave counter displayed in HUD
- [x] Each wave spawns N enemies (N increases per wave)
- [x] Brief pause between waves (3-5 seconds, "Wave X incoming!" text)
- [x] Enemy stats scale per wave: +HP, +speed, +fire rate (gradual)
- [x] Wave complete when all enemies destroyed
- [x] Game over screen on player death (show wave reached, restart button)
- [x] Victory condition: survive wave 10 (placeholder, configurable)

## Changes
- **New: `js/wave.js`** — Wave state machine (`WAITING → SPAWNING → ACTIVE → WAVE_COMPLETE → next`), wave config table with escalating `hpMult`, `speedMult`, `fireRateMult` per wave, repair logic between waves, victory after wave 10
- **Updated: `js/enemy.js`** — `spawnEnemy` now accepts `waveConfig` and applies HP/speed/fire-rate multipliers; spawning gated by wave manager instead of resource state; added `resetEnemyManager` for restart
- **Updated: `js/hud.js`** — Added centered "Wave X incoming!" announcement banner with fade, game over overlay (shows wave reached + restart button), victory overlay, wave state display in HUD panel
- **Updated: `js/main.js`** — Wired wave manager into game loop; wave events trigger banners/overlays; game freezes on death/victory; restart resets all systems
- **Updated: `js/resource.js`** — Removed wave tracking (moved to `wave.js`); added `resetResources` for restart