### PR TITLE
Phase 4A: Upgrade screen — weapons, propulsion, defense, radar

### DIFF
--- a/js/hud.js
+++ b/js/hud.js
@@ -9,6 +9,7 @@ var fuelBarBg = null;
 var fuelBar = null;
 var fuelLabel = null;
 var partsLabel = null;
+var salvageLabel = null;
 var hpBarBg = null;
 var hpBar = null;
 var hpLabel = null;
@@ -118,6 +119,14 @@ export function createHUD() {
   partsLabel.style.fontSize = "13px";
   partsLabel.style.color = "#8899aa";
   container.appendChild(partsLabel);
+
+  // salvage count
+  salvageLabel = document.createElement("div");
+  salvageLabel.textContent = "SALVAGE: 0";
+  salvageLabel.style.marginTop = "4px";
+  salvageLabel.style.fontSize = "13px";
+  salvageLabel.style.color = "#ffcc44";
+  container.appendChild(salvageLabel);
 
   // player HP bar
   hpLabel = document.createElement("div");
@@ -287,7 +296,7 @@ export function hideOverlay() {
   overlay.style.display = "none";
 }
 
-export function updateHUD(speedRatio, displaySpeed, heading, ammo, maxAmmo, hp, maxHp, fuel, maxFuel, parts, wave, waveState, dt) {
+export function updateHUD(speedRatio, displaySpeed, heading, ammo, maxAmmo, hp, maxHp, fuel, maxFuel, parts, wave, waveState, dt, salvage) {
   if (!container) return;
 
   var pct = Math.min(1, speedRatio) * 100;
@@ -319,6 +328,11 @@ export function updateHUD(speedRatio, displaySpeed, heading, ammo, maxAmmo, hp, 
   if (parts !== undefined && partsLabel) {
     partsLabel.textContent = "PARTS: " + parts;
     partsLabel.style.color = parts > 0 ? "#44dd66" : "#8899aa";
+  }
+
+  // salvage count
+  if (salvage !== undefined && salvageLabel) {
+    salvageLabel.textContent = "SALVAGE: " + salvage;
   }
 
   // player HP

--- a/js/upgrade.js
+++ b/js/upgrade.js
@@ -1,0 +1,159 @@
+// upgrade.js — upgrade config, state, and multiplier logic
+
+// --- upgrade tree definition ---
+// Each category has 3 upgrades, each with 3 tiers.
+// Costs increase per tier. Multipliers stack additively per tier.
+var UPGRADE_TREE = {
+  weapons: {
+    label: "Weapons",
+    color: "#ffaa22",
+    upgrades: [
+      { key: "damage",     label: "+Damage",          stat: "damage",         perTier: [0.15, 0.20, 0.30], costs: [30, 60, 120] },
+      { key: "fireRate",   label: "+Fire Rate",       stat: "fireRate",       perTier: [0.10, 0.15, 0.25], costs: [25, 50, 100] },
+      { key: "projSpeed",  label: "+Projectile Spd",  stat: "projSpeed",      perTier: [0.10, 0.15, 0.20], costs: [20, 45, 90]  }
+    ]
+  },
+  propulsion: {
+    label: "Propulsion",
+    color: "#22aaff",
+    upgrades: [
+      { key: "maxSpeed",   label: "+Max Speed",       stat: "maxSpeed",       perTier: [0.10, 0.15, 0.20], costs: [25, 50, 100] },
+      { key: "turnRate",   label: "+Turn Rate",       stat: "turnRate",       perTier: [0.10, 0.15, 0.20], costs: [20, 45, 90]  },
+      { key: "accel",      label: "+Acceleration",    stat: "accel",          perTier: [0.10, 0.15, 0.25], costs: [20, 45, 90]  }
+    ]
+  },
+  defense: {
+    label: "Defense",
+    color: "#44dd66",
+    upgrades: [
+      { key: "maxHp",      label: "+Max HP",          stat: "maxHp",          perTier: [0.15, 0.20, 0.30], costs: [30, 60, 120] },
+      { key: "armor",      label: "+Armor",           stat: "armor",          perTier: [0.10, 0.15, 0.20], costs: [25, 55, 110] },
+      { key: "repair",     label: "+Repair Eff.",     stat: "repair",         perTier: [0.20, 0.30, 0.50], costs: [20, 40, 80]  }
+    ]
+  },
+  radar: {
+    label: "Radar",
+    color: "#cc66ff",
+    upgrades: [
+      { key: "enemyRange", label: "+Enemy Range",     stat: "enemyRange",     perTier: [0.20, 0.30, 0.50], costs: [20, 40, 80]  },
+      { key: "pickupRange",label: "+Pickup Range",    stat: "pickupRange",    perTier: [0.25, 0.35, 0.50], costs: [15, 35, 70]  },
+      { key: "minimap",    label: "Minimap",          stat: "minimap",        perTier: [1, 0, 0],          costs: [50, 0, 0]    }
+    ]
+  }
+};
+
+// --- create upgrade state (all tiers at 0) ---
+export function createUpgradeState() {
+  var state = {
+    salvage: 0,
+    levels: {}
+  };
+  var cats = Object.keys(UPGRADE_TREE);
+  for (var c = 0; c < cats.length; c++) {
+    var upgrades = UPGRADE_TREE[cats[c]].upgrades;
+    for (var u = 0; u < upgrades.length; u++) {
+      state.levels[upgrades[u].key] = 0;
+    }
+  }
+  return state;
+}
+
+// --- reset upgrades (on game over restart) ---
+export function resetUpgrades(state) {
+  state.salvage = 0;
+  var keys = Object.keys(state.levels);
+  for (var i = 0; i < keys.length; i++) {
+    state.levels[keys[i]] = 0;
+  }
+}
+
+// --- add salvage points ---
+export function addSalvage(state, amount) {
+  state.salvage += amount;
+}
+
+// --- get the upgrade tree config ---
+export function getUpgradeTree() {
+  return UPGRADE_TREE;
+}
+
+// --- can afford upgrade? ---
+export function canAfford(state, key) {
+  var info = findUpgrade(key);
+  if (!info) return false;
+  var level = state.levels[key] || 0;
+  if (level >= 3) return false;
+  var cost = info.costs[level];
+  if (cost <= 0) return false;
+  return state.salvage >= cost;
+}
+
+// --- buy upgrade; returns true on success ---
+export function buyUpgrade(state, key) {
+  var info = findUpgrade(key);
+  if (!info) return false;
+  var level = state.levels[key] || 0;
+  if (level >= 3) return false;
+  var cost = info.costs[level];
+  if (cost <= 0) return false;
+  if (state.salvage < cost) return false;
+  state.salvage -= cost;
+  state.levels[key] = level + 1;
+  return true;
+}
+
+// --- get next tier cost (0 if maxed) ---
+export function getNextCost(state, key) {
+  var info = findUpgrade(key);
+  if (!info) return 0;
+  var level = state.levels[key] || 0;
+  if (level >= 3) return 0;
+  return info.costs[level];
+}
+
+// --- compute all multipliers from current upgrade levels ---
+export function getMultipliers(state) {
+  var mults = {
+    damage: 1,
+    fireRate: 1,
+    projSpeed: 1,
+    maxSpeed: 1,
+    turnRate: 1,
+    accel: 1,
+    maxHp: 1,
+    armor: 0,      // armor is additive 0-1 damage reduction
+    repair: 1,
+    enemyRange: 1,
+    pickupRange: 1,
+    minimap: 0      // 0 or 1
+  };
+
+  var cats = Object.keys(UPGRADE_TREE);
+  for (var c = 0; c < cats.length; c++) {
+    var upgrades = UPGRADE_TREE[cats[c]].upgrades;
+    for (var u = 0; u < upgrades.length; u++) {
+      var up = upgrades[u];
+      var level = state.levels[up.key] || 0;
+      for (var t = 0; t < level; t++) {
+        if (up.key === "armor" || up.key === "minimap") {
+          mults[up.stat] += up.perTier[t];
+        } else {
+          mults[up.stat] += up.perTier[t];
+        }
+      }
+    }
+  }
+  return mults;
+}
+
+// --- helper: find upgrade definition by key ---
+function findUpgrade(key) {
+  var cats = Object.keys(UPGRADE_TREE);
+  for (var c = 0; c < cats.length; c++) {
+    var upgrades = UPGRADE_TREE[cats[c]].upgrades;
+    for (var u = 0; u < upgrades.length; u++) {
+      if (upgrades[u].key === key) return upgrades[u];
+    }
+  }
+  return null;
+}

--- a/js/upgradeScreen.js
+++ b/js/upgradeScreen.js
@@ -1,0 +1,356 @@
+// upgradeScreen.js — between-wave upgrade UI overlay with ship diagram
+import { getUpgradeTree, canAfford, buyUpgrade, getNextCost, getMultipliers } from "./upgrade.js";
+
+var root = null;
+var salvageLabel = null;
+var categoryEls = {};
+var onCloseCallback = null;
+var currentState = null;
+var continueBtn = null;
+
+// --- create the upgrade screen DOM (called once) ---
+export function createUpgradeScreen() {
+  root = document.createElement("div");
+  root.id = "upgrade-screen";
+  root.style.cssText = [
+    "position: fixed",
+    "top: 0", "left: 0",
+    "width: 100%", "height: 100%",
+    "display: none",
+    "flex-direction: column",
+    "align-items: center",
+    "justify-content: center",
+    "background: rgba(5, 5, 15, 0.92)",
+    "z-index: 90",
+    "font-family: monospace",
+    "user-select: none",
+    "overflow-y: auto"
+  ].join(";");
+
+  // title
+  var title = document.createElement("div");
+  title.textContent = "UPGRADES";
+  title.style.cssText = [
+    "font-size: 36px",
+    "font-weight: bold",
+    "color: #ffcc44",
+    "margin-bottom: 8px",
+    "margin-top: 20px",
+    "text-shadow: 0 0 15px rgba(255,200,60,0.4)"
+  ].join(";");
+  root.appendChild(title);
+
+  // salvage display
+  salvageLabel = document.createElement("div");
+  salvageLabel.style.cssText = [
+    "font-size: 18px",
+    "color: #ffcc44",
+    "margin-bottom: 20px"
+  ].join(";");
+  root.appendChild(salvageLabel);
+
+  // ship diagram + categories container
+  var body = document.createElement("div");
+  body.style.cssText = [
+    "display: flex",
+    "flex-wrap: wrap",
+    "justify-content: center",
+    "align-items: flex-start",
+    "gap: 16px",
+    "max-width: 900px",
+    "width: 90%"
+  ].join(";");
+  root.appendChild(body);
+
+  // ship diagram (center)
+  var diagram = buildShipDiagram();
+  body.appendChild(diagram);
+
+  // category panels
+  var tree = getUpgradeTree();
+  var cats = Object.keys(tree);
+  for (var c = 0; c < cats.length; c++) {
+    var catKey = cats[c];
+    var cat = tree[catKey];
+    var panel = buildCategoryPanel(catKey, cat);
+    body.appendChild(panel);
+  }
+
+  // continue button
+  continueBtn = document.createElement("button");
+  continueBtn.textContent = "CONTINUE";
+  continueBtn.style.cssText = [
+    "font-family: monospace",
+    "font-size: 20px",
+    "padding: 14px 48px",
+    "margin-top: 20px",
+    "margin-bottom: 20px",
+    "background: rgba(40, 80, 60, 0.8)",
+    "color: #44dd66",
+    "border: 1px solid rgba(60, 140, 90, 0.6)",
+    "border-radius: 6px",
+    "cursor: pointer",
+    "pointer-events: auto",
+    "text-shadow: 0 0 10px rgba(60,200,90,0.3)"
+  ].join(";");
+  continueBtn.addEventListener("click", function () {
+    hideUpgradeScreen();
+    if (onCloseCallback) onCloseCallback();
+  });
+  root.appendChild(continueBtn);
+
+  document.body.appendChild(root);
+}
+
+// --- build ship diagram (SVG top-down view) ---
+function buildShipDiagram() {
+  var wrap = document.createElement("div");
+  wrap.style.cssText = [
+    "width: 160px",
+    "min-height: 300px",
+    "display: flex",
+    "flex-direction: column",
+    "align-items: center",
+    "justify-content: center"
+  ].join(";");
+
+  var svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.setAttribute("width", "120");
+  svg.setAttribute("height", "260");
+  svg.setAttribute("viewBox", "0 0 120 260");
+
+  // hull outline
+  var hull = document.createElementNS("http://www.w3.org/2000/svg", "polygon");
+  hull.setAttribute("points", "60,10 85,60 90,130 85,200 75,240 45,240 35,200 30,130 35,60");
+  hull.setAttribute("fill", "rgba(50,65,80,0.6)");
+  hull.setAttribute("stroke", "#556677");
+  hull.setAttribute("stroke-width", "2");
+  svg.appendChild(hull);
+
+  // system markers with labels
+  var markers = [
+    { cx: 60, cy: 70,  color: "#ffaa22", label: "W" },  // weapons (bow turret)
+    { cx: 60, cy: 180, color: "#22aaff", label: "P" },  // propulsion (stern)
+    { cx: 60, cy: 130, color: "#44dd66", label: "D" },  // defense (mid)
+    { cx: 60, cy: 50,  color: "#cc66ff", label: "R" }   // radar (top)
+  ];
+
+  for (var i = 0; i < markers.length; i++) {
+    var m = markers[i];
+    var circle = document.createElementNS("http://www.w3.org/2000/svg", "circle");
+    circle.setAttribute("cx", String(m.cx));
+    circle.setAttribute("cy", String(m.cy));
+    circle.setAttribute("r", "12");
+    circle.setAttribute("fill", m.color);
+    circle.setAttribute("opacity", "0.7");
+    svg.appendChild(circle);
+
+    var text = document.createElementNS("http://www.w3.org/2000/svg", "text");
+    text.setAttribute("x", String(m.cx));
+    text.setAttribute("y", String(m.cy + 4));
+    text.setAttribute("text-anchor", "middle");
+    text.setAttribute("font-size", "12");
+    text.setAttribute("font-family", "monospace");
+    text.setAttribute("font-weight", "bold");
+    text.setAttribute("fill", "#000");
+    text.textContent = m.label;
+    svg.appendChild(text);
+  }
+
+  wrap.appendChild(svg);
+
+  // legend
+  var legend = document.createElement("div");
+  legend.style.cssText = "font-size:10px;color:#667788;margin-top:8px;text-align:center;line-height:1.6";
+  legend.innerHTML = '<span style="color:#ffaa22">W</span>=Weapons ' +
+    '<span style="color:#22aaff">P</span>=Propulsion<br>' +
+    '<span style="color:#44dd66">D</span>=Defense ' +
+    '<span style="color:#cc66ff">R</span>=Radar';
+  wrap.appendChild(legend);
+
+  return wrap;
+}
+
+// --- build a category panel ---
+function buildCategoryPanel(catKey, cat) {
+  var panel = document.createElement("div");
+  panel.style.cssText = [
+    "background: rgba(15, 20, 35, 0.8)",
+    "border: 1px solid " + cat.color + "33",
+    "border-radius: 8px",
+    "padding: 12px",
+    "width: 180px"
+  ].join(";");
+
+  var heading = document.createElement("div");
+  heading.textContent = cat.label;
+  heading.style.cssText = [
+    "font-size: 15px",
+    "font-weight: bold",
+    "color: " + cat.color,
+    "margin-bottom: 10px",
+    "text-align: center"
+  ].join(";");
+  panel.appendChild(heading);
+
+  var upgradeEls = [];
+  for (var u = 0; u < cat.upgrades.length; u++) {
+    var up = cat.upgrades[u];
+    // skip placeholder upgrades with 0 cost at tier 0
+    var row = buildUpgradeRow(up, cat.color);
+    panel.appendChild(row.el);
+    upgradeEls.push(row);
+  }
+
+  categoryEls[catKey] = upgradeEls;
+  return panel;
+}
+
+// --- build a single upgrade row ---
+function buildUpgradeRow(up, color) {
+  var el = document.createElement("div");
+  el.style.cssText = [
+    "margin-bottom: 8px",
+    "padding: 6px",
+    "border-radius: 4px",
+    "background: rgba(20, 25, 40, 0.6)"
+  ].join(";");
+
+  // label
+  var label = document.createElement("div");
+  label.textContent = up.label;
+  label.style.cssText = "font-size:12px;color:#8899aa;margin-bottom:4px";
+  el.appendChild(label);
+
+  // tier pips
+  var pips = document.createElement("div");
+  pips.style.cssText = "display:flex;gap:3px;margin-bottom:4px";
+  var pipEls = [];
+  for (var t = 0; t < 3; t++) {
+    var pip = document.createElement("div");
+    pip.style.cssText = [
+      "width: 14px",
+      "height: 6px",
+      "border-radius: 2px",
+      "background: rgba(40, 50, 70, 0.8)",
+      "border: 1px solid rgba(80, 100, 130, 0.3)"
+    ].join(";");
+    pips.appendChild(pip);
+    pipEls.push(pip);
+  }
+  el.appendChild(pips);
+
+  // cost + buy button
+  var costRow = document.createElement("div");
+  costRow.style.cssText = "display:flex;justify-content:space-between;align-items:center";
+
+  var costLabel = document.createElement("span");
+  costLabel.style.cssText = "font-size:11px;color:#667788";
+  costRow.appendChild(costLabel);
+
+  var btn = document.createElement("button");
+  btn.textContent = "BUY";
+  btn.style.cssText = [
+    "font-family: monospace",
+    "font-size: 11px",
+    "padding: 2px 10px",
+    "background: rgba(40, 60, 90, 0.6)",
+    "color: #8899aa",
+    "border: 1px solid rgba(80, 100, 130, 0.4)",
+    "border-radius: 3px",
+    "cursor: pointer",
+    "pointer-events: auto"
+  ].join(";");
+
+  btn.addEventListener("click", function () {
+    if (!currentState) return;
+    if (buyUpgrade(currentState, up.key)) {
+      refreshUI();
+    }
+  });
+
+  costRow.appendChild(btn);
+  el.appendChild(costRow);
+
+  return {
+    el: el,
+    key: up.key,
+    pipEls: pipEls,
+    costLabel: costLabel,
+    btn: btn,
+    color: color
+  };
+}
+
+// --- refresh all UI elements ---
+function refreshUI() {
+  if (!currentState || !root) return;
+
+  salvageLabel.textContent = "Salvage: " + currentState.salvage;
+
+  var tree = getUpgradeTree();
+  var cats = Object.keys(tree);
+
+  for (var c = 0; c < cats.length; c++) {
+    var catKey = cats[c];
+    var rows = categoryEls[catKey];
+    if (!rows) continue;
+
+    for (var r = 0; r < rows.length; r++) {
+      var row = rows[r];
+      var level = currentState.levels[row.key] || 0;
+      var cost = getNextCost(currentState, row.key);
+      var affordable = canAfford(currentState, row.key);
+
+      // update pips
+      for (var t = 0; t < 3; t++) {
+        if (t < level) {
+          row.pipEls[t].style.background = row.color;
+          row.pipEls[t].style.borderColor = row.color;
+        } else {
+          row.pipEls[t].style.background = "rgba(40, 50, 70, 0.8)";
+          row.pipEls[t].style.borderColor = "rgba(80, 100, 130, 0.3)";
+        }
+      }
+
+      // update cost and button
+      if (level >= 3) {
+        row.costLabel.textContent = "MAX";
+        row.costLabel.style.color = row.color;
+        row.btn.style.display = "none";
+      } else if (cost <= 0) {
+        row.costLabel.textContent = "N/A";
+        row.costLabel.style.color = "#445566";
+        row.btn.style.display = "none";
+      } else {
+        row.costLabel.textContent = cost + " salvage";
+        row.costLabel.style.color = affordable ? "#aabbcc" : "#556677";
+        row.btn.style.display = "inline-block";
+        row.btn.disabled = !affordable;
+        row.btn.style.opacity = affordable ? "1" : "0.4";
+        row.btn.style.cursor = affordable ? "pointer" : "default";
+      }
+    }
+  }
+}
+
+// --- show upgrade screen ---
+export function showUpgradeScreen(upgradeState, closeCb) {
+  if (!root) return;
+  currentState = upgradeState;
+  onCloseCallback = closeCb;
+  refreshUI();
+  root.style.display = "flex";
+}
+
+// --- hide upgrade screen ---
+export function hideUpgradeScreen() {
+  if (!root) return;
+  root.style.display = "none";
+  currentState = null;
+}
+
+// --- is upgrade screen visible? ---
+export function isUpgradeScreenVisible() {
+  return root && root.style.display !== "none";
+}


### PR DESCRIPTION
Closes #8

## Acceptance Criteria
- [x] Upgrade screen appears between waves (or accessible from pause)
- [x] 4 upgrade categories: Weapons, Propulsion, Defense, Radar
- [x] Each category has 3 upgrade tiers (costs increase)
- [x] Weapons: +damage, +fire rate, +projectile speed
- [x] Propulsion: +max speed, +turn rate, +acceleration
- [x] Defense: +max HP, +armor (damage reduction), +repair efficiency
- [x] Radar: +enemy detection range, +pickup detection, minimap unlock
- [x] Currency: salvage points from destroyed enemies
- [x] Visual upgrade screen: ship diagram with highlighted systems
- [x] Upgrades persist across waves (reset on game over)

## Technical Notes
- `js/upgrade.js` — upgrade tree config, state management, multiplier computation
- `js/upgradeScreen.js` — HTML overlay UI with ship SVG diagram, category panels, buy buttons
- `js/main.js` — wires salvage on enemy death, shows upgrade screen between waves, applies multipliers
- `js/ship.js` — accepts upgrade multipliers for max speed, turn rate, acceleration
- `js/turret.js` — accepts upgrade multipliers for fire rate, projectile speed, damage
- `js/enemy.js` — armor damage reduction on player hits, setPlayerArmor/setPlayerMaxHp exports
- `js/hud.js` — salvage counter display

## Test Plan
- [ ] Destroy enemies and verify salvage counter increases in HUD
- [ ] Complete a wave and verify upgrade screen appears
- [ ] Buy upgrades and verify salvage decreases, tier pips fill
- [ ] Click CONTINUE and verify game resumes with next wave
- [ ] Verify ship moves faster after Propulsion upgrades
- [ ] Verify turrets fire faster after Weapons upgrades
- [ ] Verify damage reduction after Defense armor upgrades
- [ ] Verify upgrades reset on game over + restart