### PR TITLE
Phase 5C: Fleet commanders (bosses)

### DIFF
--- a/js/boss.js
+++ b/js/boss.js
@@ -1,0 +1,500 @@
+// boss.js — boss definitions, state machine, attacks, telegraphs, loot
+import * as THREE from "three";
+import { buildBossMesh } from "./bossModels.js";
+
+// --- boss definitions ---
+var BOSS_DEFS = {
+  battleship: {
+    name: "Iron Leviathan",
+    hp: 80,
+    hitRadius: 5.0,
+    speed: 6,
+    turnSpeed: 0.8,
+    phases: [
+      { threshold: 1.0, attack: "broadside", interval: 3.0, projCount: 5, spread: 0.4 },
+      { threshold: 0.5, attack: "broadside", interval: 2.0, projCount: 8, spread: 0.6 },
+      { threshold: 0.25, attack: "barrage", interval: 1.5, projCount: 12, spread: 1.0 }
+    ],
+    color: 0x884444
+  },
+  carrier: {
+    name: "Swarm Mother",
+    hp: 60,
+    hitRadius: 6.0,
+    speed: 5,
+    turnSpeed: 0.6,
+    phases: [
+      { threshold: 1.0, attack: "drones", interval: 5.0, droneCount: 2 },
+      { threshold: 0.5, attack: "drones", interval: 3.5, droneCount: 4 },
+      { threshold: 0.25, attack: "drones_barrage", interval: 2.5, droneCount: 6, projCount: 6, spread: 0.8 }
+    ],
+    color: 0x448844
+  },
+  kraken: {
+    name: "The Kraken",
+    hp: 100,
+    hitRadius: 4.0,
+    speed: 8,
+    turnSpeed: 1.2,
+    phases: [
+      { threshold: 1.0, attack: "tentacle_sweep", interval: 4.0, tentacleCount: 3 },
+      { threshold: 0.5, attack: "tentacle_grab", interval: 3.0, tentacleCount: 5 },
+      { threshold: 0.25, attack: "tentacle_frenzy", interval: 2.0, tentacleCount: 8 }
+    ],
+    color: 0x664488
+  }
+};
+
+// --- shared geometry ---
+var projGeo = null;
+var projMat = null;
+
+function ensureGeo() {
+  if (projGeo) return;
+  projGeo = new THREE.SphereGeometry(0.2, 6, 4);
+  projMat = new THREE.MeshBasicMaterial({ color: 0xff4422 });
+}
+
+// --- get boss definition ---
+export function getBossDef(bossType) {
+  return BOSS_DEFS[bossType] || null;
+}
+
+// --- create boss state ---
+export function createBoss(bossType, playerX, playerZ, scene, zoneDifficulty) {
+  ensureGeo();
+  var def = BOSS_DEFS[bossType];
+  if (!def) return null;
+
+  var mesh = buildBossMesh(bossType);
+  var spawnDist = 80;
+  var angle = Math.random() * Math.PI * 2;
+  var x = playerX + Math.sin(angle) * spawnDist;
+  var z = playerZ + Math.cos(angle) * spawnDist;
+  mesh.position.set(x, 0.5, z);
+  scene.add(mesh);
+
+  var hpScale = 1 + (zoneDifficulty - 1) * 0.2;
+
+  return {
+    type: bossType,
+    def: def,
+    mesh: mesh,
+    posX: x,
+    posZ: z,
+    heading: Math.atan2(playerX - x, playerZ - z),
+    hp: Math.round(def.hp * hpScale),
+    maxHp: Math.round(def.hp * hpScale),
+    alive: true,
+    hitRadius: def.hitRadius,
+    phase: 0,
+    attackTimer: 3.0,
+    projectiles: [],
+    telegraphs: [],
+    droneSpawns: [],
+    tentacleAttacks: [],
+    sinking: false,
+    sinkTimer: 0,
+    defeated: false
+  };
+}
+
+// --- get current phase index ---
+function getCurrentPhase(boss) {
+  var ratio = boss.hp / boss.maxHp;
+  var phases = boss.def.phases;
+  var phaseIdx = 0;
+  for (var i = phases.length - 1; i >= 0; i--) {
+    if (ratio <= phases[i].threshold) {
+      phaseIdx = i;
+    }
+  }
+  return phaseIdx;
+}
+
+// --- damage boss ---
+export function damageBoss(boss, amount, scene) {
+  if (!boss || !boss.alive) return;
+  boss.hp -= amount;
+  if (boss.hp <= 0) {
+    boss.hp = 0;
+    boss.alive = false;
+    boss.sinking = true;
+    boss.sinkTimer = 0;
+    boss.defeated = true;
+  } else {
+    var newPhase = getCurrentPhase(boss);
+    if (newPhase !== boss.phase) {
+      boss.phase = newPhase;
+      boss.mesh.traverse(function (child) {
+        if (child.isMesh && child.material && child.material.color) {
+          var origColor = child.material.color.getHex();
+          child.material.color.setHex(0xffffff);
+          setTimeout(function () {
+            child.material.color.setHex(origColor);
+          }, 150);
+        }
+      });
+    }
+  }
+}
+
+// --- spawn telegraph warning zone on water ---
+function spawnTelegraph(boss, targetX, targetZ, radius, duration, scene) {
+  var geo = new THREE.RingGeometry(0.5, radius, 24);
+  var mat = new THREE.MeshBasicMaterial({
+    color: 0xff2200, transparent: true, opacity: 0.0, side: THREE.DoubleSide
+  });
+  var mesh = new THREE.Mesh(geo, mat);
+  mesh.position.set(targetX, 0.4, targetZ);
+  mesh.rotation.x = -Math.PI / 2;
+  scene.add(mesh);
+
+  boss.telegraphs.push({
+    mesh: mesh,
+    radius: radius,
+    timer: duration,
+    maxTimer: duration
+  });
+}
+
+// --- fire a single boss projectile ---
+function fireBossProjectile(boss, angle, speed, scene) {
+  ensureGeo();
+  var startX = boss.posX + Math.sin(angle) * 3;
+  var startZ = boss.posZ + Math.cos(angle) * 3;
+  var mesh = new THREE.Mesh(projGeo, projMat.clone());
+  mesh.position.set(startX, 1.5, startZ);
+  scene.add(mesh);
+
+  boss.projectiles.push({
+    mesh: mesh,
+    vx: Math.sin(angle) * speed,
+    vy: speed * 0.06,
+    vz: Math.cos(angle) * speed,
+    age: 0
+  });
+}
+
+// --- broadside: aimed fan of projectiles ---
+function attackBroadside(boss, ship, scene, phase) {
+  var count = phase.projCount || 5;
+  var spread = phase.spread || 0.4;
+
+  var perpAngle = boss.heading + Math.PI / 2;
+  var cx = boss.posX + Math.sin(boss.heading) * 5;
+  var cz = boss.posZ + Math.cos(boss.heading) * 5;
+  for (var i = 0; i < 3; i++) {
+    var off = (i - 1) * 8;
+    spawnTelegraph(boss, cx + Math.sin(perpAngle) * off, cz + Math.cos(perpAngle) * off, 5, 1.5, scene);
+  }
+
+  setTimeout(function () {
+    if (!boss.alive) return;
+    var baseAngle = Math.atan2(ship.posX - boss.posX, ship.posZ - boss.posZ);
+    for (var i = 0; i < count; i++) {
+      var ao = (i - (count - 1) / 2) * spread / count;
+      fireBossProjectile(boss, baseAngle + ao, 45, scene);
+    }
+  }, 1500);
+}
+
+// --- barrage: 360-degree ring of projectiles ---
+function attackBarrage(boss, scene, phase) {
+  var count = phase.projCount || 12;
+  spawnTelegraph(boss, boss.posX, boss.posZ, 12, 1.2, scene);
+
+  setTimeout(function () {
+    if (!boss.alive) return;
+    for (var i = 0; i < count; i++) {
+      fireBossProjectile(boss, (i / count) * Math.PI * 2, 35, scene);
+    }
+  }, 1200);
+}
+
+// --- drone swarm: burst of projectiles in ring ---
+function attackDrones(boss, scene, phase) {
+  var count = phase.droneCount || 2;
+  spawnTelegraph(boss, boss.posX, boss.posZ, 8, 1.0, scene);
+  boss.droneSpawns.push({ timer: 1.0, count: count });
+}
+
+// --- kraken tentacle sweep ---
+function attackTentacleSweep(boss, ship, scene, phase) {
+  var count = phase.tentacleCount || 3;
+  var dx = ship.posX - boss.posX;
+  var dz = ship.posZ - boss.posZ;
+  var dist = Math.sqrt(dx * dx + dz * dz);
+  var baseAngle = Math.atan2(dx, dz);
+
+  for (var i = 0; i < count; i++) {
+    var as = (i - (count - 1) / 2) * 0.3;
+    var a = baseAngle + as;
+    var td = Math.min(dist, 30);
+    var tx = boss.posX + Math.sin(a) * td;
+    var tz = boss.posZ + Math.cos(a) * td;
+    spawnTelegraph(boss, tx, tz, 4, 1.0, scene);
+    boss.tentacleAttacks.push({
+      x: tx, z: tz, delay: 1.0, active: false,
+      activeTimer: 0, duration: 1.5, radius: 4, mesh: null, damaged: false
+    });
+  }
+}
+
+// --- execute attack based on phase config ---
+function executeAttack(boss, ship, scene, phase) {
+  var atk = phase.attack;
+  if (atk === "broadside") {
+    attackBroadside(boss, ship, scene, phase);
+  } else if (atk === "barrage") {
+    attackBarrage(boss, scene, phase);
+  } else if (atk === "drones" || atk === "drones_barrage") {
+    attackDrones(boss, scene, phase);
+    if (atk === "drones_barrage") attackBarrage(boss, scene, phase);
+  } else if (atk === "tentacle_sweep" || atk === "tentacle_grab" || atk === "tentacle_frenzy") {
+    attackTentacleSweep(boss, ship, scene, phase);
+  }
+}
+
+// --- update boss (called every frame) ---
+export function updateBoss(boss, ship, dt, scene, getWaveHeight, elapsed, enemyMgr) {
+  if (!boss || boss.defeated) return;
+
+  if (boss.sinking) {
+    boss.sinkTimer += dt;
+    boss.mesh.position.y -= 1.0 * dt;
+    boss.mesh.rotation.z += dt * 0.3;
+    var alpha = 1 - boss.sinkTimer / 5.0;
+    boss.mesh.traverse(function (child) {
+      if (child.isMesh && child.material) {
+        child.material.transparent = true;
+        child.material.opacity = Math.max(0, alpha);
+      }
+    });
+    if (boss.sinkTimer >= 5.0) scene.remove(boss.mesh);
+    updateBossProjectiles(boss, ship, dt, scene, enemyMgr);
+    updateTelegraphs(boss, dt, scene);
+    return;
+  }
+
+  if (!boss.alive) return;
+
+  // movement: chase player
+  var dx = ship.posX - boss.posX;
+  var dz = ship.posZ - boss.posZ;
+  var dist = Math.sqrt(dx * dx + dz * dz);
+  var targetAngle = Math.atan2(dx, dz);
+  var angleDiff = targetAngle - boss.heading;
+  while (angleDiff > Math.PI) angleDiff -= 2 * Math.PI;
+  while (angleDiff < -Math.PI) angleDiff += 2 * Math.PI;
+
+  var maxTurn = boss.def.turnSpeed * dt;
+  if (Math.abs(angleDiff) < maxTurn) {
+    boss.heading = targetAngle;
+  } else {
+    boss.heading += Math.sign(angleDiff) * maxTurn;
+  }
+
+  var engageDist = 25;
+  var sf = dist < engageDist ? Math.max(0.1, (dist - 5) / (engageDist - 5)) : 1;
+  if (Math.abs(angleDiff) < Math.PI * 0.6) {
+    boss.posX += Math.sin(boss.heading) * boss.def.speed * sf * dt;
+    boss.posZ += Math.cos(boss.heading) * boss.def.speed * sf * dt;
+  }
+
+  boss.mesh.position.x = boss.posX;
+  boss.mesh.position.z = boss.posZ;
+  boss.mesh.rotation.y = boss.heading;
+
+  if (getWaveHeight) {
+    boss.mesh.position.y = getWaveHeight(boss.posX, boss.posZ, elapsed) + 1.5;
+  }
+
+  // animate kraken tentacles
+  if (boss.type === "kraken" && boss.mesh.userData.tentacles) {
+    var tents = boss.mesh.userData.tentacles;
+    for (var i = 0; i < tents.length; i++) {
+      tents[i].rotation.y = Math.sin(elapsed * 0.8 + i * 0.7) * 0.3;
+      tents[i].position.y = 0.2 + Math.sin(elapsed * 1.2 + i) * 0.2;
+    }
+  }
+
+  // attack timer
+  var phaseIdx = getCurrentPhase(boss);
+  boss.phase = phaseIdx;
+  var phase = boss.def.phases[phaseIdx];
+  boss.attackTimer -= dt;
+  if (boss.attackTimer <= 0) {
+    boss.attackTimer = phase.interval;
+    executeAttack(boss, ship, scene, phase);
+  }
+
+  updateBossProjectiles(boss, ship, dt, scene, enemyMgr);
+  updateTelegraphs(boss, dt, scene);
+  updateDroneSpawns(boss, dt, scene);
+  updateTentacleAttacks(boss, ship, dt, scene, enemyMgr);
+}
+
+// --- update boss projectiles ---
+function updateBossProjectiles(boss, ship, dt, scene, enemyMgr) {
+  var alive = [];
+  for (var i = 0; i < boss.projectiles.length; i++) {
+    var p = boss.projectiles[i];
+    p.age += dt;
+    p.vy -= 9.8 * dt;
+    p.mesh.position.x += p.vx * dt;
+    p.mesh.position.y += p.vy * dt;
+    p.mesh.position.z += p.vz * dt;
+
+    var hitWater = p.mesh.position.y < 0.2;
+    var tooOld = p.age > 5;
+    var hitPlayer = false;
+    var pdx = p.mesh.position.x - ship.posX;
+    var pdz = p.mesh.position.z - ship.posZ;
+    if (pdx * pdx + pdz * pdz < 3.0 * 3.0) {
+      hitPlayer = true;
+      if (enemyMgr) {
+        var dmg = Math.max(0.2, 2 * (1 - (enemyMgr.playerArmor || 0)));
+        enemyMgr.playerHp = Math.max(0, enemyMgr.playerHp - dmg);
+      }
+    }
+
+    if (hitWater || tooOld || hitPlayer) {
+      scene.remove(p.mesh);
+    } else {
+      alive.push(p);
+    }
+  }
+  boss.projectiles = alive;
+}
+
+// --- update telegraph warning zones ---
+function updateTelegraphs(boss, dt, scene) {
+  var alive = [];
+  for (var i = 0; i < boss.telegraphs.length; i++) {
+    var t = boss.telegraphs[i];
+    t.timer -= dt;
+    var progress = 1 - t.timer / t.maxTimer;
+    t.mesh.material.opacity = (progress < 0.5 ? progress : 1 - progress) * 0.6;
+    t.mesh.scale.setScalar(1.0 + Math.sin(progress * Math.PI * 4) * 0.1);
+    if (t.timer <= 0) {
+      scene.remove(t.mesh);
+    } else {
+      alive.push(t);
+    }
+  }
+  boss.telegraphs = alive;
+}
+
+// --- update drone spawn timers ---
+function updateDroneSpawns(boss, dt, scene) {
+  var alive = [];
+  for (var i = 0; i < boss.droneSpawns.length; i++) {
+    var ds = boss.droneSpawns[i];
+    ds.timer -= dt;
+    if (ds.timer <= 0) {
+      for (var d = 0; d < ds.count; d++) {
+        var angle = (d / ds.count) * Math.PI * 2 + Math.random() * 0.3;
+        fireBossProjectile(boss, angle, 25, scene);
+      }
+    } else {
+      alive.push(ds);
+    }
+  }
+  boss.droneSpawns = alive;
+}
+
+// --- update tentacle attack zones ---
+function updateTentacleAttacks(boss, ship, dt, scene, enemyMgr) {
+  var alive = [];
+  for (var i = 0; i < boss.tentacleAttacks.length; i++) {
+    var ta = boss.tentacleAttacks[i];
+
+    if (!ta.active) {
+      ta.delay -= dt;
+      if (ta.delay <= 0) {
+        ta.active = true;
+        var tentMat = new THREE.MeshLambertMaterial({ color: 0x664488, transparent: true, opacity: 0.8 });
+        var tentGeo = new THREE.CylinderGeometry(0.4, 0.8, 6, 8);
+        ta.mesh = new THREE.Mesh(tentGeo, tentMat);
+        ta.mesh.position.set(ta.x, 3, ta.z);
+        scene.add(ta.mesh);
+      }
+      alive.push(ta);
+      continue;
+    }
+
+    ta.activeTimer += dt;
+    if (ta.mesh) {
+      var prog = ta.activeTimer / ta.duration;
+      if (prog < 0.3) {
+        ta.mesh.position.y = prog / 0.3 * 3;
+      } else if (prog < 0.7) {
+        ta.mesh.position.y = 3;
+        ta.mesh.rotation.z = Math.sin(ta.activeTimer * 8) * 0.3;
+      } else {
+        ta.mesh.position.y = 3 * (1 - (prog - 0.7) / 0.3);
+        ta.mesh.material.opacity = (1 - (prog - 0.7) / 0.3) * 0.8;
+      }
+    }
+
+    if (!ta.damaged && enemyMgr) {
+      var tdx = ship.posX - ta.x;
+      var tdz = ship.posZ - ta.z;
+      if (tdx * tdx + tdz * tdz < ta.radius * ta.radius) {
+        var dmg2 = Math.max(0.3, 3 * (1 - (enemyMgr.playerArmor || 0)));
+        enemyMgr.playerHp = Math.max(0, enemyMgr.playerHp - dmg2);
+        ta.damaged = true;
+      }
+    }
+
+    if (ta.activeTimer >= ta.duration) {
+      if (ta.mesh) scene.remove(ta.mesh);
+    } else {
+      alive.push(ta);
+    }
+  }
+  boss.tentacleAttacks = alive;
+}
+
+// --- remove boss from scene ---
+export function removeBoss(boss, scene) {
+  if (!boss) return;
+  scene.remove(boss.mesh);
+  for (var i = 0; i < boss.projectiles.length; i++) {
+    scene.remove(boss.projectiles[i].mesh);
+  }
+  for (var i = 0; i < boss.telegraphs.length; i++) {
+    scene.remove(boss.telegraphs[i].mesh);
+  }
+  for (var i = 0; i < boss.tentacleAttacks.length; i++) {
+    if (boss.tentacleAttacks[i].mesh) scene.remove(boss.tentacleAttacks[i].mesh);
+  }
+}
+
+// --- loot table ---
+var LOOT_TABLE = [
+  { type: "upgrade", label: "+25% Damage", stat: "damage", value: 0.25 },
+  { type: "upgrade", label: "+30% Max HP", stat: "maxHp", value: 0.30 },
+  { type: "upgrade", label: "+20% Fire Rate", stat: "fireRate", value: 0.20 },
+  { type: "upgrade", label: "+20% Speed", stat: "maxSpeed", value: 0.20 },
+  { type: "salvage", label: "+100 Salvage", value: 100 },
+  { type: "repair", label: "Full Repair", value: 1.0 }
+];
+
+export function rollBossLoot() {
+  return LOOT_TABLE[Math.floor(Math.random() * LOOT_TABLE.length)];
+}
+
+export function applyBossLoot(loot, upgrades, enemyMgr) {
+  if (loot.type === "salvage") {
+    upgrades.salvage += loot.value;
+  } else if (loot.type === "repair") {
+    enemyMgr.playerHp = enemyMgr.playerMaxHp;
+  } else if (loot.type === "upgrade") {
+    if (!upgrades.bossBonus) upgrades.bossBonus = {};
+    if (!upgrades.bossBonus[loot.stat]) upgrades.bossBonus[loot.stat] = 0;
+    upgrades.bossBonus[loot.stat] += loot.value;
+  }
+  return loot;
+}

--- a/js/bossHud.js
+++ b/js/bossHud.js
@@ -1,0 +1,171 @@
+// bossHud.js — boss HP bar at top of screen, segmented by phases
+var container = null;
+var nameLabel = null;
+var barBg = null;
+var barFill = null;
+var phaseMarkers = [];
+var phaseLabel = null;
+var lootBanner = null;
+var lootTimer = 0;
+
+export function createBossHud() {
+  container = document.createElement("div");
+  container.style.cssText = [
+    "position: fixed",
+    "top: 20px",
+    "left: 50%",
+    "transform: translateX(-50%)",
+    "display: none",
+    "flex-direction: column",
+    "align-items: center",
+    "pointer-events: none",
+    "font-family: monospace",
+    "z-index: 15",
+    "user-select: none"
+  ].join(";");
+
+  // boss name
+  nameLabel = document.createElement("div");
+  nameLabel.style.cssText = [
+    "font-size: 18px",
+    "font-weight: bold",
+    "color: #cc4444",
+    "text-shadow: 0 0 10px rgba(200,60,60,0.5)",
+    "margin-bottom: 6px"
+  ].join(";");
+  nameLabel.textContent = "BOSS";
+  container.appendChild(nameLabel);
+
+  // bar background
+  barBg = document.createElement("div");
+  barBg.style.cssText = [
+    "width: 400px",
+    "max-width: 80vw",
+    "height: 16px",
+    "background: rgba(20, 10, 10, 0.8)",
+    "border: 1px solid rgba(200, 60, 60, 0.5)",
+    "border-radius: 4px",
+    "overflow: hidden",
+    "position: relative"
+  ].join(";");
+
+  // bar fill
+  barFill = document.createElement("div");
+  barFill.style.cssText = [
+    "width: 100%",
+    "height: 100%",
+    "background: linear-gradient(90deg, #cc2222, #cc4444)",
+    "border-radius: 3px",
+    "transition: width 0.15s"
+  ].join(";");
+  barBg.appendChild(barFill);
+  container.appendChild(barBg);
+
+  // phase label
+  phaseLabel = document.createElement("div");
+  phaseLabel.style.cssText = [
+    "font-size: 12px",
+    "color: #aa6666",
+    "margin-top: 4px"
+  ].join(";");
+  phaseLabel.textContent = "";
+  container.appendChild(phaseLabel);
+
+  document.body.appendChild(container);
+
+  // loot banner (reuse for boss loot)
+  lootBanner = document.createElement("div");
+  lootBanner.style.cssText = [
+    "position: fixed",
+    "top: 15%",
+    "left: 50%",
+    "transform: translateX(-50%)",
+    "font-family: monospace",
+    "font-size: 24px",
+    "font-weight: bold",
+    "color: #ffcc44",
+    "text-shadow: 0 0 15px rgba(255,200,60,0.5)",
+    "pointer-events: none",
+    "user-select: none",
+    "z-index: 20",
+    "opacity: 0",
+    "transition: opacity 0.3s"
+  ].join(";");
+  document.body.appendChild(lootBanner);
+}
+
+export function showBossHud(bossName) {
+  if (!container) return;
+  nameLabel.textContent = bossName;
+  container.style.display = "flex";
+  // clear old phase markers
+  for (var i = 0; i < phaseMarkers.length; i++) {
+    barBg.removeChild(phaseMarkers[i]);
+  }
+  phaseMarkers = [];
+}
+
+export function hideBossHud() {
+  if (!container) return;
+  container.style.display = "none";
+}
+
+export function updateBossHud(boss, dt) {
+  if (!container || !boss) return;
+
+  var hpPct = Math.max(0, boss.hp / boss.maxHp) * 100;
+  barFill.style.width = hpPct + "%";
+
+  // color based on HP
+  if (hpPct > 50) {
+    barFill.style.background = "linear-gradient(90deg, #cc2222, #cc4444)";
+  } else if (hpPct > 25) {
+    barFill.style.background = "linear-gradient(90deg, #cc6622, #ccaa22)";
+  } else {
+    barFill.style.background = "linear-gradient(90deg, #cc2266, #ff4488)";
+  }
+
+  // phase markers (add once)
+  if (phaseMarkers.length === 0 && boss.def && boss.def.phases) {
+    for (var i = 1; i < boss.def.phases.length; i++) {
+      var threshold = boss.def.phases[i].threshold;
+      var marker = document.createElement("div");
+      marker.style.cssText = [
+        "position: absolute",
+        "top: 0",
+        "width: 2px",
+        "height: 100%",
+        "background: rgba(255,255,255,0.4)",
+        "left: " + (threshold * 100) + "%"
+      ].join(";");
+      barBg.appendChild(marker);
+      phaseMarkers.push(marker);
+    }
+  }
+
+  // phase text
+  var phaseNames = ["Phase 1", "Phase 2", "Phase 3"];
+  var phaseIdx = boss.phase || 0;
+  phaseLabel.textContent = phaseNames[phaseIdx] || ("Phase " + (phaseIdx + 1));
+
+  // HP numbers
+  nameLabel.textContent = boss.def.name + "  " + boss.hp + " / " + boss.maxHp;
+
+  // update loot banner
+  if (lootTimer > 0) {
+    lootTimer -= dt;
+    if (lootTimer <= 0.5) {
+      lootBanner.style.opacity = String(Math.max(0, lootTimer / 0.5));
+    }
+    if (lootTimer <= 0) {
+      lootBanner.style.opacity = "0";
+    }
+  }
+}
+
+export function showLootBanner(text) {
+  if (!lootBanner) return;
+  lootBanner.textContent = "BOSS LOOT: " + text;
+  lootBanner.style.opacity = "1";
+  lootTimer = 4;
+}

--- a/js/bossModels.js
+++ b/js/bossModels.js
@@ -1,0 +1,226 @@
+// bossModels.js — unique procedural 3D models for boss enemies
+import * as THREE from "three";
+
+// --- build battleship boss mesh (large, armored) ---
+function buildBattleshipMesh() {
+  var group = new THREE.Group();
+
+  var hullShape = new THREE.Shape();
+  hullShape.moveTo(0, 5.0);
+  hullShape.lineTo(1.4, 2.5);
+  hullShape.lineTo(1.6, 0);
+  hullShape.lineTo(1.4, -3.0);
+  hullShape.lineTo(0.8, -4.5);
+  hullShape.lineTo(-0.8, -4.5);
+  hullShape.lineTo(-1.4, -3.0);
+  hullShape.lineTo(-1.6, 0);
+  hullShape.lineTo(-1.4, 2.5);
+  hullShape.lineTo(0, 5.0);
+
+  var hullGeo = new THREE.ExtrudeGeometry(hullShape, { depth: 1.0, bevelEnabled: false });
+  var hullMat = new THREE.MeshLambertMaterial({ color: 0x664433 });
+  var hull = new THREE.Mesh(hullGeo, hullMat);
+  hull.rotation.x = -Math.PI / 2;
+  hull.position.y = -0.2;
+  group.add(hull);
+
+  var deckGeo = new THREE.PlaneGeometry(2.6, 8.0);
+  var deckMat = new THREE.MeshLambertMaterial({ color: 0x775544 });
+  var deck = new THREE.Mesh(deckGeo, deckMat);
+  deck.rotation.x = -Math.PI / 2;
+  deck.position.y = 0.8;
+  group.add(deck);
+
+  // massive bridge
+  var bridgeGeo = new THREE.BoxGeometry(1.4, 1.4, 1.8);
+  var bridgeMat = new THREE.MeshLambertMaterial({ color: 0x886655 });
+  var bridge = new THREE.Mesh(bridgeGeo, bridgeMat);
+  bridge.position.set(0, 1.5, -1.5);
+  group.add(bridge);
+
+  // broadside turrets (4 total)
+  var turretGeo = new THREE.CylinderGeometry(0.3, 0.4, 0.4, 6);
+  var turretMat = new THREE.MeshLambertMaterial({ color: 0x553322 });
+  var barrelGeo = new THREE.CylinderGeometry(0.06, 0.06, 1.0, 4);
+  var barrelMat = new THREE.MeshLambertMaterial({ color: 0x442211 });
+
+  var turrets = [];
+  var turretPositions = [
+    [0, 1.0, 2.5],
+    [0, 1.0, 0.5],
+    [0, 1.0, -0.5],
+    [0, 1.0, -3.0]
+  ];
+  for (var i = 0; i < turretPositions.length; i++) {
+    var t = new THREE.Group();
+    t.position.set(turretPositions[i][0], turretPositions[i][1], turretPositions[i][2]);
+    t.add(new THREE.Mesh(turretGeo, turretMat));
+    var b = new THREE.Mesh(barrelGeo, barrelMat);
+    b.rotation.x = Math.PI / 2;
+    b.position.set(0, 0.15, 0.5);
+    t.add(b);
+    group.add(t);
+    turrets.push(t);
+  }
+
+  // armor plating (decorative boxes along sides)
+  var plateMat = new THREE.MeshLambertMaterial({ color: 0x554433 });
+  for (var side = -1; side <= 1; side += 2) {
+    for (var pi = 0; pi < 3; pi++) {
+      var plate = new THREE.Mesh(
+        new THREE.BoxGeometry(0.2, 0.6, 1.5),
+        plateMat
+      );
+      plate.position.set(side * 1.3, 0.6, pi * 2.5 - 2.0);
+      group.add(plate);
+    }
+  }
+
+  group.userData.turrets = turrets;
+  return group;
+}
+
+// --- build carrier boss mesh (large flat deck, hangars) ---
+function buildCarrierBossMesh() {
+  var group = new THREE.Group();
+
+  var hullShape = new THREE.Shape();
+  hullShape.moveTo(0, 5.5);
+  hullShape.lineTo(1.8, 2.5);
+  hullShape.lineTo(2.0, 0);
+  hullShape.lineTo(1.8, -3.5);
+  hullShape.lineTo(1.2, -5.0);
+  hullShape.lineTo(-1.2, -5.0);
+  hullShape.lineTo(-1.8, -3.5);
+  hullShape.lineTo(-2.0, 0);
+  hullShape.lineTo(-1.8, 2.5);
+  hullShape.lineTo(0, 5.5);
+
+  var hullGeo = new THREE.ExtrudeGeometry(hullShape, { depth: 1.0, bevelEnabled: false });
+  var hullMat = new THREE.MeshLambertMaterial({ color: 0x335533 });
+  var hull = new THREE.Mesh(hullGeo, hullMat);
+  hull.rotation.x = -Math.PI / 2;
+  hull.position.y = -0.2;
+  group.add(hull);
+
+  // flight deck
+  var deckGeo = new THREE.PlaneGeometry(3.4, 9.0);
+  var deckMat = new THREE.MeshLambertMaterial({ color: 0x446644 });
+  var deck = new THREE.Mesh(deckGeo, deckMat);
+  deck.rotation.x = -Math.PI / 2;
+  deck.position.y = 0.9;
+  group.add(deck);
+
+  // runway stripes
+  for (var s = 0; s < 3; s++) {
+    var stripeGeo = new THREE.PlaneGeometry(0.08, 6.0);
+    var stripeMat = new THREE.MeshLambertMaterial({ color: 0xccccaa });
+    var stripe = new THREE.Mesh(stripeGeo, stripeMat);
+    stripe.rotation.x = -Math.PI / 2;
+    stripe.position.set((s - 1) * 0.8, 0.91, 0);
+    group.add(stripe);
+  }
+
+  // island
+  var bridgeGeo = new THREE.BoxGeometry(0.8, 1.2, 1.2);
+  var bridgeMat = new THREE.MeshLambertMaterial({ color: 0x557755 });
+  var bridgeIs = new THREE.Mesh(bridgeGeo, bridgeMat);
+  bridgeIs.position.set(1.2, 1.5, -1.5);
+  group.add(bridgeIs);
+
+  // hangar bays
+  var hangarMat = new THREE.MeshLambertMaterial({ color: 0x334433 });
+  for (var h = 0; h < 2; h++) {
+    var hangar = new THREE.Mesh(new THREE.BoxGeometry(1.0, 0.5, 1.5), hangarMat);
+    hangar.position.set(0, 0.7, h * 3.0 - 0.5);
+    group.add(hangar);
+  }
+
+  // defensive turrets
+  var turretGeo = new THREE.CylinderGeometry(0.25, 0.3, 0.3, 6);
+  var turretMat = new THREE.MeshLambertMaterial({ color: 0x334433 });
+  var barrelGeo = new THREE.CylinderGeometry(0.04, 0.04, 0.7, 4);
+  var barrelMat = new THREE.MeshLambertMaterial({ color: 0x223322 });
+
+  var turrets = [];
+  var tPos = [[0, 1.0, 3.0], [0, 1.0, -3.5]];
+  for (var i = 0; i < tPos.length; i++) {
+    var t = new THREE.Group();
+    t.position.set(tPos[i][0], tPos[i][1], tPos[i][2]);
+    t.add(new THREE.Mesh(turretGeo, turretMat));
+    var b2 = new THREE.Mesh(barrelGeo, barrelMat);
+    b2.rotation.x = Math.PI / 2;
+    b2.position.set(0, 0.1, 0.35);
+    t.add(b2);
+    group.add(t);
+    turrets.push(t);
+  }
+
+  group.userData.turrets = turrets;
+  return group;
+}
+
+// --- build kraken boss mesh (tentacles, non-ship) ---
+function buildKrakenMesh() {
+  var group = new THREE.Group();
+
+  // body — large sphere-ish mass
+  var bodyGeo = new THREE.SphereGeometry(2.5, 12, 8);
+  var bodyMat = new THREE.MeshLambertMaterial({ color: 0x553377 });
+  var body = new THREE.Mesh(bodyGeo, bodyMat);
+  body.scale.set(1.0, 0.5, 1.2);
+  body.position.y = 0.5;
+  group.add(body);
+
+  // eyes
+  var eyeGeo = new THREE.SphereGeometry(0.4, 8, 6);
+  var eyeMat = new THREE.MeshBasicMaterial({ color: 0xffcc00 });
+  var eyeL = new THREE.Mesh(eyeGeo, eyeMat);
+  eyeL.position.set(-0.8, 1.0, 1.8);
+  group.add(eyeL);
+  var eyeR = new THREE.Mesh(eyeGeo, eyeMat);
+  eyeR.position.set(0.8, 1.0, 1.8);
+  group.add(eyeR);
+
+  // tentacles (stored for animation)
+  var tentacles = [];
+  var tentacleMat = new THREE.MeshLambertMaterial({ color: 0x664488 });
+  for (var i = 0; i < 8; i++) {
+    var angle = (i / 8) * Math.PI * 2;
+    var tentGroup = new THREE.Group();
+    tentGroup.position.set(
+      Math.sin(angle) * 2.0,
+      0.2,
+      Math.cos(angle) * 2.0
+    );
+
+    // three segments per tentacle
+    for (var s = 0; s < 3; s++) {
+      var radius = 0.3 - s * 0.08;
+      var segGeo = new THREE.CylinderGeometry(radius, radius + 0.05, 2.0, 6);
+      var seg = new THREE.Mesh(segGeo, tentacleMat);
+      seg.position.set(
+        Math.sin(angle) * s * 1.5,
+        -s * 0.3,
+        Math.cos(angle) * s * 1.5
+      );
+      seg.rotation.z = angle + Math.PI / 2;
+      seg.rotation.x = 0.3 * s;
+      tentGroup.add(seg);
+    }
+
+    group.add(tentGroup);
+    tentacles.push(tentGroup);
+  }
+  group.userData.tentacles = tentacles;
+
+  return group;
+}
+
+// --- build boss mesh by type ---
+export function buildBossMesh(bossType) {
+  if (bossType === "battleship") return buildBattleshipMesh();
+  if (bossType === "carrier") return buildCarrierBossMesh();
+  if (bossType === "kraken") return buildKrakenMesh();
+  return buildBattleshipMesh();
+}

--- a/js/mapData.js
+++ b/js/mapData.js
@@ -30,6 +30,7 @@ var ZONES = [
     enemiesPerWave: 1,
     hpScale: 1.1,
     speedScale: 1.05,
+    boss: "battleship",
     x: 35,
     y: 58,
     connections: ["shallow_cove", "reef_basin"]
@@ -45,6 +46,7 @@ var ZONES = [
     enemiesPerWave: 2,
     hpScale: 1.3,
     speedScale: 1.1,
+    boss: "carrier",
     x: 60,
     y: 42,
     connections: ["iron_strait", "stormwall"]
@@ -60,6 +62,7 @@ var ZONES = [
     enemiesPerWave: 2,
     hpScale: 1.5,
     speedScale: 1.2,
+    boss: "battleship",
     x: 40,
     y: 28,
     connections: ["reef_basin", "black_trench"]
@@ -75,6 +78,7 @@ var ZONES = [
     enemiesPerWave: 3,
     hpScale: 1.8,
     speedScale: 1.3,
+    boss: "kraken",
     x: 55,
     y: 15,
     connections: ["stormwall", "leviathan_maw"]
@@ -90,6 +94,7 @@ var ZONES = [
     enemiesPerWave: 3,
     hpScale: 2.0,
     speedScale: 1.4,
+    boss: "kraken",
     x: 30,
     y: 5,
     connections: ["black_trench"]
@@ -187,16 +192,23 @@ export function getZoneStars(state, zoneId) {
 }
 
 // --- build wave configs for a zone (replaces global wave configs) ---
+// Final wave marked as boss wave if zone has a boss
 export function buildZoneWaveConfigs(zone) {
   var configs = [];
   for (var i = 1; i <= zone.waves; i++) {
-    configs.push({
+    var cfg = {
       wave: i,
       enemies: zone.enemyBase + zone.enemiesPerWave * (i - 1),
       hpMult: zone.hpScale * (1.0 + (i - 1) * 0.15),
       speedMult: zone.speedScale * (1.0 + (i - 1) * 0.08),
       fireRateMult: 1.0 + (i - 1) * 0.1
-    });
+    };
+    // mark final wave as boss wave
+    if (i === zone.waves && zone.boss) {
+      cfg.boss = zone.boss;
+      cfg.enemies = Math.max(1, Math.floor(cfg.enemies / 2)); // fewer regular enemies during boss
+    }
+    configs.push(cfg);
   }
   return configs;
 }


### PR DESCRIPTION
Closes #13

## Acceptance Criteria

- [x] Boss appears as final wave of each zone
- [x] 3+ unique bosses: Battleship (heavy armor, broadsides), Aircraft Carrier (drone swarms), Kraken (tentacles, non-ship)
- [x] Multi-phase fights: boss changes behavior at HP thresholds (100%, 50%, 25%)
- [x] Boss telegraphs attacks (warning indicators before big hits)
- [x] Unique boss models (larger, more detailed than regular enemies)
- [x] Boss HP bar at top of screen (segmented for phases)
- [x] Loot drop on defeat: rare upgrade or ship unlock

## Implementation

### New files
- `js/boss.js` — Boss state machine, attack patterns, phase transitions, loot system
- `js/bossModels.js` — Unique procedural 3D models for Battleship, Carrier, and Kraken
- `js/bossHud.js` — Segmented HP bar at top of screen with phase markers

### Modified files
- `js/mapData.js` — Added `boss` field to 5 zones (Iron Strait through Leviathan's Maw), final wave marked as boss wave
- `js/wave.js` — New `wave_start_boss` event, `bossAlive` parameter gates wave completion
- `js/weapon.js` — Player projectiles now check for boss hit detection via `checkBossHit()`
- `js/main.js` — Full boss lifecycle: spawn, update, defeat, loot, HUD, cleanup

### Boss Details
| Boss | Zones | Phase 1 | Phase 2 (50% HP) | Phase 3 (25% HP) |
|------|-------|---------|-------------------|-------------------|
| **Iron Leviathan** (Battleship) | Iron Strait, Stormwall | Broadside (5 projectiles) | Broadside (8 projectiles, faster) | 360° Barrage (12 projectiles) |
| **Swarm Mother** (Carrier) | Reef Basin | Drone swarm (2) | Drone swarm (4) | Drones + Barrage |
| **The Kraken** | Black Trench, Leviathan's Maw | Tentacle sweep (3) | Tentacle grab (5) | Tentacle frenzy (8) |

### Loot Table
Random drop on boss defeat: +25% Damage, +30% Max HP, +20% Fire Rate, +20% Speed, +100 Salvage, or Full Repair.