### PR TITLE
Phase 6A: Officer/crew system

### DIFF
--- a/js/crew.js
+++ b/js/crew.js
@@ -1,0 +1,173 @@
+// crew.js — officer/crew system: data, procedural names, roster management, bonuses
+
+// --- stations ---
+var STATIONS = ["weapons", "engine", "helm", "medical"];
+
+// --- station bonus definitions ---
+var STATION_BONUSES = {
+  weapons: { stat: "fireRate", perRank: 0.05, label: "+{pct}% Fire Rate" },
+  engine:  { stat: "maxSpeed", perRank: 0.05, label: "+{pct}% Max Speed" },
+  helm:    { stat: "turnRate", perRank: 0.05, label: "+{pct}% Turn Rate" },
+  medical: { stat: "repair",   perRank: 0.05, label: "+{pct}% Repair Eff." }
+};
+
+// --- procedural name parts (naval-themed) ---
+var FIRST_NAMES = [
+  "Ahab", "Nemo", "Drake", "Bligh", "Horatio",
+  "Morgan", "Jolly", "Calico", "Bart", "Flint",
+  "Blythe", "Coral", "Marina", "Pearl", "Tempest",
+  "Harpoon", "Anchor", "Keel", "Bosun", "Rigger",
+  "Salty", "Barnacle", "Gale", "Storm", "Tide"
+];
+
+var LAST_NAMES = [
+  "Blackbeard", "Ironside", "Wavecrest", "Saltborn", "Deepwater",
+  "Gunwhale", "Broadside", "Keelhaul", "Driftwood", "Seaspray",
+  "Tidecaller", "Stormhelm", "Reefsong", "Bowsprit", "Quarterdeck",
+  "Foghorn", "Rudderfoot", "Hullbreaker", "Anchorstone", "Shellback"
+];
+
+// --- emoji portraits per specialty ---
+var PORTRAITS = {
+  weapons: ["\u2694\ufe0f", "\ud83d\udca3", "\ud83c\udfaf", "\ud83d\udd2b"],
+  engine:  ["\u2699\ufe0f", "\ud83d\udd27", "\u26a1", "\ud83d\udee2\ufe0f"],
+  helm:    ["\ud83e\udded", "\u2693", "\ud83c\udfa1", "\ud83d\udccd"],
+  medical: ["\u2764\ufe0f", "\ud83d\udc8a", "\ud83e\ude7a", "\u2695\ufe0f"]
+};
+
+// --- generate a random officer ---
+var _nameCounter = 0;
+
+function randomOfficer(specialty, rank) {
+  _nameCounter++;
+  var seed = Date.now() + _nameCounter;
+  var first = FIRST_NAMES[(seed * 7 + _nameCounter * 3) % FIRST_NAMES.length];
+  var last = LAST_NAMES[(seed * 13 + _nameCounter * 11) % LAST_NAMES.length];
+  var portraits = PORTRAITS[specialty] || PORTRAITS.weapons;
+  var portrait = portraits[(seed * 5) % portraits.length];
+
+  return {
+    id: "officer_" + _nameCounter + "_" + Date.now(),
+    name: first + " " + last,
+    portrait: portrait,
+    specialty: specialty,
+    rank: rank || 1
+  };
+}
+
+// --- create crew state ---
+export function createCrewState() {
+  return {
+    roster: [],           // all officers the player has
+    assigned: {           // station -> officer id (or null)
+      weapons: null,
+      engine: null,
+      helm: null,
+      medical: null
+    }
+  };
+}
+
+// --- reset crew state ---
+export function resetCrew(state) {
+  state.roster = [];
+  state.assigned = { weapons: null, engine: null, helm: null, medical: null };
+}
+
+// --- add an officer to roster ---
+export function addOfficer(state, officer) {
+  state.roster.push(officer);
+}
+
+// --- generate a random officer reward ---
+export function generateOfficerReward(rank) {
+  var spec = STATIONS[Math.floor(Math.random() * STATIONS.length)];
+  var r = rank || (Math.random() < 0.6 ? 1 : (Math.random() < 0.7 ? 2 : 3));
+  return randomOfficer(spec, r);
+}
+
+// --- assign officer to a station ---
+// Returns true if assigned, false if invalid.
+export function assignOfficer(state, officerId, station) {
+  if (STATIONS.indexOf(station) === -1) return false;
+  var officer = findOfficer(state, officerId);
+  if (!officer) return false;
+
+  // un-assign from any previous station
+  for (var s = 0; s < STATIONS.length; s++) {
+    if (state.assigned[STATIONS[s]] === officerId) {
+      state.assigned[STATIONS[s]] = null;
+    }
+  }
+
+  state.assigned[station] = officerId;
+  return true;
+}
+
+// --- unassign officer from a station ---
+export function unassignStation(state, station) {
+  if (STATIONS.indexOf(station) === -1) return;
+  state.assigned[station] = null;
+}
+
+// --- get the officer assigned to a station (or null) ---
+export function getAssigned(state, station) {
+  var id = state.assigned[station];
+  if (!id) return null;
+  return findOfficer(state, id);
+}
+
+// --- compute crew bonus multipliers ---
+// Returns object like { fireRate: 1.15, maxSpeed: 1.0, turnRate: 1.1, repair: 1.0 }
+export function getCrewBonuses(state) {
+  var bonuses = { fireRate: 1, maxSpeed: 1, turnRate: 1, repair: 1 };
+
+  for (var s = 0; s < STATIONS.length; s++) {
+    var station = STATIONS[s];
+    var officerId = state.assigned[station];
+    if (!officerId) continue;
+    var officer = findOfficer(state, officerId);
+    if (!officer) continue;
+
+    var def = STATION_BONUSES[station];
+    // matching specialty = full bonus; mismatched = half bonus
+    var mult = (officer.specialty === station) ? 1.0 : 0.5;
+    var bonus = def.perRank * officer.rank * mult;
+    bonuses[def.stat] += bonus;
+  }
+
+  return bonuses;
+}
+
+// --- get station definitions for UI ---
+export function getStations() {
+  return STATIONS;
+}
+
+// --- get bonus description for an officer at a station ---
+export function getBonusLabel(officer, station) {
+  var def = STATION_BONUSES[station];
+  if (!def) return "";
+  var mult = (officer.specialty === station) ? 1.0 : 0.5;
+  var pct = Math.round(def.perRank * officer.rank * mult * 100);
+  return def.label.replace("{pct}", pct);
+}
+
+// --- get station color ---
+export function getStationColor(station) {
+  var colors = {
+    weapons: "#ffaa22",
+    engine: "#22aaff",
+    helm: "#cc66ff",
+    medical: "#44dd66"
+  };
+  return colors[station] || "#8899aa";
+}
+
+// --- helper: find officer in roster by id ---
+function findOfficer(state, id) {
+  for (var i = 0; i < state.roster.length; i++) {
+    if (state.roster[i].id === id) return state.roster[i];
+  }
+  return null;
+}

--- a/js/crewScreen.js
+++ b/js/crewScreen.js
@@ -1,0 +1,330 @@
+// crewScreen.js — crew management UI overlay (shown between waves alongside upgrades)
+import {
+  getStations, getAssigned, assignOfficer, unassignStation,
+  getBonusLabel, getStationColor
+} from "./crew.js";
+
+var root = null;
+var stationEls = {};
+var rosterEl = null;
+var currentState = null;
+var onCloseCallback = null;
+var selectedOfficerId = null;
+
+// --- create crew screen DOM (called once) ---
+export function createCrewScreen() {
+  root = document.createElement("div");
+  root.id = "crew-screen";
+  root.style.cssText = [
+    "position: fixed",
+    "top: 0", "left: 0",
+    "width: 100%", "height: 100%",
+    "display: none",
+    "flex-direction: column",
+    "align-items: center",
+    "justify-content: center",
+    "background: rgba(5, 5, 15, 0.92)",
+    "z-index: 91",
+    "font-family: monospace",
+    "user-select: none",
+    "overflow-y: auto"
+  ].join(";");
+
+  // title
+  var title = document.createElement("div");
+  title.textContent = "CREW ROSTER";
+  title.style.cssText = [
+    "font-size: 36px",
+    "font-weight: bold",
+    "color: #44ccff",
+    "margin-bottom: 4px",
+    "margin-top: 20px",
+    "text-shadow: 0 0 15px rgba(60,180,255,0.4)"
+  ].join(";");
+  root.appendChild(title);
+
+  var subtitle = document.createElement("div");
+  subtitle.textContent = "Click an officer, then click a station to assign";
+  subtitle.style.cssText = "font-size:13px;color:#667788;margin-bottom:16px";
+  root.appendChild(subtitle);
+
+  // stations row
+  var stationsRow = document.createElement("div");
+  stationsRow.style.cssText = [
+    "display: flex",
+    "flex-wrap: wrap",
+    "justify-content: center",
+    "gap: 12px",
+    "margin-bottom: 20px",
+    "max-width: 800px",
+    "width: 90%"
+  ].join(";");
+  root.appendChild(stationsRow);
+
+  var stations = getStations();
+  for (var s = 0; s < stations.length; s++) {
+    var stationKey = stations[s];
+    var stationPanel = buildStationPanel(stationKey);
+    stationsRow.appendChild(stationPanel.el);
+    stationEls[stationKey] = stationPanel;
+  }
+
+  // roster section
+  var rosterTitle = document.createElement("div");
+  rosterTitle.textContent = "AVAILABLE OFFICERS";
+  rosterTitle.style.cssText = [
+    "font-size: 16px",
+    "font-weight: bold",
+    "color: #8899aa",
+    "margin-bottom: 8px"
+  ].join(";");
+  root.appendChild(rosterTitle);
+
+  rosterEl = document.createElement("div");
+  rosterEl.style.cssText = [
+    "display: flex",
+    "flex-wrap: wrap",
+    "justify-content: center",
+    "gap: 8px",
+    "max-width: 800px",
+    "width: 90%",
+    "min-height: 60px",
+    "margin-bottom: 16px"
+  ].join(";");
+  root.appendChild(rosterEl);
+
+  // continue button
+  var btn = document.createElement("button");
+  btn.textContent = "CONTINUE";
+  btn.style.cssText = [
+    "font-family: monospace",
+    "font-size: 20px",
+    "padding: 14px 48px",
+    "margin-top: 10px",
+    "margin-bottom: 20px",
+    "background: rgba(40, 80, 60, 0.8)",
+    "color: #44dd66",
+    "border: 1px solid rgba(60, 140, 90, 0.6)",
+    "border-radius: 6px",
+    "cursor: pointer",
+    "pointer-events: auto",
+    "text-shadow: 0 0 10px rgba(60,200,90,0.3)"
+  ].join(";");
+  btn.addEventListener("click", function () {
+    hideCrewScreen();
+    if (onCloseCallback) onCloseCallback();
+  });
+  root.appendChild(btn);
+
+  document.body.appendChild(root);
+}
+
+// --- build a station panel ---
+function buildStationPanel(stationKey) {
+  var color = getStationColor(stationKey);
+  var el = document.createElement("div");
+  el.style.cssText = [
+    "background: rgba(15, 20, 35, 0.8)",
+    "border: 1px solid " + color + "44",
+    "border-radius: 8px",
+    "padding: 12px",
+    "width: 170px",
+    "min-height: 130px",
+    "cursor: pointer",
+    "transition: border-color 0.2s"
+  ].join(";");
+
+  var label = document.createElement("div");
+  label.textContent = stationKey.charAt(0).toUpperCase() + stationKey.slice(1);
+  label.style.cssText = [
+    "font-size: 15px",
+    "font-weight: bold",
+    "color: " + color,
+    "margin-bottom: 8px",
+    "text-align: center"
+  ].join(";");
+  el.appendChild(label);
+
+  var assignedEl = document.createElement("div");
+  assignedEl.style.cssText = [
+    "font-size: 13px",
+    "color: #8899aa",
+    "text-align: center",
+    "min-height: 50px",
+    "display: flex",
+    "flex-direction: column",
+    "align-items: center",
+    "justify-content: center"
+  ].join(";");
+  assignedEl.textContent = "— Empty —";
+  el.appendChild(assignedEl);
+
+  var bonusEl = document.createElement("div");
+  bonusEl.style.cssText = "font-size:11px;color:#667788;text-align:center;margin-top:6px";
+  el.appendChild(bonusEl);
+
+  // click station: assign selected officer or unassign
+  el.addEventListener("click", function () {
+    if (!currentState) return;
+    if (selectedOfficerId) {
+      assignOfficer(currentState, selectedOfficerId, stationKey);
+      selectedOfficerId = null;
+      refreshUI();
+    } else {
+      // clicking an occupied station unassigns
+      var assigned = getAssigned(currentState, stationKey);
+      if (assigned) {
+        unassignStation(currentState, stationKey);
+        refreshUI();
+      }
+    }
+  });
+
+  return { el: el, assignedEl: assignedEl, bonusEl: bonusEl, color: color };
+}
+
+// --- build a roster officer card ---
+function buildOfficerCard(officer, isAssigned) {
+  var specColor = getStationColor(officer.specialty);
+  var el = document.createElement("div");
+  el.style.cssText = [
+    "background: rgba(20, 25, 40, 0.7)",
+    "border: 1px solid " + (isAssigned ? "#334455" : specColor + "66"),
+    "border-radius: 6px",
+    "padding: 8px 12px",
+    "cursor: " + (isAssigned ? "default" : "pointer"),
+    "opacity: " + (isAssigned ? "0.4" : "1"),
+    "min-width: 140px",
+    "text-align: center",
+    "transition: border-color 0.2s, background 0.2s"
+  ].join(";");
+
+  // portrait + name row
+  var nameRow = document.createElement("div");
+  nameRow.style.cssText = "font-size:14px;color:#ccddee;margin-bottom:4px";
+  nameRow.textContent = officer.portrait + " " + officer.name;
+  el.appendChild(nameRow);
+
+  // specialty + rank
+  var infoRow = document.createElement("div");
+  infoRow.style.cssText = "font-size:11px;color:" + specColor;
+  var stars = "";
+  for (var r = 0; r < officer.rank; r++) stars += "\u2605";
+  infoRow.textContent = officer.specialty.charAt(0).toUpperCase() + officer.specialty.slice(1) + " " + stars;
+  el.appendChild(infoRow);
+
+  if (!isAssigned) {
+    el.addEventListener("click", function (e) {
+      e.stopPropagation();
+      if (selectedOfficerId === officer.id) {
+        selectedOfficerId = null;
+      } else {
+        selectedOfficerId = officer.id;
+      }
+      refreshUI();
+    });
+  }
+
+  // highlight if selected
+  if (selectedOfficerId === officer.id) {
+    el.style.borderColor = "#44ccff";
+    el.style.background = "rgba(30, 60, 80, 0.6)";
+  }
+
+  return el;
+}
+
+// --- refresh all UI elements ---
+function refreshUI() {
+  if (!currentState || !root) return;
+
+  var stations = getStations();
+  // get set of assigned officer ids
+  var assignedIds = {};
+  for (var s = 0; s < stations.length; s++) {
+    var stKey = stations[s];
+    var assigned = getAssigned(currentState, stKey);
+    if (assigned) assignedIds[assigned.id] = stKey;
+  }
+
+  // update station panels
+  for (var s = 0; s < stations.length; s++) {
+    var stKey = stations[s];
+    var panel = stationEls[stKey];
+    var assigned = getAssigned(currentState, stKey);
+
+    if (assigned) {
+      var stars = "";
+      for (var r = 0; r < assigned.rank; r++) stars += "\u2605";
+      panel.assignedEl.innerHTML = "";
+      var portrait = document.createElement("div");
+      portrait.style.cssText = "font-size:24px;margin-bottom:2px";
+      portrait.textContent = assigned.portrait;
+      panel.assignedEl.appendChild(portrait);
+
+      var nameEl = document.createElement("div");
+      nameEl.style.cssText = "font-size:12px;color:#ccddee";
+      nameEl.textContent = assigned.name;
+      panel.assignedEl.appendChild(nameEl);
+
+      var rankEl = document.createElement("div");
+      rankEl.style.cssText = "font-size:11px;color:" + getStationColor(assigned.specialty);
+      rankEl.textContent = assigned.specialty.charAt(0).toUpperCase() + assigned.specialty.slice(1) + " " + stars;
+      panel.assignedEl.appendChild(rankEl);
+
+      panel.bonusEl.textContent = getBonusLabel(assigned, stKey);
+      panel.bonusEl.style.color = (assigned.specialty === stKey) ? panel.color : "#887766";
+      if (assigned.specialty !== stKey) {
+        panel.bonusEl.textContent += " (mismatch)";
+      }
+    } else {
+      panel.assignedEl.innerHTML = "";
+      panel.assignedEl.textContent = selectedOfficerId ? "Click to assign" : "\u2014 Empty \u2014";
+      panel.assignedEl.style.color = selectedOfficerId ? "#44ccff" : "#556677";
+      panel.bonusEl.textContent = "";
+    }
+
+    // highlight station if officer is selected
+    if (selectedOfficerId) {
+      panel.el.style.borderColor = panel.color + "88";
+    } else {
+      panel.el.style.borderColor = panel.color + "44";
+    }
+  }
+
+  // rebuild roster cards
+  rosterEl.innerHTML = "";
+  var roster = currentState.roster;
+  if (roster.length === 0) {
+    var emptyMsg = document.createElement("div");
+    emptyMsg.textContent = "No officers yet — complete waves to recruit!";
+    emptyMsg.style.cssText = "font-size:13px;color:#556677;padding:16px";
+    rosterEl.appendChild(emptyMsg);
+    return;
+  }
+
+  for (var i = 0; i < roster.length; i++) {
+    var officer = roster[i];
+    var isAssigned = !!assignedIds[officer.id];
+    var card = buildOfficerCard(officer, isAssigned);
+    rosterEl.appendChild(card);
+  }
+}
+
+// --- show crew screen ---
+export function showCrewScreen(crewState, closeCb) {
+  if (!root) return;
+  currentState = crewState;
+  onCloseCallback = closeCb;
+  selectedOfficerId = null;
+  refreshUI();
+  root.style.display = "flex";
+}
+
+// --- hide crew screen ---
+export function hideCrewScreen() {
+  if (!root) return;
+  root.style.display = "none";
+  currentState = null;
+  selectedOfficerId = null;
+}


### PR DESCRIPTION
Closes #14

## Summary
- New `crew.js` module: officer data model, naval-themed procedural name generator, roster management, station assignment, and bonus multiplier logic
- New `crewScreen.js`: full crew management UI overlay with click-to-select officer → click-to-assign station workflow, shown between waves after upgrades
- Integrated into `main.js`: crew state, bonus application to game multipliers, officer recruitment on wave completion (50% chance, rank 1) and boss defeat (guaranteed, rank 2-3)

## Acceptance Criteria
- [x] Crew roster screen (accessible between waves)
- [x] 4 stations: Weapons, Engine, Helm, Medical
- [x] Officers have: name, portrait (procedural/emoji), specialty, rank (1-3)
- [x] Assigning officer to matching station: bonus (e.g., Weapons officer → +15% fire rate)
- [x] Officers gained as rewards (wave completion, boss defeat)
- [x] Max 4 active officers (one per station)
- [x] Visual: crew management panel with drag-drop or click-assign