### PR TITLE
Phase 6B: Tech tree

### DIFF
--- a/js/techScreen.js
+++ b/js/techScreen.js
@@ -1,0 +1,366 @@
+// techScreen.js — tech tree visual UI with node-graph and connecting lines
+import {
+  getTechBranches, isUnlocked, canUnlock, unlockNode,
+  getNextIndex, getTechBonuses, loadTechState
+} from "./techTree.js";
+
+var root = null;
+var currentState = null;
+var currentSalvage = null;     // { get, spend } callbacks
+var onCloseCallback = null;
+var branchEls = {};            // branchKey -> { nodeEls: [...], lineEls: [...] }
+var salvageLabel = null;
+
+// --- create tech screen DOM (called once) ---
+export function createTechScreen() {
+  root = document.createElement("div");
+  root.id = "tech-screen";
+  root.style.cssText = [
+    "position: fixed",
+    "top: 0", "left: 0",
+    "width: 100%", "height: 100%",
+    "display: none",
+    "flex-direction: column",
+    "align-items: center",
+    "justify-content: flex-start",
+    "background: rgba(5, 5, 15, 0.94)",
+    "z-index: 92",
+    "font-family: monospace",
+    "user-select: none",
+    "overflow-y: auto",
+    "padding: 20px 0"
+  ].join(";");
+
+  // title
+  var title = document.createElement("div");
+  title.textContent = "TECH TREE";
+  title.style.cssText = [
+    "font-size: 36px",
+    "font-weight: bold",
+    "color: #ffcc44",
+    "margin-bottom: 4px",
+    "text-shadow: 0 0 15px rgba(255,200,60,0.4)"
+  ].join(";");
+  root.appendChild(title);
+
+  var subtitle = document.createElement("div");
+  subtitle.textContent = "Permanent upgrades — persists across runs";
+  subtitle.style.cssText = "font-size:13px;color:#667788;margin-bottom:8px";
+  root.appendChild(subtitle);
+
+  // salvage display
+  salvageLabel = document.createElement("div");
+  salvageLabel.style.cssText = [
+    "font-size: 18px",
+    "color: #ffcc44",
+    "margin-bottom: 16px"
+  ].join(";");
+  root.appendChild(salvageLabel);
+
+  // branches container
+  var branchesRow = document.createElement("div");
+  branchesRow.style.cssText = [
+    "display: flex",
+    "flex-wrap: wrap",
+    "justify-content: center",
+    "gap: 24px",
+    "max-width: 1000px",
+    "width: 95%",
+    "margin-bottom: 20px"
+  ].join(";");
+  root.appendChild(branchesRow);
+
+  // build each branch
+  var branches = getTechBranches();
+  var branchKeys = Object.keys(branches);
+  for (var b = 0; b < branchKeys.length; b++) {
+    var bKey = branchKeys[b];
+    var branch = branches[bKey];
+    var branchPanel = buildBranchPanel(bKey, branch);
+    branchesRow.appendChild(branchPanel.el);
+    branchEls[bKey] = branchPanel;
+  }
+
+  // continue button
+  var btn = document.createElement("button");
+  btn.textContent = "CONTINUE";
+  btn.style.cssText = [
+    "font-family: monospace",
+    "font-size: 20px",
+    "padding: 14px 48px",
+    "margin-top: 10px",
+    "margin-bottom: 20px",
+    "background: rgba(40, 80, 60, 0.8)",
+    "color: #44dd66",
+    "border: 1px solid rgba(60, 140, 90, 0.6)",
+    "border-radius: 6px",
+    "cursor: pointer",
+    "pointer-events: auto",
+    "text-shadow: 0 0 10px rgba(60,200,90,0.3)"
+  ].join(";");
+  btn.addEventListener("click", function () {
+    hideTechScreen();
+    if (onCloseCallback) onCloseCallback();
+  });
+  root.appendChild(btn);
+
+  document.body.appendChild(root);
+}
+
+// --- build a branch panel with node-graph ---
+function buildBranchPanel(branchKey, branch) {
+  var el = document.createElement("div");
+  el.style.cssText = [
+    "background: rgba(15, 20, 35, 0.8)",
+    "border: 1px solid " + branch.color + "33",
+    "border-radius: 10px",
+    "padding: 16px",
+    "width: 280px",
+    "display: flex",
+    "flex-direction: column",
+    "align-items: center"
+  ].join(";");
+
+  // branch heading
+  var heading = document.createElement("div");
+  heading.textContent = branch.label;
+  heading.style.cssText = [
+    "font-size: 18px",
+    "font-weight: bold",
+    "color: " + branch.color,
+    "margin-bottom: 12px",
+    "text-align: center",
+    "text-shadow: 0 0 10px " + branch.color + "44"
+  ].join(";");
+  el.appendChild(heading);
+
+  // node graph container (relative for line positioning)
+  var graphWrap = document.createElement("div");
+  graphWrap.style.cssText = [
+    "position: relative",
+    "width: 100%",
+    "display: flex",
+    "flex-direction: column",
+    "align-items: center",
+    "gap: 0"
+  ].join(";");
+  el.appendChild(graphWrap);
+
+  var nodeEls = [];
+  var lineEls = [];
+
+  for (var n = 0; n < branch.nodes.length; n++) {
+    // connecting line (before nodes 1-4)
+    if (n > 0) {
+      var line = document.createElement("div");
+      line.style.cssText = [
+        "width: 3px",
+        "height: 20px",
+        "background: " + branch.color + "33",
+        "margin: 0 auto"
+      ].join(";");
+      graphWrap.appendChild(line);
+      lineEls.push(line);
+    }
+
+    var nodeEl = buildNodeEl(branchKey, n, branch);
+    graphWrap.appendChild(nodeEl.el);
+    nodeEls.push(nodeEl);
+  }
+
+  return { el: el, nodeEls: nodeEls, lineEls: lineEls, color: branch.color };
+}
+
+// --- build a single tech node element ---
+function buildNodeEl(branchKey, nodeIndex, branch) {
+  var node = branch.nodes[nodeIndex];
+
+  var el = document.createElement("div");
+  el.style.cssText = [
+    "width: 240px",
+    "padding: 10px 12px",
+    "border-radius: 8px",
+    "background: rgba(20, 25, 40, 0.7)",
+    "border: 2px solid " + branch.color + "33",
+    "cursor: pointer",
+    "pointer-events: auto",
+    "transition: border-color 0.2s, background 0.2s"
+  ].join(";");
+
+  // top row: icon + name
+  var topRow = document.createElement("div");
+  topRow.style.cssText = "display:flex;align-items:center;gap:8px;margin-bottom:4px";
+
+  var icon = document.createElement("div");
+  icon.style.cssText = [
+    "width: 28px",
+    "height: 28px",
+    "border-radius: 50%",
+    "background: " + branch.color + "22",
+    "border: 2px solid " + branch.color + "55",
+    "display: flex",
+    "align-items: center",
+    "justify-content: center",
+    "font-size: 14px",
+    "color: " + branch.color,
+    "font-weight: bold",
+    "flex-shrink: 0"
+  ].join(";");
+  icon.textContent = String(nodeIndex + 1);
+  topRow.appendChild(icon);
+
+  var nameEl = document.createElement("div");
+  nameEl.style.cssText = "font-size:14px;font-weight:bold;color:#ccddee";
+  nameEl.textContent = node.label;
+  topRow.appendChild(nameEl);
+
+  el.appendChild(topRow);
+
+  // description
+  var descEl = document.createElement("div");
+  descEl.style.cssText = "font-size:11px;color:#8899aa;margin-bottom:6px;margin-left:36px";
+  descEl.textContent = node.desc;
+  el.appendChild(descEl);
+
+  // cost row
+  var costRow = document.createElement("div");
+  costRow.style.cssText = "display:flex;justify-content:space-between;align-items:center;margin-left:36px";
+
+  var costLabel = document.createElement("span");
+  costLabel.style.cssText = "font-size:12px;color:#667788";
+  costRow.appendChild(costLabel);
+
+  var statusLabel = document.createElement("span");
+  statusLabel.style.cssText = "font-size:11px;font-weight:bold";
+  costRow.appendChild(statusLabel);
+
+  el.appendChild(costRow);
+
+  // click handler
+  el.addEventListener("click", function () {
+    if (!currentState || !currentSalvage) return;
+    var salvage = currentSalvage.get();
+    if (canUnlock(currentState, branchKey, nodeIndex, salvage)) {
+      var cost = unlockNode(currentState, branchKey, nodeIndex, salvage);
+      if (cost > 0) {
+        currentSalvage.spend(cost);
+        refreshUI();
+      }
+    }
+  });
+
+  return {
+    el: el,
+    icon: icon,
+    nameEl: nameEl,
+    costLabel: costLabel,
+    statusLabel: statusLabel,
+    branchKey: branchKey,
+    nodeIndex: nodeIndex,
+    color: branch.color
+  };
+}
+
+// --- refresh all UI ---
+function refreshUI() {
+  if (!currentState || !root) return;
+
+  var salvage = currentSalvage ? currentSalvage.get() : 0;
+  salvageLabel.textContent = "Salvage: " + salvage;
+
+  var branches = getTechBranches();
+  var branchKeys = Object.keys(branches);
+
+  for (var b = 0; b < branchKeys.length; b++) {
+    var bKey = branchKeys[b];
+    var branch = branches[bKey];
+    var bPanel = branchEls[bKey];
+    if (!bPanel) continue;
+
+    var nextIdx = getNextIndex(currentState, bKey);
+
+    for (var n = 0; n < branch.nodes.length; n++) {
+      var node = branch.nodes[n];
+      var nEl = bPanel.nodeEls[n];
+      var unlocked = isUnlocked(currentState, node.key);
+      var isNext = (n === nextIdx);
+      var affordable = isNext && salvage >= node.cost;
+
+      if (unlocked) {
+        // unlocked: bright
+        nEl.el.style.borderColor = bPanel.color;
+        nEl.el.style.background = bPanel.color + "22";
+        nEl.icon.style.background = bPanel.color;
+        nEl.icon.style.borderColor = bPanel.color;
+        nEl.icon.style.color = "#000";
+        nEl.nameEl.style.color = "#ffffff";
+        nEl.costLabel.textContent = "";
+        nEl.statusLabel.textContent = "UNLOCKED";
+        nEl.statusLabel.style.color = bPanel.color;
+        nEl.el.style.cursor = "default";
+      } else if (isNext) {
+        // next available
+        nEl.el.style.borderColor = affordable ? bPanel.color + "aa" : bPanel.color + "44";
+        nEl.el.style.background = affordable ? "rgba(30, 40, 60, 0.8)" : "rgba(20, 25, 40, 0.7)";
+        nEl.icon.style.background = bPanel.color + "33";
+        nEl.icon.style.borderColor = bPanel.color + "88";
+        nEl.icon.style.color = bPanel.color;
+        nEl.nameEl.style.color = "#aabbcc";
+        nEl.costLabel.textContent = node.cost + " salvage";
+        nEl.costLabel.style.color = affordable ? "#aabbcc" : "#556677";
+        nEl.statusLabel.textContent = affordable ? "UNLOCK" : "LOCKED";
+        nEl.statusLabel.style.color = affordable ? "#44dd66" : "#556677";
+        nEl.el.style.cursor = affordable ? "pointer" : "default";
+      } else {
+        // locked (prerequisite not met)
+        nEl.el.style.borderColor = "#222233";
+        nEl.el.style.background = "rgba(15, 18, 30, 0.5)";
+        nEl.icon.style.background = "#1a1a2a";
+        nEl.icon.style.borderColor = "#333344";
+        nEl.icon.style.color = "#444455";
+        nEl.nameEl.style.color = "#445566";
+        nEl.costLabel.textContent = node.cost + " salvage";
+        nEl.costLabel.style.color = "#334455";
+        nEl.statusLabel.textContent = "LOCKED";
+        nEl.statusLabel.style.color = "#334455";
+        nEl.el.style.cursor = "default";
+      }
+    }
+
+    // update connecting lines
+    for (var l = 0; l < bPanel.lineEls.length; l++) {
+      var prevUnlocked = isUnlocked(currentState, branch.nodes[l].key);
+      var nextUnlocked = isUnlocked(currentState, branch.nodes[l + 1].key);
+      if (prevUnlocked && nextUnlocked) {
+        bPanel.lineEls[l].style.background = bPanel.color;
+      } else if (prevUnlocked) {
+        bPanel.lineEls[l].style.background = bPanel.color + "66";
+      } else {
+        bPanel.lineEls[l].style.background = bPanel.color + "22";
+      }
+    }
+  }
+}
+
+// --- show tech screen ---
+export function showTechScreen(techState, salvageCallbacks, closeCb) {
+  if (!root) return;
+  currentState = techState;
+  currentSalvage = salvageCallbacks;
+  onCloseCallback = closeCb;
+  refreshUI();
+  root.style.display = "flex";
+}
+
+// --- hide tech screen ---
+export function hideTechScreen() {
+  if (!root) return;
+  root.style.display = "none";
+  currentState = null;
+  currentSalvage = null;
+}
+
+// --- is tech screen visible? ---
+export function isTechScreenVisible() {
+  return root && root.style.display !== "none";
+}

--- a/js/techTree.js
+++ b/js/techTree.js
@@ -1,0 +1,169 @@
+// techTree.js — tech tree config, persistent state, and bonus logic
+
+var STORAGE_KEY = "ocean-outlaws-tech";
+
+// --- tech tree definition ---
+// 3 branches, each with 5 linear nodes
+var TECH_BRANCHES = {
+  offense: {
+    label: "Offense",
+    color: "#ff4444",
+    nodes: [
+      { key: "adv_cannons",   label: "Adv. Cannons",    desc: "+15% damage",             cost: 40,  stat: "damage",      bonus: 0.15 },
+      { key: "crit_chance",   label: "Critical Hit",     desc: "10% crit chance (2x dmg)", cost: 80,  stat: "critChance",  bonus: 0.10 },
+      { key: "rapid_load",    label: "Rapid Load",       desc: "+20% fire rate",          cost: 120, stat: "fireRate",    bonus: 0.20 },
+      { key: "splash_rounds", label: "Splash Rounds",    desc: "Splash damage on hit",    cost: 180, stat: "splash",      bonus: 1    },
+      { key: "deadly_aim",    label: "Deadly Aim",       desc: "+25% damage, +5% crit",   cost: 260, stat: "deadlyAim",   bonus: 1    }
+    ]
+  },
+  defense: {
+    label: "Defense",
+    color: "#4488ff",
+    nodes: [
+      { key: "hull_plating",  label: "Hull Plating",     desc: "+10% max HP",             cost: 40,  stat: "maxHp",        bonus: 0.10 },
+      { key: "shield_gen",    label: "Shield Gen",       desc: "+10 armor rating",        cost: 80,  stat: "armor",        bonus: 0.10 },
+      { key: "auto_repair",   label: "Auto-Repair",      desc: "Regen 1 HP/sec",          cost: 120, stat: "autoRepair",   bonus: 1    },
+      { key: "dmg_reflect",   label: "Dmg. Reflect",     desc: "Reflect 15% damage",      cost: 180, stat: "dmgReflect",   bonus: 0.15 },
+      { key: "fortress",      label: "Fortress",         desc: "+20% HP, +5 armor",       cost: 260, stat: "fortress",     bonus: 1    }
+    ]
+  },
+  utility: {
+    label: "Utility",
+    color: "#44dd66",
+    nodes: [
+      { key: "wide_radar",    label: "Wide Radar",       desc: "+30% radar range",        cost: 40,  stat: "enemyRange",   bonus: 0.30 },
+      { key: "mag_pickup",    label: "Mag. Pickup",      desc: "+40% pickup range",       cost: 80,  stat: "pickupRange",  bonus: 0.40 },
+      { key: "salvage_bonus", label: "Salvage Bonus",    desc: "+25% salvage earned",     cost: 120, stat: "salvageBonus", bonus: 0.25 },
+      { key: "swift_nav",     label: "Swift Nav",        desc: "+15% max speed",          cost: 180, stat: "maxSpeed",     bonus: 0.15 },
+      { key: "master_loot",   label: "Master Loot",      desc: "+50% salvage, +20% range", cost: 260, stat: "masterLoot",  bonus: 1    }
+    ]
+  }
+};
+
+// --- load persistent tech state from localStorage ---
+export function loadTechState() {
+  var state = { unlocked: {} };
+  try {
+    var raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      var parsed = JSON.parse(raw);
+      if (parsed && parsed.unlocked) {
+        state.unlocked = parsed.unlocked;
+      }
+    }
+  } catch (e) {
+    // ignore corrupt data
+  }
+  return state;
+}
+
+// --- save persistent tech state ---
+export function saveTechState(state) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch (e) {
+    // storage full or unavailable
+  }
+}
+
+// --- get the branch definitions ---
+export function getTechBranches() {
+  return TECH_BRANCHES;
+}
+
+// --- is a node unlocked? ---
+export function isUnlocked(state, nodeKey) {
+  return !!state.unlocked[nodeKey];
+}
+
+// --- can a node be purchased? (previous node must be unlocked, or first in branch) ---
+export function canUnlock(state, branchKey, nodeIndex, salvage) {
+  var branch = TECH_BRANCHES[branchKey];
+  if (!branch) return false;
+  var node = branch.nodes[nodeIndex];
+  if (!node) return false;
+  if (state.unlocked[node.key]) return false;
+
+  // check prerequisite: previous node must be unlocked (or index 0)
+  if (nodeIndex > 0) {
+    var prevKey = branch.nodes[nodeIndex - 1].key;
+    if (!state.unlocked[prevKey]) return false;
+  }
+
+  return salvage >= node.cost;
+}
+
+// --- purchase a tech node; returns cost spent or 0 on failure ---
+export function unlockNode(state, branchKey, nodeIndex, salvage) {
+  if (!canUnlock(state, branchKey, nodeIndex, salvage)) return 0;
+  var node = TECH_BRANCHES[branchKey].nodes[nodeIndex];
+  state.unlocked[node.key] = true;
+  saveTechState(state);
+  return node.cost;
+}
+
+// --- get the next unlockable index in a branch (-1 if all done) ---
+export function getNextIndex(state, branchKey) {
+  var branch = TECH_BRANCHES[branchKey];
+  if (!branch) return -1;
+  for (var i = 0; i < branch.nodes.length; i++) {
+    if (!state.unlocked[branch.nodes[i].key]) return i;
+  }
+  return -1;
+}
+
+// --- compute all tech bonuses from unlocked nodes ---
+export function getTechBonuses(state) {
+  var bonuses = {
+    damage: 0,
+    critChance: 0,
+    fireRate: 0,
+    splash: false,
+    maxHp: 0,
+    armor: 0,
+    autoRepair: false,
+    dmgReflect: 0,
+    enemyRange: 0,
+    pickupRange: 0,
+    salvageBonus: 0,
+    maxSpeed: 0
+  };
+
+  var branches = Object.keys(TECH_BRANCHES);
+  for (var b = 0; b < branches.length; b++) {
+    var nodes = TECH_BRANCHES[branches[b]].nodes;
+    for (var n = 0; n < nodes.length; n++) {
+      var node = nodes[n];
+      if (!state.unlocked[node.key]) continue;
+
+      if (node.stat === "damage") bonuses.damage += node.bonus;
+      else if (node.stat === "critChance") bonuses.critChance += node.bonus;
+      else if (node.stat === "fireRate") bonuses.fireRate += node.bonus;
+      else if (node.stat === "splash") bonuses.splash = true;
+      else if (node.stat === "deadlyAim") { bonuses.damage += 0.25; bonuses.critChance += 0.05; }
+      else if (node.stat === "maxHp") bonuses.maxHp += node.bonus;
+      else if (node.stat === "armor") bonuses.armor += node.bonus;
+      else if (node.stat === "autoRepair") bonuses.autoRepair = true;
+      else if (node.stat === "dmgReflect") bonuses.dmgReflect += node.bonus;
+      else if (node.stat === "fortress") { bonuses.maxHp += 0.20; bonuses.armor += 0.05; }
+      else if (node.stat === "enemyRange") bonuses.enemyRange += node.bonus;
+      else if (node.stat === "pickupRange") bonuses.pickupRange += node.bonus;
+      else if (node.stat === "salvageBonus") bonuses.salvageBonus += node.bonus;
+      else if (node.stat === "maxSpeed") bonuses.maxSpeed += node.bonus;
+      else if (node.stat === "masterLoot") { bonuses.salvageBonus += 0.50; bonuses.pickupRange += 0.20; }
+    }
+  }
+
+  return bonuses;
+}
+
+// --- count total unlocked nodes ---
+export function getTotalUnlocked(state) {
+  return Object.keys(state.unlocked).length;
+}
+
+// --- reset tech tree (for testing/debug) ---
+export function resetTechState(state) {
+  state.unlocked = {};
+  saveTechState(state);
+}


### PR DESCRIPTION
Closes #15

## Acceptance Criteria
- [x] Tech tree screen with 3 branches: Offense, Defense, Utility
- [x] Each branch has 5 nodes (linear unlock path)
- [x] Research costs salvage points (same currency as upgrades)
- [x] Offense: advanced weapons, crit chance, splash damage
- [x] Defense: shields, auto-repair, damage reflection
- [x] Utility: larger radar, faster pickup collection, bonus salvage
- [x] Tech persists across runs (permanent progression)
- [x] Visual: node-graph with connecting lines, locked/unlocked states

## Changes
- `js/techTree.js` — Tech tree data config (3 branches × 5 nodes), localStorage persistence, bonus computation
- `js/techScreen.js` — Node-graph UI with connecting lines, locked/unlocked/affordable states
- `js/main.js` — Integration: tech screen shown before map, tech bonuses applied to multipliers (damage, fire rate, HP, armor, radar, pickup range, speed, salvage bonus), auto-repair, crit chance, splash, damage reflection