### PR TITLE
Control scheme overhaul — click-to-move, auto-aim, auto-fire

### DIFF
--- a/js/hud.js
+++ b/js/hud.js
@@ -1,12 +1,11 @@
-// hud.js — speed indicator, compass, ammo counter, fuel gauge, parts count, wave info, ability, overlays
-
+// hud.js — HUD elements, on-screen weapon selector, ability button, overlays
 var container = null;
 var speedBar = null;
 var speedLabel = null;
 var compassLabel = null;
 var ammoLabel = null;
 var weaponPanel = null;
-var weaponItems = [];    // {el, label, nameEl} per weapon slot
+var weaponItems = [];
 var fuelBarBg = null;
 var fuelBar = null;
 var fuelLabel = null;
@@ -16,14 +15,13 @@ var hpBarBg = null;
 var hpBar = null;
 var hpLabel = null;
 var waveLabel = null;
-var abilityContainer = null;
-var abilityLabel = null;
+var abilityBtn = null;
 var abilityBarBg = null;
 var abilityBar = null;
 var abilityStatus = null;
 var weatherLabel = null;
-
-// overlay elements
+var onWeaponSwitchCallback = null;
+var onAbilityCallback = null;
 var banner = null;
 var bannerTimer = 0;
 var overlay = null;
@@ -32,91 +30,80 @@ var overlaySubtext = null;
 var overlayBtn = null;
 var onRestartCallback = null;
 
+var BTN_BASE = [
+  "font-family:monospace", "font-size:13px", "padding:6px 10px",
+  "border-radius:4px", "cursor:pointer", "pointer-events:auto",
+  "user-select:none", "text-align:center", "min-width:80px"
+].join(";");
+
 export function createHUD() {
   container = document.createElement("div");
   container.style.cssText = [
-    "position: fixed",
-    "bottom: 20px",
-    "left: 20px",
-    "pointer-events: none",
-    "font-family: monospace",
-    "color: #8899aa",
-    "font-size: 13px",
-    "user-select: none",
-    "z-index: 10"
+    "position:fixed", "bottom:20px", "left:20px", "pointer-events:none",
+    "font-family:monospace", "color:#8899aa", "font-size:13px",
+    "user-select:none", "z-index:10"
   ].join(";");
 
-  // speed bar background
   var barBg = document.createElement("div");
   barBg.style.cssText = [
-    "width: 120px",
-    "height: 8px",
-    "background: rgba(20, 30, 50, 0.7)",
-    "border: 1px solid rgba(80, 100, 130, 0.4)",
-    "border-radius: 4px",
-    "overflow: hidden",
-    "margin-bottom: 6px"
+    "width:120px", "height:8px", "background:rgba(20,30,50,0.7)",
+    "border:1px solid rgba(80,100,130,0.4)", "border-radius:4px",
+    "overflow:hidden", "margin-bottom:6px"
   ].join(";");
-
   speedBar = document.createElement("div");
   speedBar.style.cssText = [
-    "width: 0%",
-    "height: 100%",
-    "background: #4477aa",
-    "border-radius: 3px",
-    "transition: width 0.1s"
+    "width:0%", "height:100%", "background:#4477aa",
+    "border-radius:3px", "transition:width 0.1s"
   ].join(";");
   barBg.appendChild(speedBar);
   container.appendChild(barBg);
 
-  // speed text
   speedLabel = document.createElement("div");
   speedLabel.textContent = "0 kn";
   speedLabel.style.marginBottom = "4px";
   container.appendChild(speedLabel);
 
-  // compass heading
   compassLabel = document.createElement("div");
   compassLabel.textContent = "N";
   compassLabel.style.fontSize = "12px";
   compassLabel.style.color = "#667788";
   container.appendChild(compassLabel);
 
-  // weapon selector panel
   weaponPanel = document.createElement("div");
-  weaponPanel.style.marginTop = "8px";
+  weaponPanel.style.cssText = "margin-top:8px;display:flex;flex-direction:column;gap:3px;";
   var weaponDefs = [
-    { name: "Turret", shortcut: "1", color: "#ffcc44" },
-    { name: "Missile", shortcut: "2", color: "#ff6644" },
-    { name: "Torpedo", shortcut: "3", color: "#44aaff" }
+    { name: "Turret", color: "#ffcc44" },
+    { name: "Missile", color: "#ff6644" },
+    { name: "Torpedo", color: "#44aaff" }
   ];
   weaponItems = [];
   for (var w = 0; w < weaponDefs.length; w++) {
     var row = document.createElement("div");
     row.style.cssText = [
-      "display: flex",
-      "align-items: center",
-      "gap: 6px",
-      "padding: 2px 4px",
-      "margin-bottom: 2px",
-      "border-radius: 3px",
-      "font-size: 12px"
+      BTN_BASE, "display:flex", "align-items:center", "gap:6px",
+      "background:rgba(20,30,50,0.7)", "border:1px solid transparent",
+      "color:" + weaponDefs[w].color
     ].join(";");
+    row.dataset.weaponIndex = String(w);
+    row.addEventListener("click", (function (idx) {
+      return function (e) {
+        e.stopPropagation();
+        if (onWeaponSwitchCallback) onWeaponSwitchCallback(idx);
+      };
+    })(w));
     var nameEl = document.createElement("span");
-    nameEl.textContent = weaponDefs[w].shortcut + " " + weaponDefs[w].name;
-    nameEl.style.color = weaponDefs[w].color;
-    nameEl.style.minWidth = "72px";
+    nameEl.textContent = weaponDefs[w].name;
+    nameEl.style.minWidth = "60px";
     row.appendChild(nameEl);
     var label = document.createElement("span");
     label.textContent = "--";
     label.style.color = "#8899aa";
     row.appendChild(label);
     weaponPanel.appendChild(row);
-    weaponItems.push({ el: row, label: label, nameEl: nameEl, color: weaponDefs[w].color });
+    weaponItems.push({ el: row, label: label, nameEl: nameEl, color: weaponDefs[w].color, index: w });
   }
   container.appendChild(weaponPanel);
 
-  // total ammo counter
   ammoLabel = document.createElement("div");
   ammoLabel.textContent = "AMMO: --";
   ammoLabel.style.marginTop = "4px";
@@ -124,37 +111,26 @@ export function createHUD() {
   ammoLabel.style.color = "#8899aa";
   container.appendChild(ammoLabel);
 
-  // fuel gauge
   fuelLabel = document.createElement("div");
   fuelLabel.textContent = "FUEL";
   fuelLabel.style.marginTop = "8px";
   fuelLabel.style.fontSize = "12px";
   fuelLabel.style.color = "#667788";
   container.appendChild(fuelLabel);
-
   fuelBarBg = document.createElement("div");
   fuelBarBg.style.cssText = [
-    "width: 120px",
-    "height: 8px",
-    "background: rgba(20, 30, 50, 0.7)",
-    "border: 1px solid rgba(80, 100, 130, 0.4)",
-    "border-radius: 4px",
-    "overflow: hidden",
-    "margin-top: 3px"
+    "width:120px", "height:8px", "background:rgba(20,30,50,0.7)",
+    "border:1px solid rgba(80,100,130,0.4)", "border-radius:4px",
+    "overflow:hidden", "margin-top:3px"
   ].join(";");
-
   fuelBar = document.createElement("div");
   fuelBar.style.cssText = [
-    "width: 100%",
-    "height: 100%",
-    "background: #2288cc",
-    "border-radius: 3px",
-    "transition: width 0.2s"
+    "width:100%", "height:100%", "background:#2288cc",
+    "border-radius:3px", "transition:width 0.2s"
   ].join(";");
   fuelBarBg.appendChild(fuelBar);
   container.appendChild(fuelBarBg);
 
-  // parts count
   partsLabel = document.createElement("div");
   partsLabel.textContent = "PARTS: 0";
   partsLabel.style.marginTop = "6px";
@@ -162,7 +138,6 @@ export function createHUD() {
   partsLabel.style.color = "#8899aa";
   container.appendChild(partsLabel);
 
-  // salvage count
   salvageLabel = document.createElement("div");
   salvageLabel.textContent = "SALVAGE: 0";
   salvageLabel.style.marginTop = "4px";
@@ -170,37 +145,26 @@ export function createHUD() {
   salvageLabel.style.color = "#ffcc44";
   container.appendChild(salvageLabel);
 
-  // player HP bar
   hpLabel = document.createElement("div");
   hpLabel.textContent = "HP";
   hpLabel.style.marginTop = "8px";
   hpLabel.style.fontSize = "12px";
   hpLabel.style.color = "#667788";
   container.appendChild(hpLabel);
-
   hpBarBg = document.createElement("div");
   hpBarBg.style.cssText = [
-    "width: 120px",
-    "height: 8px",
-    "background: rgba(20, 30, 50, 0.7)",
-    "border: 1px solid rgba(80, 100, 130, 0.4)",
-    "border-radius: 4px",
-    "overflow: hidden",
-    "margin-top: 3px"
+    "width:120px", "height:8px", "background:rgba(20,30,50,0.7)",
+    "border:1px solid rgba(80,100,130,0.4)", "border-radius:4px",
+    "overflow:hidden", "margin-top:3px"
   ].join(";");
-
   hpBar = document.createElement("div");
   hpBar.style.cssText = [
-    "width: 100%",
-    "height: 100%",
-    "background: #44aa66",
-    "border-radius: 3px",
-    "transition: width 0.2s"
+    "width:100%", "height:100%", "background:#44aa66",
+    "border-radius:3px", "transition:width 0.2s"
   ].join(";");
   hpBarBg.appendChild(hpBar);
   container.appendChild(hpBarBg);
 
-  // wave indicator
   waveLabel = document.createElement("div");
   waveLabel.textContent = "WAVE 1";
   waveLabel.style.marginTop = "10px";
@@ -209,141 +173,97 @@ export function createHUD() {
   waveLabel.style.fontWeight = "bold";
   container.appendChild(waveLabel);
 
-  // ability indicator
-  abilityContainer = document.createElement("div");
+  var abilityContainer = document.createElement("div");
   abilityContainer.style.marginTop = "10px";
-
-  abilityLabel = document.createElement("div");
-  abilityLabel.textContent = "[Q] Ability";
-  abilityLabel.style.fontSize = "12px";
-  abilityLabel.style.color = "#667788";
-  abilityLabel.style.marginBottom = "3px";
-  abilityContainer.appendChild(abilityLabel);
-
+  abilityBtn = document.createElement("div");
+  abilityBtn.style.cssText = [
+    BTN_BASE, "background:rgba(20,30,50,0.7)",
+    "border:1px solid rgba(80,100,130,0.5)",
+    "color:#cc66ff", "margin-bottom:3px"
+  ].join(";");
+  abilityBtn.textContent = "Ability";
+  abilityBtn.addEventListener("click", function (e) {
+    e.stopPropagation();
+    if (onAbilityCallback) onAbilityCallback();
+  });
+  abilityContainer.appendChild(abilityBtn);
   abilityBarBg = document.createElement("div");
   abilityBarBg.style.cssText = [
-    "width: 120px",
-    "height: 10px",
-    "background: rgba(20, 30, 50, 0.7)",
-    "border: 1px solid rgba(80, 100, 130, 0.4)",
-    "border-radius: 4px",
-    "overflow: hidden"
+    "width:120px", "height:10px", "background:rgba(20,30,50,0.7)",
+    "border:1px solid rgba(80,100,130,0.4)", "border-radius:4px",
+    "overflow:hidden"
   ].join(";");
-
   abilityBar = document.createElement("div");
   abilityBar.style.cssText = [
-    "width: 100%",
-    "height: 100%",
-    "background: #cc66ff",
-    "border-radius: 3px",
-    "transition: width 0.1s"
+    "width:100%", "height:100%", "background:#cc66ff",
+    "border-radius:3px", "transition:width 0.1s"
   ].join(";");
   abilityBarBg.appendChild(abilityBar);
   abilityContainer.appendChild(abilityBarBg);
-
   abilityStatus = document.createElement("div");
   abilityStatus.textContent = "READY";
   abilityStatus.style.fontSize = "11px";
   abilityStatus.style.color = "#cc66ff";
   abilityStatus.style.marginTop = "2px";
   abilityContainer.appendChild(abilityStatus);
-
   container.appendChild(abilityContainer);
 
-  // weather indicator
   weatherLabel = document.createElement("div");
   weatherLabel.textContent = "CALM";
   weatherLabel.style.marginTop = "10px";
   weatherLabel.style.fontSize = "12px";
   weatherLabel.style.color = "#667788";
   container.appendChild(weatherLabel);
-
   document.body.appendChild(container);
 
-  // --- wave announcement banner (centered, fades out) ---
   banner = document.createElement("div");
   banner.style.cssText = [
-    "position: fixed",
-    "top: 25%",
-    "left: 50%",
-    "transform: translate(-50%, -50%)",
-    "font-family: monospace",
-    "font-size: 32px",
-    "font-weight: bold",
-    "color: #ffcc44",
-    "text-shadow: 0 0 20px rgba(255,200,60,0.6)",
-    "pointer-events: none",
-    "user-select: none",
-    "z-index: 20",
-    "opacity: 0",
-    "transition: opacity 0.3s"
+    "position:fixed", "top:25%", "left:50%",
+    "transform:translate(-50%,-50%)", "font-family:monospace",
+    "font-size:32px", "font-weight:bold", "color:#ffcc44",
+    "text-shadow:0 0 20px rgba(255,200,60,0.6)", "pointer-events:none",
+    "user-select:none", "z-index:20", "opacity:0", "transition:opacity 0.3s"
   ].join(";");
   banner.textContent = "";
   document.body.appendChild(banner);
 
-  // --- game over / victory overlay ---
   overlay = document.createElement("div");
   overlay.style.cssText = [
-    "position: fixed",
-    "top: 0",
-    "left: 0",
-    "width: 100%",
-    "height: 100%",
-    "display: none",
-    "flex-direction: column",
-    "align-items: center",
-    "justify-content: center",
-    "background: rgba(5, 5, 15, 0.85)",
-    "z-index: 100",
-    "font-family: monospace",
-    "user-select: none"
+    "position:fixed", "top:0", "left:0", "width:100%", "height:100%",
+    "display:none", "flex-direction:column", "align-items:center",
+    "justify-content:center", "background:rgba(5,5,15,0.85)",
+    "z-index:100", "font-family:monospace", "user-select:none"
   ].join(";");
-
   overlayTitle = document.createElement("div");
   overlayTitle.style.cssText = [
-    "font-size: 48px",
-    "font-weight: bold",
-    "color: #cc4444",
-    "margin-bottom: 16px"
+    "font-size:48px", "font-weight:bold", "color:#cc4444", "margin-bottom:16px"
   ].join(";");
   overlay.appendChild(overlayTitle);
-
   overlaySubtext = document.createElement("div");
   overlaySubtext.style.cssText = [
-    "font-size: 20px",
-    "color: #8899aa",
-    "margin-bottom: 32px"
+    "font-size:20px", "color:#8899aa", "margin-bottom:32px"
   ].join(";");
   overlay.appendChild(overlaySubtext);
-
   overlayBtn = document.createElement("button");
   overlayBtn.textContent = "RESTART";
   overlayBtn.style.cssText = [
-    "font-family: monospace",
-    "font-size: 18px",
-    "padding: 12px 36px",
-    "background: rgba(40, 60, 90, 0.8)",
-    "color: #8899aa",
-    "border: 1px solid rgba(80, 100, 130, 0.5)",
-    "border-radius: 6px",
-    "cursor: pointer",
-    "pointer-events: auto"
+    "font-family:monospace", "font-size:18px", "padding:12px 36px",
+    "background:rgba(40,60,90,0.8)", "color:#8899aa",
+    "border:1px solid rgba(80,100,130,0.5)", "border-radius:6px",
+    "cursor:pointer", "pointer-events:auto"
   ].join(";");
   overlayBtn.addEventListener("click", function () {
     hideOverlay();
     if (onRestartCallback) onRestartCallback();
   });
   overlay.appendChild(overlayBtn);
-
   document.body.appendChild(overlay);
 }
 
-// --- set restart callback ---
-export function setRestartCallback(cb) {
-  onRestartCallback = cb;
-}
+export function setWeaponSwitchCallback(cb) { onWeaponSwitchCallback = cb; }
+export function setAbilityCallback(cb) { onAbilityCallback = cb; }
+export function setRestartCallback(cb) { onRestartCallback = cb; }
 
-// --- show wave announcement banner ---
 export function showBanner(text, duration) {
   if (!banner) return;
   banner.textContent = text;
@@ -351,7 +271,6 @@ export function showBanner(text, duration) {
   bannerTimer = duration || 3;
 }
 
-// --- update banner fade ---
 function updateBanner(dt) {
   if (bannerTimer <= 0) return;
   bannerTimer -= dt;
@@ -363,7 +282,6 @@ function updateBanner(dt) {
   }
 }
 
-// --- show game over overlay ---
 export function showGameOver(waveReached) {
   if (!overlay) return;
   overlayTitle.textContent = "GAME OVER";
@@ -372,7 +290,6 @@ export function showGameOver(waveReached) {
   overlay.style.display = "flex";
 }
 
-// --- show victory overlay ---
 export function showVictory(waveReached) {
   if (!overlay) return;
   overlayTitle.textContent = "VICTORY";
@@ -381,7 +298,6 @@ export function showVictory(waveReached) {
   overlay.style.display = "flex";
 }
 
-// --- hide overlay ---
 export function hideOverlay() {
   if (!overlay) return;
   overlay.style.display = "none";
@@ -389,24 +305,20 @@ export function hideOverlay() {
 
 export function updateHUD(speedRatio, displaySpeed, heading, ammo, maxAmmo, hp, maxHp, fuel, maxFuel, parts, wave, waveState, dt, salvage, weaponInfo, abilityInfo, weatherText) {
   if (!container) return;
-
   var pct = Math.min(1, speedRatio) * 100;
   speedBar.style.width = pct + "%";
   speedLabel.textContent = displaySpeed.toFixed(1) + " kn";
-
-  // heading to compass direction
   var deg = ((heading * 180 / Math.PI) % 360 + 360) % 360;
   var dirs = ["N", "NE", "E", "SE", "S", "SW", "W", "NW"];
   var idx = Math.round(deg / 45) % 8;
   compassLabel.textContent = dirs[idx] + " " + Math.round(deg) + "\u00B0";
 
-  // weapon panel
   if (weaponInfo && weaponItems.length > 0) {
     var ammoCosts = weaponInfo.ammoCosts;
     for (var w = 0; w < weaponItems.length; w++) {
       var item = weaponItems[w];
       var isActive = w === weaponInfo.activeIndex;
-      item.el.style.background = isActive ? "rgba(40, 60, 90, 0.6)" : "transparent";
+      item.el.style.background = isActive ? "rgba(40,60,90,0.6)" : "rgba(20,30,50,0.7)";
       item.el.style.border = isActive ? "1px solid " + item.color : "1px solid transparent";
       var cost = ammoCosts[w];
       var canAfford = ammo >= cost;
@@ -415,14 +327,10 @@ export function updateHUD(speedRatio, displaySpeed, heading, ammo, maxAmmo, hp, 
       item.nameEl.style.opacity = isActive ? "1" : "0.5";
     }
   }
-
-  // ammo counter
   if (ammo !== undefined) {
     ammoLabel.textContent = "AMMO: " + ammo + " / " + maxAmmo;
     ammoLabel.style.color = ammo <= 5 ? "#cc6644" : ammo === 0 ? "#cc2222" : "#8899aa";
   }
-
-  // fuel gauge
   if (fuel !== undefined && fuelBar) {
     var fuelPct = Math.max(0, fuel / maxFuel) * 100;
     fuelBar.style.width = fuelPct + "%";
@@ -430,19 +338,13 @@ export function updateHUD(speedRatio, displaySpeed, heading, ammo, maxAmmo, hp, 
     fuelLabel.textContent = "FUEL: " + Math.round(fuel) + "%";
     fuelLabel.style.color = fuelPct > 15 ? "#667788" : "#cc4444";
   }
-
-  // parts count
   if (parts !== undefined && partsLabel) {
     partsLabel.textContent = "PARTS: " + parts;
     partsLabel.style.color = parts > 0 ? "#44dd66" : "#8899aa";
   }
-
-  // salvage count
   if (salvage !== undefined && salvageLabel) {
     salvageLabel.textContent = "SALVAGE: " + salvage;
   }
-
-  // player HP
   if (hp !== undefined && hpBar) {
     var hpPct = Math.max(0, hp / maxHp) * 100;
     hpBar.style.width = hpPct + "%";
@@ -450,8 +352,6 @@ export function updateHUD(speedRatio, displaySpeed, heading, ammo, maxAmmo, hp, 
     hpLabel.textContent = "HP: " + hp + " / " + maxHp;
     hpLabel.style.color = hpPct > 25 ? "#667788" : "#cc4444";
   }
-
-  // wave indicator
   if (wave !== undefined && waveLabel) {
     if (waveState === "SPAWNING" || waveState === "ACTIVE") {
       waveLabel.textContent = "WAVE " + wave;
@@ -467,39 +367,35 @@ export function updateHUD(speedRatio, displaySpeed, heading, ammo, maxAmmo, hp, 
       waveLabel.style.color = "#8899aa";
     }
   }
-
-  // ability indicator
-  if (abilityInfo && abilityContainer) {
-    abilityLabel.textContent = "[Q] " + abilityInfo.name;
-    abilityLabel.style.color = abilityInfo.color || "#667788";
-
+  if (abilityInfo && abilityBtn) {
+    abilityBtn.textContent = abilityInfo.name;
+    abilityBtn.style.color = abilityInfo.color || "#cc66ff";
     if (abilityInfo.active) {
       var activePct = Math.max(0, abilityInfo.activeTimer / abilityInfo.duration) * 100;
       abilityBar.style.width = activePct + "%";
       abilityBar.style.background = abilityInfo.color || "#cc66ff";
       abilityStatus.textContent = "ACTIVE";
       abilityStatus.style.color = abilityInfo.color || "#cc66ff";
+      abilityBtn.style.borderColor = abilityInfo.color || "#cc66ff";
     } else if (abilityInfo.cooldownTimer > 0) {
       var cdPct = (1 - abilityInfo.cooldownTimer / abilityInfo.cooldown) * 100;
       abilityBar.style.width = cdPct + "%";
       abilityBar.style.background = "#556677";
       abilityStatus.textContent = Math.ceil(abilityInfo.cooldownTimer) + "s";
       abilityStatus.style.color = "#667788";
+      abilityBtn.style.borderColor = "rgba(80,100,130,0.5)";
     } else {
       abilityBar.style.width = "100%";
       abilityBar.style.background = abilityInfo.color || "#cc66ff";
       abilityStatus.textContent = "READY";
       abilityStatus.style.color = abilityInfo.color || "#cc66ff";
+      abilityBtn.style.borderColor = abilityInfo.color || "#cc66ff";
     }
   }
-
-  // weather indicator
   if (weatherText && weatherLabel) {
     weatherLabel.textContent = "WEATHER: " + weatherText;
     var wColors = { CALM: "#44aa66", ROUGH: "#ccaa44", STORM: "#cc4444" };
     weatherLabel.style.color = wColors[weatherText] || "#667788";
   }
-
-  // update banner
   updateBanner(dt || 0.016);
 }

--- a/js/input.js
+++ b/js/input.js
@@ -1,42 +1,11 @@
-// input.js — keyboard, mouse, and touch input handler
-
-var keys = {
-  forward: false,
-  backward: false,
-  left: false,
-  right: false
-};
+// input.js — click/tap input handler (no keyboard controls)
 
 var mouse = {
   x: 0,
   y: 0,
-  firePressed: false,
-  fireConsumed: false
+  clicked: false,
+  clickConsumed: false
 };
-
-var weaponSwitch = -1;  // -1 means no switch requested
-var abilityPressed = false;
-
-function onKeyDown(e) {
-  setKey(e.code, true);
-  // weapon switch: 1, 2, 3
-  if (e.code === "Digit1") weaponSwitch = 0;
-  if (e.code === "Digit2") weaponSwitch = 1;
-  if (e.code === "Digit3") weaponSwitch = 2;
-  // ability: Q
-  if (e.code === "KeyQ") abilityPressed = true;
-}
-
-function onKeyUp(e) {
-  setKey(e.code, false);
-}
-
-function setKey(code, down) {
-  if (code === "KeyW" || code === "ArrowUp")    keys.forward  = down;
-  if (code === "KeyS" || code === "ArrowDown")   keys.backward = down;
-  if (code === "KeyA" || code === "ArrowLeft")   keys.left     = down;
-  if (code === "KeyD" || code === "ArrowRight")  keys.right    = down;
-}
 
 function onMouseMove(e) {
   mouse.x = e.clientX;
@@ -45,8 +14,8 @@ function onMouseMove(e) {
 
 function onMouseDown(e) {
   if (e.button === 0) {
-    mouse.firePressed = true;
-    mouse.fireConsumed = false;
+    mouse.clicked = true;
+    mouse.clickConsumed = false;
   }
 }
 
@@ -54,8 +23,8 @@ function onTouchStart(e) {
   var touch = e.touches[0];
   mouse.x = touch.clientX;
   mouse.y = touch.clientY;
-  mouse.firePressed = true;
-  mouse.fireConsumed = false;
+  mouse.clicked = true;
+  mouse.clickConsumed = false;
 }
 
 function onTouchMove(e) {
@@ -65,8 +34,6 @@ function onTouchMove(e) {
 }
 
 export function initInput() {
-  window.addEventListener("keydown", onKeyDown);
-  window.addEventListener("keyup", onKeyUp);
   window.addEventListener("mousemove", onMouseMove);
   window.addEventListener("mousedown", onMouseDown);
   window.addEventListener("touchstart", onTouchStart, { passive: true });
@@ -74,26 +41,15 @@ export function initInput() {
 }
 
 export function getInput() {
-  return keys;
+  // return a static no-keys object for backward compat with updateShip signature
+  return { forward: false, backward: false, left: false, right: false };
 }
 
 export function getMouse() {
   return mouse;
 }
 
-export function consumeFire() {
-  mouse.firePressed = false;
-  mouse.fireConsumed = true;
-}
-
-export function consumeWeaponSwitch() {
-  var val = weaponSwitch;
-  weaponSwitch = -1;
-  return val;
-}
-
-export function consumeAbility() {
-  var val = abilityPressed;
-  abilityPressed = false;
-  return val;
+export function consumeClick() {
+  mouse.clicked = false;
+  mouse.clickConsumed = true;
 }

--- a/js/nav.js
+++ b/js/nav.js
@@ -1,11 +1,11 @@
-// nav.js — click/tap-to-move navigation + destination marker
+// nav.js — click-to-move navigation + destination marker + enemy click targeting
 import * as THREE from "three";
 import { setNavTarget } from "./ship.js";
 import { getWaveHeight } from "./ocean.js";
 
 var raycaster = new THREE.Raycaster();
 var pointer = new THREE.Vector2();
-var oceanPlane = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0); // y=0 plane
+var oceanPlane = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0);
 var intersectPoint = new THREE.Vector3();
 
 var marker = null;
@@ -14,7 +14,12 @@ var markerTargetX = 0;
 var markerTargetZ = 0;
 var navShipRef = null;
 var navCameraRef = null;
+var navEnemyMgrRef = null;
 var initialized = false;
+
+// combat target reticle (ring around targeted enemy)
+var reticle = null;
+var combatTarget = null;   // reference to targeted enemy object (or null)
 
 // --- build destination marker (pulsing ring on water) ---
 function buildMarker() {
@@ -49,6 +54,39 @@ function buildMarker() {
   return group;
 }
 
+// --- build combat target reticle (red pulsing ring) ---
+function buildReticle() {
+  var group = new THREE.Group();
+
+  var ringGeo = new THREE.RingGeometry(2.0, 2.4, 24);
+  var ringMat = new THREE.MeshBasicMaterial({
+    color: 0xff4444,
+    side: THREE.DoubleSide,
+    transparent: true,
+    opacity: 0.7,
+    depthWrite: false
+  });
+  var ring = new THREE.Mesh(ringGeo, ringMat);
+  ring.rotation.x = -Math.PI / 2;
+  group.add(ring);
+
+  var innerGeo = new THREE.RingGeometry(1.4, 1.6, 24);
+  var innerMat = new THREE.MeshBasicMaterial({
+    color: 0xff6666,
+    side: THREE.DoubleSide,
+    transparent: true,
+    opacity: 0.4,
+    depthWrite: false
+  });
+  var inner = new THREE.Mesh(innerGeo, innerMat);
+  inner.rotation.x = -Math.PI / 2;
+  inner.position.y = 0.05;
+  group.add(inner);
+
+  group.visible = false;
+  return group;
+}
+
 function projectToOcean(clientX, clientY, camera) {
   pointer.x = (clientX / window.innerWidth) * 2 - 1;
   pointer.y = -(clientY / window.innerHeight) * 2 + 1;
@@ -57,10 +95,33 @@ function projectToOcean(clientX, clientY, camera) {
   return raycaster.ray.intersectPlane(oceanPlane, intersectPoint);
 }
 
+// --- check if click hit an enemy (2D distance on XZ plane) ---
+var ENEMY_CLICK_RADIUS = 4.0;
+
+function findClickedEnemy(worldX, worldZ) {
+  if (!navEnemyMgrRef) return null;
+  var enemies = navEnemyMgrRef.enemies;
+  var best = null;
+  var bestDist = ENEMY_CLICK_RADIUS * ENEMY_CLICK_RADIUS;
+  for (var i = 0; i < enemies.length; i++) {
+    var e = enemies[i];
+    if (!e.alive) continue;
+    var dx = e.posX - worldX;
+    var dz = e.posZ - worldZ;
+    var distSq = dx * dx + dz * dz;
+    if (distSq < bestDist) {
+      bestDist = distSq;
+      best = e;
+    }
+  }
+  return best;
+}
+
 // --- init click/tap handler ---
-export function initNav(camera, ship, scene) {
+export function initNav(camera, ship, scene, enemyMgr) {
   navShipRef = ship;
   navCameraRef = camera;
+  navEnemyMgrRef = enemyMgr || null;
 
   if (initialized) return;
   initialized = true;
@@ -68,50 +129,91 @@ export function initNav(camera, ship, scene) {
   marker = buildMarker();
   scene.add(marker);
 
-  function handleNav(clientX, clientY) {
-    if (!navShipRef || !navCameraRef) return;
-    var hit = projectToOcean(clientX, clientY, navCameraRef);
-    if (hit) {
-      markerTargetX = intersectPoint.x;
-      markerTargetZ = intersectPoint.z;
-      markerActive = true;
-      marker.visible = true;
-      setNavTarget(navShipRef, intersectPoint.x, intersectPoint.z);
-    }
-  }
+  reticle = buildReticle();
+  scene.add(reticle);
 
   window.addEventListener("contextmenu", function (e) {
     e.preventDefault();
   });
-
-  window.addEventListener("mousedown", function (e) {
-    if (e.button !== 2) return;
-    if (e.target !== document.querySelector("canvas")) return;
-    handleNav(e.clientX, e.clientY);
-  });
-
-  window.addEventListener("touchstart", function (e) {
-    if (e.touches.length !== 1) return;
-    var touch = e.touches[0];
-    handleNav(touch.clientX, touch.clientY);
-  }, { passive: true });
 }
 
-// --- update marker position (bob on waves, pulse) ---
-export function updateNav(ship, elapsed) {
-  if (!marker) return;
+// --- process a click at screen coords; returns "nav" or "enemy" ---
+export function handleClick(clientX, clientY) {
+  if (!navShipRef || !navCameraRef) return null;
+  var hit = projectToOcean(clientX, clientY, navCameraRef);
+  if (!hit) return null;
 
-  if (!ship.navTarget) {
-    if (markerActive) {
-      markerActive = false;
-      marker.visible = false;
-    }
-    return;
+  var worldX = intersectPoint.x;
+  var worldZ = intersectPoint.z;
+
+  // check if clicked on an enemy first
+  var enemy = findClickedEnemy(worldX, worldZ);
+  if (enemy) {
+    combatTarget = enemy;
+    return "enemy";
   }
 
-  var waveY = getWaveHeight(markerTargetX, markerTargetZ, elapsed);
-  marker.position.set(markerTargetX, waveY + 0.3, markerTargetZ);
+  // clicked on water — set nav target (does NOT change combat target)
+  markerTargetX = worldX;
+  markerTargetZ = worldZ;
+  markerActive = true;
+  marker.visible = true;
+  setNavTarget(navShipRef, worldX, worldZ);
+  return "nav";
+}
 
-  var pulse = 1.0 + Math.sin(elapsed * 3) * 0.15;
-  marker.scale.set(pulse, 1, pulse);
+// --- get current combat target ---
+export function getCombatTarget() {
+  // clear dead targets
+  if (combatTarget && !combatTarget.alive) {
+    combatTarget = null;
+  }
+  return combatTarget;
+}
+
+// --- set combat target programmatically (for auto-acquire) ---
+export function setCombatTarget(enemy) {
+  combatTarget = enemy;
+}
+
+// --- clear combat target ---
+export function clearCombatTarget() {
+  combatTarget = null;
+}
+
+// --- update marker + reticle positions ---
+export function updateNav(ship, elapsed) {
+  // nav marker
+  if (marker) {
+    if (!ship.navTarget) {
+      if (markerActive) {
+        markerActive = false;
+        marker.visible = false;
+      }
+    } else {
+      var waveY = getWaveHeight(markerTargetX, markerTargetZ, elapsed);
+      marker.position.set(markerTargetX, waveY + 0.3, markerTargetZ);
+      var pulse = 1.0 + Math.sin(elapsed * 3) * 0.15;
+      marker.scale.set(pulse, 1, pulse);
+    }
+  }
+
+  // combat target reticle
+  if (reticle) {
+    if (combatTarget && combatTarget.alive) {
+      reticle.visible = true;
+      reticle.position.set(
+        combatTarget.posX,
+        combatTarget.mesh.position.y + 0.2,
+        combatTarget.posZ
+      );
+      var rPulse = 1.0 + Math.sin(elapsed * 4) * 0.1;
+      reticle.scale.set(rPulse, 1, rPulse);
+    } else {
+      reticle.visible = false;
+      if (combatTarget && !combatTarget.alive) {
+        combatTarget = null;
+      }
+    }
+  }
 }

--- a/js/upgrade.js
+++ b/js/upgrade.js
@@ -146,6 +146,32 @@ export function getMultipliers(state) {
   return mults;
 }
 
+// --- build combined multipliers from upgrades + crew + tech ---
+export function buildCombinedMults(upgradeState, crewBonuses, techBonuses) {
+  var mults = getMultipliers(upgradeState);
+  mults = Object.assign({}, mults);
+  if (crewBonuses) {
+    mults.fireRate = mults.fireRate * crewBonuses.fireRate;
+    mults.maxSpeed = mults.maxSpeed * crewBonuses.maxSpeed;
+    mults.turnRate = mults.turnRate * crewBonuses.turnRate;
+    mults.repair = mults.repair * crewBonuses.repair;
+  }
+  if (techBonuses) {
+    mults.damage += techBonuses.damage;
+    mults.fireRate += techBonuses.fireRate;
+    mults.maxHp += techBonuses.maxHp;
+    mults.armor += techBonuses.armor;
+    mults.enemyRange += techBonuses.enemyRange;
+    mults.pickupRange += techBonuses.pickupRange;
+    mults.maxSpeed += techBonuses.maxSpeed;
+    mults.critChance = techBonuses.critChance;
+    mults.splash = techBonuses.splash;
+    mults.autoRepair = techBonuses.autoRepair;
+    mults.dmgReflect = techBonuses.dmgReflect;
+  }
+  return mults;
+}
+
 // --- helper: find upgrade definition by key ---
 function findUpgrade(key) {
   var cats = Object.keys(UPGRADE_TREE);


### PR DESCRIPTION
Closes #35

## Summary
- Replaced all keyboard controls (WASD, Q, 1/2/3) with click-to-move navigation and on-screen UI buttons
- Added auto-targeting (nearest enemy in weapon range) and auto-fire combat system
- Added combat target reticle (red pulsing ring) and nav waypoint marker (blue pulsing ring)

## Acceptance Criteria
- [x] Click on water sets nav target — ship turns and moves toward click point
- [x] Ship auto-acquires nearest enemy within weapon range as target
- [x] Ship auto-fires at current target (respecting fire rate and ammo)
- [x] Click on enemy ship switches target to that ship
- [x] Clicking on water does NOT change combat target (only movement)
- [x] On-screen ability buttons replace keyboard ability activation
- [x] On-screen weapon selector replaces number key switching (1/2/3)
- [x] All legacy keyboard controls removed (WASD movement, Q ability, number key weapon switch)
- [x] Touch-friendly — all interactions work on mobile tap
- [x] Visual indicator showing current nav target (waypoint marker on water)
- [x] Visual indicator showing current combat target (highlight/reticle on enemy)

## Test plan
- [ ] Open game in browser, verify no keyboard controls work (WASD, Q, 1/2/3)
- [ ] Click on water — ship navigates to clicked point with blue waypoint marker
- [ ] Approach enemies — ship auto-acquires target with red reticle and fires
- [ ] Click on a specific enemy — combat target switches to clicked enemy
- [ ] Click on water while targeting enemy — nav changes but combat target persists
- [ ] Click on-screen weapon buttons to switch weapons
- [ ] Click on-screen ability button to activate ability
- [ ] Test on mobile/touch device — all taps register correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)