### PR TITLE
Bug fixes & balance pass — HP rounding, victory text, pickup cleanup, speed tuning

### DIFF
--- a/js/hud.js
+++ b/js/hud.js
@@ -287,6 +287,7 @@ export function showGameOver(waveReached) {
   overlayTitle.textContent = "GAME OVER";
   overlayTitle.style.color = "#cc4444";
   overlaySubtext.textContent = "You reached Wave " + waveReached;
+  overlayBtn.textContent = "RESTART";
   overlay.style.display = "flex";
 }
 
@@ -295,6 +296,7 @@ export function showVictory(waveReached) {
   overlayTitle.textContent = "VICTORY";
   overlayTitle.style.color = "#44dd66";
   overlaySubtext.textContent = "All " + waveReached + " waves survived!";
+  overlayBtn.textContent = "CONTINUE";
   overlay.style.display = "flex";
 }
 
@@ -349,7 +351,7 @@ export function updateHUD(speedRatio, displaySpeed, heading, ammo, maxAmmo, hp, 
     var hpPct = Math.max(0, hp / maxHp) * 100;
     hpBar.style.width = hpPct + "%";
     hpBar.style.background = hpPct > 50 ? "#44aa66" : hpPct > 25 ? "#aaaa44" : "#cc4444";
-    hpLabel.textContent = "HP: " + hp + " / " + maxHp;
+    hpLabel.textContent = "HP: " + Math.round(hp) + " / " + Math.round(maxHp);
     hpLabel.style.color = hpPct > 25 ? "#667788" : "#cc4444";
   }
   if (wave !== undefined && waveLabel) {

--- a/js/main.js
+++ b/js/main.js
@@ -9,7 +9,7 @@ import { createWeaponState, fireWeapon, updateWeapons, switchWeapon, getWeaponOr
 import { createEnemyManager, updateEnemies, getPlayerHp, setOnDeathCallback, setPlayerHp, setPlayerArmor, setPlayerMaxHp, resetEnemyManager } from "./enemy.js";
 import { initHealthBars, updateHealthBars } from "./health.js";
 import { createResources, consumeFuel, getFuelSpeedMult, resetResources } from "./resource.js";
-import { createPickupManager, spawnPickup, updatePickups } from "./pickup.js";
+import { createPickupManager, spawnPickup, updatePickups, clearPickups } from "./pickup.js";
 import { createWaveManager, updateWaveState, getWaveConfig, getWaveState, resetWaveManager } from "./wave.js";
 import { createUpgradeState, resetUpgrades, addSalvage, getMultipliers, buildCombinedMults } from "./upgrade.js";
 import { createUpgradeScreen, showUpgradeScreen, hideUpgradeScreen } from "./upgradeScreen.js";
@@ -344,6 +344,7 @@ function animate() {
         }
       } else if (event === "wave_complete") {
         showBanner("Wave " + waveMgr.wave + " cleared!", 2.5);
+        clearPickups(pickupMgr, scene);
         if (activeBoss) {
           removeBoss(activeBoss, scene);
           activeBoss = null;

--- a/js/pickup.js
+++ b/js/pickup.js
@@ -104,6 +104,14 @@ export function spawnPickup(manager, x, y, z, scene) {
   });
 }
 
+// --- clear all pickups (called on wave transition) ---
+export function clearPickups(manager, scene) {
+  for (var i = 0; i < manager.pickups.length; i++) {
+    scene.remove(manager.pickups[i].mesh);
+  }
+  manager.pickups = [];
+}
+
 // --- update pickups: bob, glow, check proximity, despawn ---
 export function updatePickups(manager, ship, resources, dt, elapsed, getWaveHeight, scene) {
   var alive = [];

--- a/js/ship.js
+++ b/js/ship.js
@@ -3,8 +3,8 @@ import * as THREE from "three";
 import { buildClassMesh } from "./shipModels.js";
 
 // --- default physics tuning (used as fallback) ---
-var DEFAULT_MAX_SPEED = 30;
-var DEFAULT_ACCEL = 12;
+var DEFAULT_MAX_SPEED = 16;
+var DEFAULT_ACCEL = 7;
 var DEFAULT_TURN_RATE = 2.2;
 var REVERSE_ACCEL_RATIO = 0.5;  // reverse accel as fraction of forward accel
 var DRAG = 4;

--- a/js/shipClass.js
+++ b/js/shipClass.js
@@ -9,9 +9,9 @@ var SHIP_CLASSES = {
     color: "#44aaff",
     stats: {
       hp: 8,
-      maxSpeed: 40,
+      maxSpeed: 22,
       turnRate: 2.8,
-      accel: 16,
+      accel: 9,
       armor: 0
     },
     ability: {
@@ -29,9 +29,9 @@ var SHIP_CLASSES = {
     color: "#ffcc44",
     stats: {
       hp: 10,
-      maxSpeed: 30,
+      maxSpeed: 16,
       turnRate: 2.2,
-      accel: 12,
+      accel: 7,
       armor: 0.1
     },
     ability: {
@@ -49,9 +49,9 @@ var SHIP_CLASSES = {
     color: "#44dd66",
     stats: {
       hp: 14,
-      maxSpeed: 20,
+      maxSpeed: 11,
       turnRate: 1.4,
-      accel: 8,
+      accel: 5,
       armor: 0.15
     },
     ability: {
@@ -69,9 +69,9 @@ var SHIP_CLASSES = {
     color: "#cc66ff",
     stats: {
       hp: 9,
-      maxSpeed: 25,
+      maxSpeed: 14,
       turnRate: 1.8,
-      accel: 10,
+      accel: 6,
       armor: 0.05
     },
     ability: {

--- a/js/upgrade.js
+++ b/js/upgrade.js
@@ -17,9 +17,9 @@ var UPGRADE_TREE = {
     label: "Propulsion",
     color: "#22aaff",
     upgrades: [
-      { key: "maxSpeed",   label: "+Max Speed",       stat: "maxSpeed",       perTier: [0.10, 0.15, 0.20], costs: [25, 50, 100] },
+      { key: "maxSpeed",   label: "+Max Speed",       stat: "maxSpeed",       perTier: [0.15, 0.20, 0.30], costs: [25, 50, 100] },
       { key: "turnRate",   label: "+Turn Rate",       stat: "turnRate",       perTier: [0.10, 0.15, 0.20], costs: [20, 45, 90]  },
-      { key: "accel",      label: "+Acceleration",    stat: "accel",          perTier: [0.10, 0.15, 0.25], costs: [20, 45, 90]  }
+      { key: "accel",      label: "+Acceleration",    stat: "accel",          perTier: [0.15, 0.20, 0.30], costs: [20, 45, 90]  }
     ]
   },
   defense: {


### PR DESCRIPTION
Closes #34

## Acceptance Criteria
- [x] HP display uses `Math.round()` — no more "1.99999" showing in HUD
- [x] Victory screen button says "Continue" instead of "Restart"
- [x] Uncollected pickup items are cleared/despawned when a new wave starts
- [x] Base ship speed reduced significantly (all classes ~55% of original)
- [x] Per-class speed values rebalanced relative to each other
- [x] Ship speed upgrade tiers rebalanced to account for lower base speed

## Changes
- **hud.js**: `Math.round(hp)` / `Math.round(maxHp)` in HP label; dynamic button text (`CONTINUE` on victory, `RESTART` on game over)
- **pickup.js**: New `clearPickups()` export to remove all active pickups from scene
- **main.js**: Call `clearPickups()` on `wave_complete` event
- **shipClass.js**: Destroyer 40→22, Cruiser 30→16, Carrier 20→11, Submarine 25→14; accel values reduced proportionally
- **ship.js**: Default fallback speed/accel aligned with cruiser (16/7)
- **upgrade.js**: maxSpeed tiers 10/15/20% → 15/20/30%; accel tiers 10/15/25% → 15/20/30%