### PR TITLE
Combat balance & autofire toggle — range, fire rate, keybindings

### DIFF
--- a/js/enemy.js
+++ b/js/enemy.js
@@ -4,11 +4,11 @@ import * as THREE from "three";
 // --- tuning ---
 var ENEMY_SPEED = 14;
 var ENEMY_TURN_SPEED = 1.8;
-var ENGAGE_DIST = 35;          // desired engagement distance
+var ENGAGE_DIST = 25;          // desired engagement distance
 var ARRIVE_TOLERANCE = 5;
-var FIRE_RANGE = 40;
-var FIRE_COOLDOWN = 2.0;       // seconds between enemy shots
-var ENEMY_PROJ_SPEED = 40;
+var FIRE_RANGE = 30;
+var FIRE_COOLDOWN = 1.5;       // seconds between enemy shots
+var ENEMY_PROJ_SPEED = 30;
 var ENEMY_PROJ_GRAVITY = 9.8;
 var FLOAT_OFFSET = 1.0;
 var BUOYANCY_LERP = 8;
@@ -405,7 +405,7 @@ function updateEnemyProjectiles(manager, ship, dt, scene) {
 
     // hit water
     var hitWater = p.mesh.position.y < 0.2;
-    var outOfRange = dist > 80;
+    var outOfRange = dist > 50;
 
     // hit player
     var hitPlayer = false;

--- a/js/hud.js
+++ b/js/hud.js
@@ -20,8 +20,10 @@ var abilityBarBg = null;
 var abilityBar = null;
 var abilityStatus = null;
 var weatherLabel = null;
+var autofireLabel = null;
 var onWeaponSwitchCallback = null;
 var onAbilityCallback = null;
+var onAutofireToggleCallback = null;
 var banner = null;
 var bannerTimer = 0;
 var overlay = null;
@@ -110,6 +112,19 @@ export function createHUD() {
   ammoLabel.style.fontSize = "13px";
   ammoLabel.style.color = "#8899aa";
   container.appendChild(ammoLabel);
+
+  autofireLabel = document.createElement("div");
+  autofireLabel.style.cssText = [
+    BTN_BASE, "margin-top:6px", "background:rgba(20,30,50,0.7)",
+    "border:1px solid rgba(80,100,130,0.5)", "color:#667788",
+    "font-size:12px"
+  ].join(";");
+  autofireLabel.textContent = "AUTOFIRE: OFF [F]";
+  autofireLabel.addEventListener("click", function (e) {
+    e.stopPropagation();
+    if (onAutofireToggleCallback) onAutofireToggleCallback();
+  });
+  container.appendChild(autofireLabel);
 
   fuelLabel = document.createElement("div");
   fuelLabel.textContent = "FUEL";
@@ -263,6 +278,7 @@ export function createHUD() {
 export function setWeaponSwitchCallback(cb) { onWeaponSwitchCallback = cb; }
 export function setAbilityCallback(cb) { onAbilityCallback = cb; }
 export function setRestartCallback(cb) { onRestartCallback = cb; }
+export function setAutofireToggleCallback(cb) { onAutofireToggleCallback = cb; }
 
 export function showBanner(text, duration) {
   if (!banner) return;
@@ -305,7 +321,7 @@ export function hideOverlay() {
   overlay.style.display = "none";
 }
 
-export function updateHUD(speedRatio, displaySpeed, heading, ammo, maxAmmo, hp, maxHp, fuel, maxFuel, parts, wave, waveState, dt, salvage, weaponInfo, abilityInfo, weatherText) {
+export function updateHUD(speedRatio, displaySpeed, heading, ammo, maxAmmo, hp, maxHp, fuel, maxFuel, parts, wave, waveState, dt, salvage, weaponInfo, abilityInfo, weatherText, autofireOn) {
   if (!container) return;
   var pct = Math.min(1, speedRatio) * 100;
   speedBar.style.width = pct + "%";
@@ -398,6 +414,17 @@ export function updateHUD(speedRatio, displaySpeed, heading, ammo, maxAmmo, hp, 
     weatherLabel.textContent = "WEATHER: " + weatherText;
     var wColors = { CALM: "#44aa66", ROUGH: "#ccaa44", STORM: "#cc4444" };
     weatherLabel.style.color = wColors[weatherText] || "#667788";
+  }
+  if (autofireLabel) {
+    if (autofireOn) {
+      autofireLabel.textContent = "AUTOFIRE: ON [F]";
+      autofireLabel.style.color = "#44dd66";
+      autofireLabel.style.borderColor = "#44dd66";
+    } else {
+      autofireLabel.textContent = "AUTOFIRE: OFF [F]";
+      autofireLabel.style.color = "#667788";
+      autofireLabel.style.borderColor = "rgba(80,100,130,0.5)";
+    }
   }
   updateBanner(dt || 0.016);
 }

--- a/js/input.js
+++ b/js/input.js
@@ -1,4 +1,4 @@
-// input.js — click/tap input handler (no keyboard controls)
+// input.js — click/tap + keyboard input handler
 
 var mouse = {
   x: 0,
@@ -6,6 +6,12 @@ var mouse = {
   clicked: false,
   clickConsumed: false
 };
+
+// keyboard action queue — consumed once per frame
+var keyActions = [];
+
+// autofire state
+var autofire = false;
 
 function onMouseMove(e) {
   mouse.x = e.clientX;
@@ -33,11 +39,34 @@ function onTouchMove(e) {
   mouse.y = touch.clientY;
 }
 
+function onKeyDown(e) {
+  var key = e.key;
+  if (key === " " || key === "f" || key === "F") {
+    e.preventDefault();
+    keyActions.push("toggleAutofire");
+  } else if (key === "1") {
+    keyActions.push("weapon0");
+  } else if (key === "2") {
+    keyActions.push("weapon1");
+  } else if (key === "3") {
+    keyActions.push("weapon2");
+  } else if (key === "q" || key === "Q") {
+    keyActions.push("weapon0");
+  } else if (key === "w" || key === "W") {
+    keyActions.push("weapon1");
+  } else if (key === "e" || key === "E") {
+    keyActions.push("weapon2");
+  } else if (key === "r" || key === "R" || key === "Shift") {
+    keyActions.push("ability");
+  }
+}
+
 export function initInput() {
   window.addEventListener("mousemove", onMouseMove);
   window.addEventListener("mousedown", onMouseDown);
   window.addEventListener("touchstart", onTouchStart, { passive: true });
   window.addEventListener("touchmove", onTouchMove, { passive: true });
+  window.addEventListener("keydown", onKeyDown);
 }
 
 export function getInput() {
@@ -52,4 +81,23 @@ export function getMouse() {
 export function consumeClick() {
   mouse.clicked = false;
   mouse.clickConsumed = true;
+}
+
+export function getKeyActions() {
+  var actions = keyActions;
+  keyActions = [];
+  return actions;
+}
+
+export function getAutofire() {
+  return autofire;
+}
+
+export function toggleAutofire() {
+  autofire = !autofire;
+  return autofire;
+}
+
+export function setAutofire(val) {
+  autofire = val;
 }

--- a/js/weapon.js
+++ b/js/weapon.js
@@ -6,21 +6,21 @@ import { damageBoss } from "./boss.js";
 
 var WEAPON_TYPES = {
   turret: {
-    name: "Turret", key: 0, fireRate: 0.25, damage: 1, projSpeed: 65,
+    name: "Turret", key: 0, fireRate: 1.0, damage: 1, projSpeed: 35,
     ammoCost: 1, color: 0xffcc44, trailColor: 0xffcc44, projRadius: 0.12,
-    gravity: 9.8, loft: 0.08, maxRange: 120, homing: false,
+    gravity: 9.8, loft: 0.08, maxRange: 40, homing: false,
     waterLevel: false, splashScale: 1.0
   },
   missile: {
-    name: "Missile", key: 1, fireRate: 1.2, damage: 3, projSpeed: 40,
+    name: "Missile", key: 1, fireRate: 2.5, damage: 3, projSpeed: 28,
     ammoCost: 3, color: 0xff6644, trailColor: 0xff8844, projRadius: 0.2,
-    gravity: 2.0, loft: 0.15, maxRange: 150, homing: true,
+    gravity: 2.0, loft: 0.15, maxRange: 50, homing: true,
     homingTurnRate: 1.8, waterLevel: false, splashScale: 2.0
   },
   torpedo: {
-    name: "Torpedo", key: 2, fireRate: 2.0, damage: 6, projSpeed: 25,
+    name: "Torpedo", key: 2, fireRate: 4.0, damage: 6, projSpeed: 18,
     ammoCost: 5, color: 0x44aaff, trailColor: 0x88ccff, projRadius: 0.25,
-    gravity: 0, loft: 0, maxRange: 100, homing: false,
+    gravity: 0, loft: 0, maxRange: 35, homing: false,
     waterLevel: true, splashScale: 3.5, wakeTrail: true
   }
 };


### PR DESCRIPTION
Closes #45

## Changes
- Reduced weapon ranges to screen-proportional distances (turret 40, missile 50, torpedo 35)
- Slowed fire rates for deliberate combat (turret 1/s, missile 0.4/s, torpedo 0.25/s)
- Reduced projectile speeds proportionally
- Rebalanced enemy weapons (range 30, cooldown 1.5s, proj speed 30)
- Added autofire toggle (default OFF) with spacebar/F keybinding
- Added HUD indicator for autofire ON/OFF state (clickable button)
- Click-to-fire when autofire is OFF; continuous fire when ON
- Added keyboard shortcuts: 1/2/3 and Q/W/E for weapon switching, R/Shift for ability
- On-screen buttons remain for touch/mobile users

## Acceptance Criteria
- [x] Weapon range reduced — all weapons engage at screen-proportional distances
- [x] Fire rate reduced — combat feels deliberate (turret ~1/s, missile ~0.3-0.5/s, torpedo ~0.2-0.25/s)
- [x] Autofire is toggleable (default OFF)
- [x] Keybinding to toggle autofire (spacebar or F)
- [x] HUD indicator shows autofire ON/OFF state
- [x] When autofire OFF, clicking enemy fires at target
- [x] Keyboard shortcuts for weapon switching (1/2/3 or Q/W/E)
- [x] Keyboard shortcut for special ability (R or Shift)
- [x] On-screen buttons still work for touch users
- [x] Enemy weapon range and fire rate also rebalanced to match
- [x] Balance feels right for the default camera zoom level