### PR TITLE
fix: terrain visibility — disable ocean depthWrite, raise terrain

### DIFF
--- a/js/ocean.js
+++ b/js/ocean.js
@@ -144,7 +144,7 @@ export function createOcean() {
     uniforms: uniforms,
     side: THREE.DoubleSide,
     transparent: false,
-    depthWrite: true
+    depthWrite: false
   });
 
   var mesh = new THREE.Mesh(geometry, material);

--- a/js/terrain.js
+++ b/js/terrain.js
@@ -314,11 +314,12 @@ function buildTerrainMesh(heightmap) {
 
   var material = new THREE.MeshLambertMaterial({
     vertexColors: true,
-    flatShading: true
+    flatShading: true,
+    side: THREE.DoubleSide
   });
 
   var mesh = new THREE.Mesh(geometry, material);
-  mesh.position.y = 2;  // raise terrain above max wave height
+  mesh.position.y = 4;  // raise terrain above max wave height
   mesh.renderOrder = 2; // render after ocean
   return mesh;
 }


### PR DESCRIPTION
Terrain was invisible because ocean's depthWrite:true was occluding the terrain mesh in the depth buffer.

**Changes:**
1. Ocean material: `depthWrite: false` — stops ocean from hiding terrain
2. Terrain mesh: `position.y = 4` — raised above max wave displacement  
3. Terrain material: `side: THREE.DoubleSide` — visible from all angles

Built by Claude Code 🤖

Fixes #53