### PR TITLE
Ammo & resource rework — passive regen + map spawns

### DIFF
--- a/js/crate.js
+++ b/js/crate.js
@@ -1,0 +1,232 @@
+// crate.js — periodic resource crates: spawn at random water positions
+import * as THREE from "three";
+import { addAmmo, addFuel, addParts } from "./resource.js";
+import { isLand } from "./terrain.js";
+
+// --- tuning ---
+var SPAWN_INTERVAL = 18;         // seconds between crate spawns
+var CRATE_LIFETIME = 45;         // seconds before despawn
+var COLLECT_RADIUS = 3.5;        // same as enemy drops
+var FLOAT_OFFSET = 0.8;
+var BOB_AMP = 0.3;
+var BOB_SPEED = 2.0;
+var SPIN_SPEED = 0.8;
+var GLOW_PULSE_SPEED = 3.0;
+var GLOW_PULSE_MIN = 0.5;
+var SPAWN_DIST_MIN = 30;         // min distance from player
+var SPAWN_DIST_MAX = 100;        // max distance from player
+var MAP_HALF = 200;
+var MAX_CRATES = 8;              // max concurrent crates on map
+
+// crate drop amounts (slightly less than port, more than enemy drops)
+var CRATE_AMMO = 12;
+var CRATE_FUEL = 20;
+var CRATE_PARTS = 1;
+
+// drop chances
+var CHANCE_AMMO = 0.45;
+var CHANCE_FUEL = 0.35;
+// remainder = parts
+
+// --- shared geometry ---
+var crateGeo = null;
+var barrelGeo = null;
+
+function ensureGeo() {
+  if (crateGeo) return;
+  crateGeo = new THREE.BoxGeometry(0.7, 0.7, 0.7);
+  barrelGeo = new THREE.CylinderGeometry(0.28, 0.32, 0.75, 8);
+}
+
+// --- colors ---
+var TYPE_COLORS = {
+  ammo: 0xffaa22,
+  fuel: 0x22aaff,
+  parts: 0x44dd66
+};
+
+var GLOW_COLORS = {
+  ammo: 0xffdd66,
+  fuel: 0x66ccff,
+  parts: 0x88ff99
+};
+
+// --- build crate mesh ---
+function buildCrateMesh(type) {
+  ensureGeo();
+  var group = new THREE.Group();
+
+  var color = TYPE_COLORS[type] || 0xffffff;
+  var mat = new THREE.MeshLambertMaterial({ color: color });
+
+  var mesh;
+  if (type === "fuel") {
+    mesh = new THREE.Mesh(barrelGeo, mat);
+  } else {
+    mesh = new THREE.Mesh(crateGeo, mat);
+  }
+  group.add(mesh);
+
+  // stripe to distinguish from enemy drops (white band)
+  var stripeGeo = new THREE.BoxGeometry(0.72, 0.1, 0.72);
+  var stripeMat = new THREE.MeshLambertMaterial({ color: 0xffffff });
+  var stripe = new THREE.Mesh(stripeGeo, stripeMat);
+  stripe.position.y = 0.15;
+  group.add(stripe);
+
+  // glow
+  var glowColor = GLOW_COLORS[type] || 0xffffff;
+  var light = new THREE.PointLight(glowColor, 1.2, 8);
+  light.position.set(0, 0.6, 0);
+  group.add(light);
+
+  group.userData.light = light;
+  return group;
+}
+
+// --- crate manager ---
+export function createCrateManager() {
+  return {
+    crates: [],
+    spawnTimer: SPAWN_INTERVAL * 0.5  // first crate spawns sooner
+  };
+}
+
+// --- find random water position for crate ---
+function findCrateSpawnPosition(ship, terrain) {
+  for (var attempt = 0; attempt < 30; attempt++) {
+    var angle = Math.random() * Math.PI * 2;
+    var dist = SPAWN_DIST_MIN + Math.random() * (SPAWN_DIST_MAX - SPAWN_DIST_MIN);
+    var x = ship.posX + Math.sin(angle) * dist;
+    var z = ship.posZ + Math.cos(angle) * dist;
+
+    // keep within map bounds
+    if (Math.abs(x) > MAP_HALF - 20 || Math.abs(z) > MAP_HALF - 20) continue;
+
+    // must be on water
+    if (terrain && isLand(terrain, x, z)) continue;
+
+    return { x: x, z: z };
+  }
+  return null;
+}
+
+// --- spawn a crate ---
+function spawnCrate(manager, ship, terrain, scene) {
+  if (manager.crates.length >= MAX_CRATES) return;
+
+  var pos = findCrateSpawnPosition(ship, terrain);
+  if (!pos) return;
+
+  var roll = Math.random();
+  var type;
+  if (roll < CHANCE_AMMO) {
+    type = "ammo";
+  } else if (roll < CHANCE_AMMO + CHANCE_FUEL) {
+    type = "fuel";
+  } else {
+    type = "parts";
+  }
+
+  var mesh = buildCrateMesh(type);
+  mesh.position.set(pos.x, FLOAT_OFFSET, pos.z);
+  scene.add(mesh);
+
+  manager.crates.push({
+    mesh: mesh,
+    type: type,
+    posX: pos.x,
+    posZ: pos.z,
+    age: 0
+  });
+}
+
+// --- clear all crates ---
+export function clearCrates(manager, scene) {
+  for (var i = 0; i < manager.crates.length; i++) {
+    scene.remove(manager.crates[i].mesh);
+  }
+  manager.crates = [];
+  manager.spawnTimer = SPAWN_INTERVAL * 0.5;
+}
+
+// --- update crates: spawn timer, bob, collect, despawn ---
+export function updateCrates(manager, ship, resources, terrain, dt, elapsed, getWaveHeight, scene) {
+  // tick spawn timer
+  manager.spawnTimer -= dt;
+  if (manager.spawnTimer <= 0) {
+    spawnCrate(manager, ship, terrain, scene);
+    manager.spawnTimer = SPAWN_INTERVAL;
+  }
+
+  var alive = [];
+
+  for (var i = 0; i < manager.crates.length; i++) {
+    var c = manager.crates[i];
+    c.age += dt;
+
+    // despawn old crates
+    if (c.age > CRATE_LIFETIME) {
+      scene.remove(c.mesh);
+      continue;
+    }
+
+    // proximity collection
+    var dx = ship.posX - c.posX;
+    var dz = ship.posZ - c.posZ;
+    var distSq = dx * dx + dz * dz;
+
+    if (distSq < COLLECT_RADIUS * COLLECT_RADIUS) {
+      collectCrate(c, resources);
+      scene.remove(c.mesh);
+      continue;
+    }
+
+    // bob on waves
+    var waveY = getWaveHeight(c.posX, c.posZ, elapsed);
+    var bob = Math.sin(elapsed * BOB_SPEED + c.posX * 0.5) * BOB_AMP;
+    c.mesh.position.y = waveY + FLOAT_OFFSET + bob;
+
+    // spin
+    c.mesh.rotation.y += SPIN_SPEED * dt;
+
+    // glow pulse
+    var light = c.mesh.userData.light;
+    if (light) {
+      var pulse = GLOW_PULSE_MIN + (1 - GLOW_PULSE_MIN) * (0.5 + 0.5 * Math.sin(elapsed * GLOW_PULSE_SPEED));
+      light.intensity = pulse * 1.2;
+    }
+
+    // fade near end of life
+    if (c.age > CRATE_LIFETIME - 5) {
+      var fade = (CRATE_LIFETIME - c.age) / 5;
+      c.mesh.traverse(function (child) {
+        if (child.isMesh && child.material) {
+          child.material.transparent = true;
+          child.material.opacity = fade;
+        }
+      });
+    }
+
+    alive.push(c);
+  }
+
+  manager.crates = alive;
+}
+
+// --- collect crate ---
+function collectCrate(crate, resources) {
+  if (crate.type === "ammo") {
+    addAmmo(resources, CRATE_AMMO);
+  } else if (crate.type === "fuel") {
+    addFuel(resources, CRATE_FUEL);
+  } else if (crate.type === "parts") {
+    addParts(resources, CRATE_PARTS);
+  }
+  console.log("[CRATE] Collected " + crate.type);
+}
+
+// --- get spawn interval for external tuning ---
+export function getCrateInterval() {
+  return SPAWN_INTERVAL;
+}

--- a/js/hud.js
+++ b/js/hud.js
@@ -20,6 +20,7 @@ var abilityBarBg = null;
 var abilityBar = null;
 var abilityStatus = null;
 var weatherLabel = null;
+var portLabel = null;
 var autofireLabel = null;
 var onWeaponSwitchCallback = null;
 var onAbilityCallback = null;
@@ -229,6 +230,13 @@ export function createHUD() {
   weatherLabel.style.fontSize = "12px";
   weatherLabel.style.color = "#667788";
   container.appendChild(weatherLabel);
+
+  portLabel = document.createElement("div");
+  portLabel.textContent = "";
+  portLabel.style.marginTop = "6px";
+  portLabel.style.fontSize = "12px";
+  portLabel.style.color = "#44ff88";
+  container.appendChild(portLabel);
   document.body.appendChild(container);
 
   banner = document.createElement("div");
@@ -321,7 +329,7 @@ export function hideOverlay() {
   overlay.style.display = "none";
 }
 
-export function updateHUD(speedRatio, displaySpeed, heading, ammo, maxAmmo, hp, maxHp, fuel, maxFuel, parts, wave, waveState, dt, salvage, weaponInfo, abilityInfo, weatherText, autofireOn) {
+export function updateHUD(speedRatio, displaySpeed, heading, ammo, maxAmmo, hp, maxHp, fuel, maxFuel, parts, wave, waveState, dt, salvage, weaponInfo, abilityInfo, weatherText, autofireOn, portInfo) {
   if (!container) return;
   var pct = Math.min(1, speedRatio) * 100;
   speedBar.style.width = pct + "%";
@@ -424,6 +432,19 @@ export function updateHUD(speedRatio, displaySpeed, heading, ammo, maxAmmo, hp, 
       autofireLabel.textContent = "AUTOFIRE: OFF [F]";
       autofireLabel.style.color = "#667788";
       autofireLabel.style.borderColor = "rgba(80,100,130,0.5)";
+    }
+  }
+  if (portLabel) {
+    if (portInfo && portInfo.dist < 50) {
+      if (portInfo.available) {
+        portLabel.textContent = "PORT: " + Math.round(portInfo.dist) + "m";
+        portLabel.style.color = "#44ff88";
+      } else {
+        portLabel.textContent = "PORT: " + Math.ceil(portInfo.cooldown) + "s";
+        portLabel.style.color = "#884422";
+      }
+    } else {
+      portLabel.textContent = "";
     }
   }
   updateBanner(dt || 0.016);

--- a/js/port.js
+++ b/js/port.js
@@ -1,0 +1,271 @@
+// port.js — supply ports: fixed resupply points on island coastlines
+import * as THREE from "three";
+import { addAmmo, addFuel } from "./resource.js";
+import { getTerrainHeight, isLand } from "./terrain.js";
+
+// --- tuning ---
+var PORT_COUNT = 3;              // ports per map
+var PORT_COLLECT_RADIUS = 8;     // proximity to trigger resupply
+var PORT_COOLDOWN = 45;          // seconds before port can be used again
+var PORT_AMMO_RESTOCK = 30;
+var PORT_FUEL_RESTOCK = 40;
+var PORT_HP_RESTOCK = 15;        // flat HP restored
+
+// coastline search: find cells near sea level
+var COAST_SEARCH_ATTEMPTS = 200;
+var COAST_HEIGHT_MIN = -0.05;    // just below sea level (water side)
+var COAST_HEIGHT_MAX = 0.15;     // just above sea level (beach)
+var MAP_HALF = 200;              // half of MAP_SIZE (400)
+var MIN_PORT_SPACING = 60;       // minimum distance between ports
+var MIN_CENTER_DIST = 40;        // keep ports away from spawn
+
+// --- find coastline positions ---
+function findCoastlinePositions(terrain) {
+  var positions = [];
+  for (var attempt = 0; attempt < COAST_SEARCH_ATTEMPTS && positions.length < PORT_COUNT; attempt++) {
+    // random position on map, avoiding edges
+    var x = (Math.random() - 0.5) * (MAP_HALF * 2 - 80);
+    var z = (Math.random() - 0.5) * (MAP_HALF * 2 - 80);
+
+    // check distance from center
+    var cdist = Math.sqrt(x * x + z * z);
+    if (cdist < MIN_CENTER_DIST) continue;
+
+    // sample terrain height — we want positions right at the coastline
+    var h = getTerrainHeight(terrain, x, z);
+    if (h < COAST_HEIGHT_MIN || h > COAST_HEIGHT_MAX) continue;
+
+    // ensure there's land nearby (within 10 units in some direction)
+    var hasLand = false;
+    for (var a = 0; a < 8; a++) {
+      var angle = a * Math.PI / 4;
+      var checkX = x + Math.cos(angle) * 8;
+      var checkZ = z + Math.sin(angle) * 8;
+      if (isLand(terrain, checkX, checkZ)) {
+        hasLand = true;
+        break;
+      }
+    }
+    if (!hasLand) continue;
+
+    // ensure there's water nearby (so ship can reach)
+    var hasWater = false;
+    for (var a = 0; a < 8; a++) {
+      var angle = a * Math.PI / 4;
+      var checkX = x + Math.cos(angle) * 8;
+      var checkZ = z + Math.sin(angle) * 8;
+      if (!isLand(terrain, checkX, checkZ)) {
+        hasWater = true;
+        break;
+      }
+    }
+    if (!hasWater) continue;
+
+    // check spacing from existing ports
+    var tooClose = false;
+    for (var j = 0; j < positions.length; j++) {
+      var dx = positions[j].x - x;
+      var dz = positions[j].z - z;
+      if (Math.sqrt(dx * dx + dz * dz) < MIN_PORT_SPACING) {
+        tooClose = true;
+        break;
+      }
+    }
+    if (tooClose) continue;
+
+    // nudge position slightly toward water for accessibility
+    var bestWaterAngle = 0;
+    var bestWaterH = 999;
+    for (var a = 0; a < 16; a++) {
+      var angle = a * Math.PI / 8;
+      var testH = getTerrainHeight(terrain, x + Math.cos(angle) * 6, z + Math.sin(angle) * 6);
+      if (testH < bestWaterH) {
+        bestWaterH = testH;
+        bestWaterAngle = angle;
+      }
+    }
+    // nudge 3 units toward the deepest water neighbor
+    x += Math.cos(bestWaterAngle) * 3;
+    z += Math.sin(bestWaterAngle) * 3;
+
+    positions.push({ x: x, z: z });
+  }
+  return positions;
+}
+
+// --- build dock mesh ---
+function buildPortMesh() {
+  var group = new THREE.Group();
+
+  // pier platform
+  var pierGeo = new THREE.BoxGeometry(3, 0.4, 6);
+  var pierMat = new THREE.MeshLambertMaterial({ color: 0x8b6914 });
+  var pier = new THREE.Mesh(pierGeo, pierMat);
+  pier.position.set(0, 1.5, 0);
+  group.add(pier);
+
+  // pilings (4 corner posts)
+  var pilingGeo = new THREE.CylinderGeometry(0.15, 0.15, 3, 6);
+  var pilingMat = new THREE.MeshLambertMaterial({ color: 0x5a4010 });
+  var offsets = [[-1.2, -2.5], [1.2, -2.5], [-1.2, 2.5], [1.2, 2.5]];
+  for (var i = 0; i < offsets.length; i++) {
+    var piling = new THREE.Mesh(pilingGeo, pilingMat);
+    piling.position.set(offsets[i][0], 0.2, offsets[i][1]);
+    group.add(piling);
+  }
+
+  // supply crate on pier
+  var crateGeo = new THREE.BoxGeometry(0.8, 0.8, 0.8);
+  var crateMat = new THREE.MeshLambertMaterial({ color: 0x44aa66 });
+  var crate = new THREE.Mesh(crateGeo, crateMat);
+  crate.position.set(0.5, 2.1, 1.0);
+  group.add(crate);
+
+  // barrel on pier
+  var barrelGeo = new THREE.CylinderGeometry(0.3, 0.3, 0.7, 8);
+  var barrelMat = new THREE.MeshLambertMaterial({ color: 0x2288cc });
+  var barrel = new THREE.Mesh(barrelGeo, barrelMat);
+  barrel.position.set(-0.6, 2.05, -0.8);
+  group.add(barrel);
+
+  // glow light (green when available, grey when on cooldown)
+  var light = new THREE.PointLight(0x44ff88, 1.5, 15);
+  light.position.set(0, 3, 0);
+  group.add(light);
+
+  // beacon post
+  var postGeo = new THREE.CylinderGeometry(0.08, 0.08, 2, 6);
+  var postMat = new THREE.MeshLambertMaterial({ color: 0x888888 });
+  var post = new THREE.Mesh(postGeo, postMat);
+  post.position.set(1.2, 2.5, -2.5);
+  group.add(post);
+
+  // beacon lamp
+  var lampGeo = new THREE.SphereGeometry(0.2, 8, 8);
+  var lampMat = new THREE.MeshBasicMaterial({ color: 0x44ff88 });
+  var lamp = new THREE.Mesh(lampGeo, lampMat);
+  lamp.position.set(1.2, 3.6, -2.5);
+  group.add(lamp);
+
+  group.userData.light = light;
+  group.userData.lamp = lamp;
+  group.userData.lampMat = lampMat;
+
+  return group;
+}
+
+// --- port manager ---
+export function createPortManager() {
+  return {
+    ports: [],
+    initialized: false
+  };
+}
+
+// --- initialize ports for a zone ---
+export function initPorts(manager, terrain, scene) {
+  clearPorts(manager, scene);
+  var positions = findCoastlinePositions(terrain);
+
+  for (var i = 0; i < positions.length; i++) {
+    var mesh = buildPortMesh();
+    mesh.position.set(positions[i].x, 0, positions[i].z);
+    scene.add(mesh);
+
+    manager.ports.push({
+      mesh: mesh,
+      posX: positions[i].x,
+      posZ: positions[i].z,
+      cooldown: 0,       // 0 = available
+      available: true
+    });
+  }
+
+  manager.initialized = true;
+}
+
+// --- clear all ports ---
+export function clearPorts(manager, scene) {
+  for (var i = 0; i < manager.ports.length; i++) {
+    scene.remove(manager.ports[i].mesh);
+  }
+  manager.ports = [];
+  manager.initialized = false;
+}
+
+// --- update ports: check proximity, tick cooldowns, update visuals ---
+export function updatePorts(manager, ship, resources, enemyMgr, dt) {
+  for (var i = 0; i < manager.ports.length; i++) {
+    var port = manager.ports[i];
+
+    // tick cooldown
+    if (port.cooldown > 0) {
+      port.cooldown -= dt;
+      if (port.cooldown <= 0) {
+        port.cooldown = 0;
+        port.available = true;
+      }
+    }
+
+    // check proximity for resupply
+    if (port.available) {
+      var dx = ship.posX - port.posX;
+      var dz = ship.posZ - port.posZ;
+      var distSq = dx * dx + dz * dz;
+
+      if (distSq < PORT_COLLECT_RADIUS * PORT_COLLECT_RADIUS) {
+        // resupply
+        addAmmo(resources, PORT_AMMO_RESTOCK);
+        addFuel(resources, PORT_FUEL_RESTOCK);
+        // heal player
+        var hpInfo = { hp: enemyMgr.playerHp, maxHp: enemyMgr.playerMaxHp };
+        var newHp = Math.min(hpInfo.maxHp, hpInfo.hp + PORT_HP_RESTOCK);
+        enemyMgr.playerHp = newHp;
+        // start cooldown
+        port.cooldown = PORT_COOLDOWN;
+        port.available = false;
+        console.log("[PORT] Resupplied at port " + i);
+      }
+    }
+
+    // update visuals: green glow when available, dim grey on cooldown
+    var light = port.mesh.userData.light;
+    var lamp = port.mesh.userData.lamp;
+    var lampMat = port.mesh.userData.lampMat;
+
+    if (port.available) {
+      light.color.setHex(0x44ff88);
+      light.intensity = 1.5 + Math.sin(Date.now() * 0.003) * 0.5;
+      lampMat.color.setHex(0x44ff88);
+    } else {
+      // cooldown: dim red/grey, pulse slowly
+      var cdRatio = port.cooldown / PORT_COOLDOWN;
+      light.color.setHex(0x884422);
+      light.intensity = 0.3 + cdRatio * 0.2;
+      lampMat.color.setHex(0x884422);
+    }
+  }
+}
+
+// --- get port info for HUD ---
+export function getPortsInfo(manager, ship) {
+  var nearest = null;
+  var nearestDist = Infinity;
+  for (var i = 0; i < manager.ports.length; i++) {
+    var port = manager.ports[i];
+    var dx = ship.posX - port.posX;
+    var dz = ship.posZ - port.posZ;
+    var dist = Math.sqrt(dx * dx + dz * dz);
+    if (dist < nearestDist) {
+      nearestDist = dist;
+      nearest = port;
+    }
+  }
+  if (!nearest) return null;
+  return {
+    dist: nearestDist,
+    available: nearest.available,
+    cooldown: nearest.cooldown,
+    maxCooldown: PORT_COOLDOWN
+  };
+}


### PR DESCRIPTION
Closes #36

## Changes
- **Supply ports** (`js/port.js`): 2-3 fixed resupply points per map, procedurally placed on island coastlines
- **Resource crates** (`js/crate.js`): periodic spawns at random water positions every ~18s
- **HUD indicator** (`js/hud.js`): shows nearest port distance and cooldown status
- **Game loop integration** (`js/main.js`): ports + crates wired into combat loop, cleared on wave/restart

## Acceptance Criteria
- [x] Supply ports exist as fixed points on the map (2-3 per map)
- [x] Ports have a visible 3D model (small dock/pier structure)
- [x] Sailing into port proximity restocks ammo, health, and fuel
- [x] Ports have a cooldown after use (visual indicator when unavailable)
- [x] Ports are placed on island coastlines (ties into procedural terrain from #38)
- [x] Resource crates (ammo/health/fuel) spawn periodically at random map positions
- [x] Crates spawn independently of enemy kills
- [x] Crate spawn rate is tunable (start ~15-20s interval)
- [x] Crates have visible 3D models on the water surface
- [x] Crates are collected on ship proximity (same as enemy drops)
- [x] Crates despawn between waves (consistent with pickup cleanup)