### PR TITLE
Upgrade UX — preview stats before apply, home screen respec

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -131,7 +131,7 @@ showShipSelectScreen(function (classKey) {
   selectedClass = classKey;
   hideShipSelectScreen();
   openTechThenMap();
-});
+}, upgrades);
 
 function openTechThenMap() {
   techState = loadTechState();


### PR DESCRIPTION
Closes #37

## Acceptance Criteria
- [x] Selecting an upgrade shows stat preview (current value → new value) before purchasing
- [x] Upgrade requires explicit "Apply" / "Confirm" button press to purchase
- [x] Browsing upgrades without confirming has no effect
- [x] Ship select / home screen has a "Reset Upgrades" button
- [x] Reset refunds all spent salvage
- [x] Reset removes all applied upgrades (back to base stats)
- [x] Reset confirmation dialog ("Are you sure? This resets all upgrades.")
- [x] Upgrade preview shows affected stats clearly (e.g., "Fire Rate: 100% → 110%")

## Changes
- **upgradeScreen.js** — Replaced one-click BUY with click-to-select → preview → APPLY flow. Selecting an upgrade shows a stat preview panel with current → new values and an APPLY button. Browsing without clicking APPLY has no effect.
- **upgrade.js** — Added `getTotalSpent()`, `respecUpgrades()`, `getMultiplierForKey()`, and exported `findUpgrade()` for preview/respec support.
- **shipSelect.js** — Added "RESET UPGRADES" button (only visible when upgrades exist) with a confirmation dialog showing refund amount.
- **main.js** — Pass upgrade state to `showShipSelectScreen()` so reset button can operate on it.