### PR TITLE
Phase 7B: UI polish — HUD, minimap, damage indicators

### DIFF
--- a/js/enemy.js
+++ b/js/enemy.js
@@ -127,7 +127,8 @@ export function createEnemyManager() {
     playerHp: PLAYER_HP,
     playerMaxHp: PLAYER_HP,
     playerArmor: 0,           // damage reduction 0-1 from upgrades
-    onDeathCallback: null     // called with (x, y, z) when enemy destroyed
+    onDeathCallback: null,    // called with (x, y, z) when enemy destroyed
+    onHitCallback: null       // called with (x, y, z, dmg) on any enemy hit
   };
 }
 
@@ -156,6 +157,11 @@ export function resetEnemyManager(manager, scene) {
 // --- set callback for enemy death (used for pickup spawning) ---
 export function setOnDeathCallback(manager, callback) {
   manager.onDeathCallback = callback;
+}
+
+// --- set callback for enemy hit (used for floating damage numbers) ---
+export function setOnHitCallback(manager, callback) {
+  manager.onHitCallback = callback;
 }
 
 // --- set player HP (used by repair system) ---
@@ -495,6 +501,9 @@ export function damageEnemy(manager, enemy, scene, damageMult) {
   var dmg = Math.round(1 * (damageMult || 1));
   if (dmg < 1) dmg = 1;
   enemy.hp -= dmg;
+  if (manager.onHitCallback) {
+    manager.onHitCallback(enemy.posX, enemy.mesh.position.y, enemy.posZ, dmg);
+  }
   if (enemy.hp <= 0) {
     enemy.alive = false;
     enemy.sinking = true;

--- a/js/hud.js
+++ b/js/hud.js
@@ -1,42 +1,26 @@
-// hud.js — HUD elements, on-screen weapon selector, ability button, overlays
-var container = null;
-var speedBar = null;
-var speedLabel = null;
-var compassLabel = null;
-var ammoLabel = null;
-var weaponPanel = null;
-var weaponItems = [];
-var fuelBarBg = null;
-var fuelBar = null;
-var fuelLabel = null;
-var partsLabel = null;
-var salvageLabel = null;
-var hpBarBg = null;
-var hpBar = null;
-var hpLabel = null;
-var waveLabel = null;
-var abilityBtn = null;
-var abilityBarBg = null;
-var abilityBar = null;
-var abilityStatus = null;
-var weatherLabel = null;
-var portLabel = null;
-var autofireLabel = null;
-var onWeaponSwitchCallback = null;
-var onAbilityCallback = null;
-var onAutofireToggleCallback = null;
-var banner = null;
-var bannerTimer = 0;
-var overlay = null;
-var overlayTitle = null;
-var overlaySubtext = null;
-var overlayBtn = null;
-var onRestartCallback = null;
-var onMuteCallback = null;
-var onVolumeCallback = null;
-var muteBtn = null;
-var volumeSlider = null;
-var soundPanel = null;
+// hud.js — HUD elements: HP (top-left), wave (top-center), minimap (top-right),
+// weapons/ammo (bottom-center), ability & status (bottom-left)
+import { createMinimap, updateMinimap as renderMinimap } from "./minimap.js";
+
+// --- color palette ---
+var C = {
+  bg: "rgba(5,10,20,0.7)",
+  bgLight: "rgba(20,30,50,0.7)",
+  border: "rgba(80,100,130,0.4)",
+  borderActive: "rgba(80,100,130,0.5)",
+  text: "#8899aa",
+  textDim: "#667788",
+  green: "#44aa66",
+  greenBright: "#44dd66",
+  yellow: "#ffcc44",
+  orange: "#cc8822",
+  red: "#cc4444",
+  blue: "#4477aa",
+  blueBright: "#2288cc",
+  purple: "#cc66ff",
+  cyan: "#44aaff",
+  portGreen: "#44ff88"
+};
 
 var BTN_BASE = [
   "font-family:monospace", "font-size:13px", "padding:6px 10px",
@@ -44,264 +28,154 @@ var BTN_BASE = [
   "user-select:none", "text-align:center", "min-width:80px"
 ].join(";");
 
+// --- top-left: HP, fuel, resources ---
+var topLeftPanel = null;
+var hpBarBg = null, hpBar = null, hpLabel = null;
+var fuelBarBg = null, fuelBar = null, fuelLabel = null;
+var partsLabel = null, salvageLabel = null;
+var weatherLabel = null, portLabel = null;
+
+// --- top-center: wave info ---
+var topCenterPanel = null;
+var waveLabel = null;
+var compassLabel = null;
+
+// --- top-right: minimap + sound ---
+var minimapContainer = null;
+var soundPanel = null, muteBtn = null, volumeSlider = null;
+
+// --- bottom-center: weapons/ammo ---
+var bottomPanel = null;
+var weaponPanel = null, weaponItems = [];
+var ammoLabel = null;
+var speedBar = null, speedLabel = null;
+var autofireLabel = null;
+
+// --- bottom-left: ability ---
+var bottomLeftPanel = null;
+var abilityBtn = null, abilityBarBg = null, abilityBar = null, abilityStatus = null;
+
+// --- overlays ---
+var banner = null, bannerTimer = 0;
+var overlay = null, overlayTitle = null, overlaySubtext = null, overlayBtn = null;
+
+// --- callbacks ---
+var onWeaponSwitchCallback = null;
+var onAbilityCallback = null;
+var onAutofireToggleCallback = null;
+var onRestartCallback = null;
+var onMuteCallback = null;
+var onVolumeCallback = null;
+
+function makeBar(width, height) {
+  var bg = document.createElement("div");
+  bg.style.cssText = [
+    "width:" + width + "px", "height:" + height + "px",
+    "background:" + C.bgLight, "border:1px solid " + C.border,
+    "border-radius:4px", "overflow:hidden"
+  ].join(";");
+  var fill = document.createElement("div");
+  fill.style.cssText = [
+    "width:100%", "height:100%", "background:" + C.green,
+    "border-radius:3px", "transition:width 0.2s"
+  ].join(";");
+  bg.appendChild(fill);
+  return { bg: bg, fill: fill };
+}
+
 export function createHUD() {
-  container = document.createElement("div");
-  container.style.cssText = [
-    "position:fixed", "bottom:20px", "left:20px", "pointer-events:none",
-    "font-family:monospace", "color:#8899aa", "font-size:13px",
+  // === TOP-LEFT: HP, fuel, resources ===
+  topLeftPanel = document.createElement("div");
+  topLeftPanel.style.cssText = [
+    "position:fixed", "top:16px", "left:16px", "pointer-events:none",
+    "font-family:monospace", "color:" + C.text, "font-size:13px",
     "user-select:none", "z-index:10"
   ].join(";");
 
-  var barBg = document.createElement("div");
-  barBg.style.cssText = [
-    "width:120px", "height:8px", "background:rgba(20,30,50,0.7)",
-    "border:1px solid rgba(80,100,130,0.4)", "border-radius:4px",
-    "overflow:hidden", "margin-bottom:6px"
-  ].join(";");
-  speedBar = document.createElement("div");
-  speedBar.style.cssText = [
-    "width:0%", "height:100%", "background:#4477aa",
-    "border-radius:3px", "transition:width 0.1s"
-  ].join(";");
-  barBg.appendChild(speedBar);
-  container.appendChild(barBg);
-
-  speedLabel = document.createElement("div");
-  speedLabel.textContent = "0 kn";
-  speedLabel.style.marginBottom = "4px";
-  container.appendChild(speedLabel);
-
-  compassLabel = document.createElement("div");
-  compassLabel.textContent = "N";
-  compassLabel.style.fontSize = "12px";
-  compassLabel.style.color = "#667788";
-  container.appendChild(compassLabel);
-
-  weaponPanel = document.createElement("div");
-  weaponPanel.style.cssText = "margin-top:8px;display:flex;flex-direction:column;gap:3px;";
-  var weaponDefs = [
-    { name: "Turret", color: "#ffcc44" },
-    { name: "Missile", color: "#ff6644" },
-    { name: "Torpedo", color: "#44aaff" }
-  ];
-  weaponItems = [];
-  for (var w = 0; w < weaponDefs.length; w++) {
-    var row = document.createElement("div");
-    row.style.cssText = [
-      BTN_BASE, "display:flex", "align-items:center", "gap:6px",
-      "background:rgba(20,30,50,0.7)", "border:1px solid transparent",
-      "color:" + weaponDefs[w].color
-    ].join(";");
-    row.dataset.weaponIndex = String(w);
-    row.addEventListener("click", (function (idx) {
-      return function (e) {
-        e.stopPropagation();
-        if (onWeaponSwitchCallback) onWeaponSwitchCallback(idx);
-      };
-    })(w));
-    var nameEl = document.createElement("span");
-    nameEl.textContent = weaponDefs[w].name;
-    nameEl.style.minWidth = "60px";
-    row.appendChild(nameEl);
-    var label = document.createElement("span");
-    label.textContent = "--";
-    label.style.color = "#8899aa";
-    row.appendChild(label);
-    weaponPanel.appendChild(row);
-    weaponItems.push({ el: row, label: label, nameEl: nameEl, color: weaponDefs[w].color, index: w });
-  }
-  container.appendChild(weaponPanel);
-
-  ammoLabel = document.createElement("div");
-  ammoLabel.textContent = "AMMO: --";
-  ammoLabel.style.marginTop = "4px";
-  ammoLabel.style.fontSize = "13px";
-  ammoLabel.style.color = "#8899aa";
-  container.appendChild(ammoLabel);
-
-  autofireLabel = document.createElement("div");
-  autofireLabel.style.cssText = [
-    BTN_BASE, "margin-top:6px", "background:rgba(20,30,50,0.7)",
-    "border:1px solid rgba(80,100,130,0.5)", "color:#667788",
-    "font-size:12px"
-  ].join(";");
-  autofireLabel.textContent = "AUTOFIRE: OFF [F]";
-  autofireLabel.addEventListener("click", function (e) {
-    e.stopPropagation();
-    if (onAutofireToggleCallback) onAutofireToggleCallback();
-  });
-  container.appendChild(autofireLabel);
+  hpLabel = document.createElement("div");
+  hpLabel.textContent = "HP";
+  hpLabel.style.cssText = "font-size:12px;color:" + C.textDim + ";margin-bottom:3px;";
+  topLeftPanel.appendChild(hpLabel);
+  var hpBars = makeBar(160, 10);
+  hpBarBg = hpBars.bg;
+  hpBar = hpBars.fill;
+  topLeftPanel.appendChild(hpBarBg);
 
   fuelLabel = document.createElement("div");
   fuelLabel.textContent = "FUEL";
-  fuelLabel.style.marginTop = "8px";
-  fuelLabel.style.fontSize = "12px";
-  fuelLabel.style.color = "#667788";
-  container.appendChild(fuelLabel);
-  fuelBarBg = document.createElement("div");
-  fuelBarBg.style.cssText = [
-    "width:120px", "height:8px", "background:rgba(20,30,50,0.7)",
-    "border:1px solid rgba(80,100,130,0.4)", "border-radius:4px",
-    "overflow:hidden", "margin-top:3px"
-  ].join(";");
-  fuelBar = document.createElement("div");
-  fuelBar.style.cssText = [
-    "width:100%", "height:100%", "background:#2288cc",
-    "border-radius:3px", "transition:width 0.2s"
-  ].join(";");
-  fuelBarBg.appendChild(fuelBar);
-  container.appendChild(fuelBarBg);
+  fuelLabel.style.cssText = "font-size:12px;color:" + C.textDim + ";margin-top:8px;margin-bottom:3px;";
+  topLeftPanel.appendChild(fuelLabel);
+  var fuelBars = makeBar(160, 8);
+  fuelBarBg = fuelBars.bg;
+  fuelBar = fuelBars.fill;
+  fuelBar.style.background = C.blueBright;
+  topLeftPanel.appendChild(fuelBarBg);
 
   partsLabel = document.createElement("div");
   partsLabel.textContent = "PARTS: 0";
-  partsLabel.style.marginTop = "6px";
-  partsLabel.style.fontSize = "13px";
-  partsLabel.style.color = "#8899aa";
-  container.appendChild(partsLabel);
+  partsLabel.style.cssText = "margin-top:6px;font-size:12px;color:" + C.text + ";";
+  topLeftPanel.appendChild(partsLabel);
 
   salvageLabel = document.createElement("div");
   salvageLabel.textContent = "SALVAGE: 0";
-  salvageLabel.style.marginTop = "4px";
-  salvageLabel.style.fontSize = "13px";
-  salvageLabel.style.color = "#ffcc44";
-  container.appendChild(salvageLabel);
-
-  hpLabel = document.createElement("div");
-  hpLabel.textContent = "HP";
-  hpLabel.style.marginTop = "8px";
-  hpLabel.style.fontSize = "12px";
-  hpLabel.style.color = "#667788";
-  container.appendChild(hpLabel);
-  hpBarBg = document.createElement("div");
-  hpBarBg.style.cssText = [
-    "width:120px", "height:8px", "background:rgba(20,30,50,0.7)",
-    "border:1px solid rgba(80,100,130,0.4)", "border-radius:4px",
-    "overflow:hidden", "margin-top:3px"
-  ].join(";");
-  hpBar = document.createElement("div");
-  hpBar.style.cssText = [
-    "width:100%", "height:100%", "background:#44aa66",
-    "border-radius:3px", "transition:width 0.2s"
-  ].join(";");
-  hpBarBg.appendChild(hpBar);
-  container.appendChild(hpBarBg);
-
-  waveLabel = document.createElement("div");
-  waveLabel.textContent = "WAVE 1";
-  waveLabel.style.marginTop = "10px";
-  waveLabel.style.fontSize = "14px";
-  waveLabel.style.color = "#8899aa";
-  waveLabel.style.fontWeight = "bold";
-  container.appendChild(waveLabel);
-
-  var abilityContainer = document.createElement("div");
-  abilityContainer.style.marginTop = "10px";
-  abilityBtn = document.createElement("div");
-  abilityBtn.style.cssText = [
-    BTN_BASE, "background:rgba(20,30,50,0.7)",
-    "border:1px solid rgba(80,100,130,0.5)",
-    "color:#cc66ff", "margin-bottom:3px"
-  ].join(";");
-  abilityBtn.textContent = "Ability";
-  abilityBtn.addEventListener("click", function (e) {
-    e.stopPropagation();
-    if (onAbilityCallback) onAbilityCallback();
-  });
-  abilityContainer.appendChild(abilityBtn);
-  abilityBarBg = document.createElement("div");
-  abilityBarBg.style.cssText = [
-    "width:120px", "height:10px", "background:rgba(20,30,50,0.7)",
-    "border:1px solid rgba(80,100,130,0.4)", "border-radius:4px",
-    "overflow:hidden"
-  ].join(";");
-  abilityBar = document.createElement("div");
-  abilityBar.style.cssText = [
-    "width:100%", "height:100%", "background:#cc66ff",
-    "border-radius:3px", "transition:width 0.1s"
-  ].join(";");
-  abilityBarBg.appendChild(abilityBar);
-  abilityContainer.appendChild(abilityBarBg);
-  abilityStatus = document.createElement("div");
-  abilityStatus.textContent = "READY";
-  abilityStatus.style.fontSize = "11px";
-  abilityStatus.style.color = "#cc66ff";
-  abilityStatus.style.marginTop = "2px";
-  abilityContainer.appendChild(abilityStatus);
-  container.appendChild(abilityContainer);
+  salvageLabel.style.cssText = "margin-top:3px;font-size:12px;color:" + C.yellow + ";";
+  topLeftPanel.appendChild(salvageLabel);
 
   weatherLabel = document.createElement("div");
   weatherLabel.textContent = "CALM";
-  weatherLabel.style.marginTop = "10px";
-  weatherLabel.style.fontSize = "12px";
-  weatherLabel.style.color = "#667788";
-  container.appendChild(weatherLabel);
+  weatherLabel.style.cssText = "margin-top:6px;font-size:12px;color:" + C.textDim + ";";
+  topLeftPanel.appendChild(weatherLabel);
 
   portLabel = document.createElement("div");
   portLabel.textContent = "";
-  portLabel.style.marginTop = "6px";
-  portLabel.style.fontSize = "12px";
-  portLabel.style.color = "#44ff88";
-  container.appendChild(portLabel);
-  document.body.appendChild(container);
+  portLabel.style.cssText = "margin-top:3px;font-size:12px;color:" + C.portGreen + ";";
+  topLeftPanel.appendChild(portLabel);
 
-  banner = document.createElement("div");
-  banner.style.cssText = [
-    "position:fixed", "top:25%", "left:50%",
-    "transform:translate(-50%,-50%)", "font-family:monospace",
-    "font-size:32px", "font-weight:bold", "color:#ffcc44",
-    "text-shadow:0 0 20px rgba(255,200,60,0.6)", "pointer-events:none",
-    "user-select:none", "z-index:20", "opacity:0", "transition:opacity 0.3s"
-  ].join(";");
-  banner.textContent = "";
-  document.body.appendChild(banner);
+  document.body.appendChild(topLeftPanel);
 
-  overlay = document.createElement("div");
-  overlay.style.cssText = [
-    "position:fixed", "top:0", "left:0", "width:100%", "height:100%",
-    "display:none", "flex-direction:column", "align-items:center",
-    "justify-content:center", "background:rgba(5,5,15,0.85)",
-    "z-index:100", "font-family:monospace", "user-select:none"
+  // === TOP-CENTER: wave info ===
+  topCenterPanel = document.createElement("div");
+  topCenterPanel.style.cssText = [
+    "position:fixed", "top:16px", "left:50%", "transform:translateX(-50%)",
+    "pointer-events:none", "font-family:monospace", "color:" + C.text,
+    "font-size:13px", "user-select:none", "z-index:10", "text-align:center"
   ].join(";");
-  overlayTitle = document.createElement("div");
-  overlayTitle.style.cssText = [
-    "font-size:48px", "font-weight:bold", "color:#cc4444", "margin-bottom:16px"
-  ].join(";");
-  overlay.appendChild(overlayTitle);
-  overlaySubtext = document.createElement("div");
-  overlaySubtext.style.cssText = [
-    "font-size:20px", "color:#8899aa", "margin-bottom:32px"
-  ].join(";");
-  overlay.appendChild(overlaySubtext);
-  overlayBtn = document.createElement("button");
-  overlayBtn.textContent = "RESTART";
-  overlayBtn.style.cssText = [
-    "font-family:monospace", "font-size:18px", "padding:12px 36px",
-    "background:rgba(40,60,90,0.8)", "color:#8899aa",
-    "border:1px solid rgba(80,100,130,0.5)", "border-radius:6px",
-    "cursor:pointer", "pointer-events:auto"
-  ].join(";");
-  overlayBtn.addEventListener("click", function () {
-    hideOverlay();
-    if (onRestartCallback) onRestartCallback();
-  });
-  overlay.appendChild(overlayBtn);
-  document.body.appendChild(overlay);
 
-  // sound controls — top-right
+  waveLabel = document.createElement("div");
+  waveLabel.textContent = "WAVE 1";
+  waveLabel.style.cssText = "font-size:16px;font-weight:bold;color:" + C.text + ";";
+  topCenterPanel.appendChild(waveLabel);
+
+  compassLabel = document.createElement("div");
+  compassLabel.textContent = "N 0\u00B0";
+  compassLabel.style.cssText = "font-size:12px;color:" + C.textDim + ";margin-top:4px;";
+  topCenterPanel.appendChild(compassLabel);
+
+  document.body.appendChild(topCenterPanel);
+
+  // === TOP-RIGHT: minimap + sound ===
+  minimapContainer = document.createElement("div");
+  minimapContainer.style.cssText = [
+    "position:fixed", "top:16px", "right:16px",
+    "pointer-events:none", "user-select:none", "z-index:10"
+  ].join(";");
+
+  createMinimap(minimapContainer);
+
+  // sound controls below minimap
   soundPanel = document.createElement("div");
   soundPanel.style.cssText = [
-    "position:fixed", "top:16px", "right:16px", "z-index:10",
-    "font-family:monospace", "font-size:12px", "color:#8899aa",
-    "display:flex", "align-items:center", "gap:8px",
-    "user-select:none"
+    "display:flex", "align-items:center", "gap:6px",
+    "margin-top:8px", "font-family:monospace", "font-size:12px",
+    "color:" + C.text, "justify-content:center"
   ].join(";");
   muteBtn = document.createElement("div");
   muteBtn.style.cssText = [
     BTN_BASE, "font-size:16px", "min-width:36px", "padding:4px 8px",
-    "background:rgba(20,30,50,0.7)", "border:1px solid rgba(80,100,130,0.5)",
-    "color:#8899aa"
+    "background:" + C.bgLight, "border:1px solid " + C.borderActive,
+    "color:" + C.text
   ].join(";");
-  muteBtn.textContent = "♪";
+  muteBtn.textContent = "\u266A";
   muteBtn.addEventListener("click", function (e) {
     e.stopPropagation();
     if (onMuteCallback) onMuteCallback();
@@ -312,13 +186,180 @@ export function createHUD() {
   volumeSlider.min = "0";
   volumeSlider.max = "100";
   volumeSlider.value = "50";
-  volumeSlider.style.cssText = "width:80px;cursor:pointer;pointer-events:auto;accent-color:#4477aa;";
+  volumeSlider.style.cssText = "width:70px;cursor:pointer;pointer-events:auto;accent-color:" + C.blue + ";";
   volumeSlider.addEventListener("input", function (e) {
     e.stopPropagation();
     if (onVolumeCallback) onVolumeCallback(parseFloat(volumeSlider.value) / 100);
   });
   soundPanel.appendChild(volumeSlider);
-  document.body.appendChild(soundPanel);
+  minimapContainer.appendChild(soundPanel);
+
+  document.body.appendChild(minimapContainer);
+
+  // === BOTTOM-CENTER: weapons, ammo, speed ===
+  bottomPanel = document.createElement("div");
+  bottomPanel.style.cssText = [
+    "position:fixed", "bottom:16px", "left:50%", "transform:translateX(-50%)",
+    "pointer-events:none", "font-family:monospace", "color:" + C.text,
+    "font-size:13px", "user-select:none", "z-index:10", "text-align:center"
+  ].join(";");
+
+  weaponPanel = document.createElement("div");
+  weaponPanel.style.cssText = "display:flex;gap:4px;justify-content:center;margin-bottom:6px;";
+  var weaponDefs = [
+    { name: "Turret", color: "#ffcc44", key: "1" },
+    { name: "Missile", color: "#ff6644", key: "2" },
+    { name: "Torpedo", color: "#44aaff", key: "3" }
+  ];
+  weaponItems = [];
+  for (var w = 0; w < weaponDefs.length; w++) {
+    var row = document.createElement("div");
+    row.style.cssText = [
+      BTN_BASE, "display:flex", "align-items:center", "gap:4px",
+      "background:" + C.bgLight, "border:1px solid transparent",
+      "color:" + weaponDefs[w].color, "min-width:90px", "padding:5px 8px",
+      "font-size:12px"
+    ].join(";");
+    row.dataset.weaponIndex = String(w);
+    row.addEventListener("click", (function (idx) {
+      return function (e) {
+        e.stopPropagation();
+        if (onWeaponSwitchCallback) onWeaponSwitchCallback(idx);
+      };
+    })(w));
+    var keyHint = document.createElement("span");
+    keyHint.textContent = "[" + weaponDefs[w].key + "]";
+    keyHint.style.cssText = "color:" + C.textDim + ";font-size:10px;";
+    row.appendChild(keyHint);
+    var nameEl = document.createElement("span");
+    nameEl.textContent = weaponDefs[w].name;
+    row.appendChild(nameEl);
+    var label = document.createElement("span");
+    label.textContent = "--";
+    label.style.color = C.text;
+    row.appendChild(label);
+    weaponPanel.appendChild(row);
+    weaponItems.push({ el: row, label: label, nameEl: nameEl, color: weaponDefs[w].color, index: w });
+  }
+  bottomPanel.appendChild(weaponPanel);
+
+  ammoLabel = document.createElement("div");
+  ammoLabel.textContent = "AMMO: --";
+  ammoLabel.style.cssText = "font-size:13px;color:" + C.text + ";margin-bottom:6px;";
+  bottomPanel.appendChild(ammoLabel);
+
+  // speed bar row
+  var speedRow = document.createElement("div");
+  speedRow.style.cssText = "display:flex;align-items:center;gap:8px;justify-content:center;";
+  var speedBarBg = document.createElement("div");
+  speedBarBg.style.cssText = [
+    "width:100px", "height:6px", "background:" + C.bgLight,
+    "border:1px solid " + C.border, "border-radius:3px", "overflow:hidden"
+  ].join(";");
+  speedBar = document.createElement("div");
+  speedBar.style.cssText = "width:0%;height:100%;background:" + C.blue + ";border-radius:2px;transition:width 0.1s;";
+  speedBarBg.appendChild(speedBar);
+  speedRow.appendChild(speedBarBg);
+  speedLabel = document.createElement("span");
+  speedLabel.textContent = "0 kn";
+  speedLabel.style.cssText = "font-size:12px;color:" + C.textDim + ";min-width:50px;";
+  speedRow.appendChild(speedLabel);
+  bottomPanel.appendChild(speedRow);
+
+  // autofire toggle
+  autofireLabel = document.createElement("div");
+  autofireLabel.style.cssText = [
+    BTN_BASE, "margin-top:6px", "display:inline-block",
+    "background:" + C.bgLight, "border:1px solid " + C.borderActive,
+    "color:" + C.textDim, "font-size:11px", "padding:4px 10px"
+  ].join(";");
+  autofireLabel.textContent = "AUTOFIRE: OFF [F]";
+  autofireLabel.addEventListener("click", function (e) {
+    e.stopPropagation();
+    if (onAutofireToggleCallback) onAutofireToggleCallback();
+  });
+  bottomPanel.appendChild(autofireLabel);
+
+  document.body.appendChild(bottomPanel);
+
+  // === BOTTOM-LEFT: ability ===
+  bottomLeftPanel = document.createElement("div");
+  bottomLeftPanel.style.cssText = [
+    "position:fixed", "bottom:16px", "left:16px", "pointer-events:none",
+    "font-family:monospace", "color:" + C.text, "font-size:13px",
+    "user-select:none", "z-index:10"
+  ].join(";");
+
+  abilityBtn = document.createElement("div");
+  abilityBtn.style.cssText = [
+    BTN_BASE, "background:" + C.bgLight,
+    "border:1px solid " + C.borderActive,
+    "color:" + C.purple, "margin-bottom:3px"
+  ].join(";");
+  abilityBtn.textContent = "Ability";
+  abilityBtn.addEventListener("click", function (e) {
+    e.stopPropagation();
+    if (onAbilityCallback) onAbilityCallback();
+  });
+  bottomLeftPanel.appendChild(abilityBtn);
+  abilityBarBg = document.createElement("div");
+  abilityBarBg.style.cssText = [
+    "width:120px", "height:8px", "background:" + C.bgLight,
+    "border:1px solid " + C.border, "border-radius:4px", "overflow:hidden"
+  ].join(";");
+  abilityBar = document.createElement("div");
+  abilityBar.style.cssText = [
+    "width:100%", "height:100%", "background:" + C.purple,
+    "border-radius:3px", "transition:width 0.1s"
+  ].join(";");
+  abilityBarBg.appendChild(abilityBar);
+  bottomLeftPanel.appendChild(abilityBarBg);
+  abilityStatus = document.createElement("div");
+  abilityStatus.textContent = "READY";
+  abilityStatus.style.cssText = "font-size:11px;color:" + C.purple + ";margin-top:2px;";
+  bottomLeftPanel.appendChild(abilityStatus);
+
+  document.body.appendChild(bottomLeftPanel);
+
+  // === BANNER ===
+  banner = document.createElement("div");
+  banner.style.cssText = [
+    "position:fixed", "top:25%", "left:50%",
+    "transform:translate(-50%,-50%)", "font-family:monospace",
+    "font-size:32px", "font-weight:bold", "color:" + C.yellow,
+    "text-shadow:0 0 20px rgba(255,200,60,0.6)", "pointer-events:none",
+    "user-select:none", "z-index:20", "opacity:0", "transition:opacity 0.3s"
+  ].join(";");
+  document.body.appendChild(banner);
+
+  // === OVERLAY (game over / victory) ===
+  overlay = document.createElement("div");
+  overlay.style.cssText = [
+    "position:fixed", "top:0", "left:0", "width:100%", "height:100%",
+    "display:none", "flex-direction:column", "align-items:center",
+    "justify-content:center", "background:rgba(5,5,15,0.85)",
+    "z-index:100", "font-family:monospace", "user-select:none"
+  ].join(";");
+  overlayTitle = document.createElement("div");
+  overlayTitle.style.cssText = "font-size:48px;font-weight:bold;color:" + C.red + ";margin-bottom:16px;";
+  overlay.appendChild(overlayTitle);
+  overlaySubtext = document.createElement("div");
+  overlaySubtext.style.cssText = "font-size:20px;color:" + C.text + ";margin-bottom:32px;";
+  overlay.appendChild(overlaySubtext);
+  overlayBtn = document.createElement("button");
+  overlayBtn.textContent = "RESTART";
+  overlayBtn.style.cssText = [
+    "font-family:monospace", "font-size:18px", "padding:12px 36px",
+    "background:rgba(40,60,90,0.8)", "color:" + C.text,
+    "border:1px solid " + C.borderActive, "border-radius:6px",
+    "cursor:pointer", "pointer-events:auto"
+  ].join(";");
+  overlayBtn.addEventListener("click", function () {
+    hideOverlay();
+    if (onRestartCallback) onRestartCallback();
+  });
+  overlay.appendChild(overlayBtn);
+  document.body.appendChild(overlay);
 }
 
 export function setWeaponSwitchCallback(cb) { onWeaponSwitchCallback = cb; }
@@ -327,15 +368,8 @@ export function setRestartCallback(cb) { onRestartCallback = cb; }
 export function setAutofireToggleCallback(cb) { onAutofireToggleCallback = cb; }
 export function setMuteCallback(cb) { onMuteCallback = cb; }
 export function setVolumeCallback(cb) { onVolumeCallback = cb; }
-
-export function updateMuteButton(m) {
-  if (!muteBtn) return;
-  muteBtn.textContent = m ? "♪✕" : "♪";
-  muteBtn.style.color = m ? "#cc4444" : "#8899aa";
-}
-export function updateVolumeSlider(v) {
-  if (volumeSlider) volumeSlider.value = String(Math.round(v * 100));
-}
+export function updateMuteButton(m) { if (!muteBtn) return; muteBtn.textContent = m ? "\u266A\u2715" : "\u266A"; muteBtn.style.color = m ? C.red : C.text; }
+export function updateVolumeSlider(v) { if (volumeSlider) volumeSlider.value = String(Math.round(v * 100)); }
 
 export function showBanner(text, duration) {
   if (!banner) return;
@@ -350,150 +384,114 @@ function updateBanner(dt) {
   if (bannerTimer <= 0.5) {
     banner.style.opacity = String(Math.max(0, bannerTimer / 0.5));
   }
-  if (bannerTimer <= 0) {
-    banner.style.opacity = "0";
-  }
+  if (bannerTimer <= 0) { banner.style.opacity = "0"; }
 }
 
 export function showGameOver(waveReached) {
   if (!overlay) return;
   overlayTitle.textContent = "GAME OVER";
-  overlayTitle.style.color = "#cc4444";
+  overlayTitle.style.color = C.red;
   overlaySubtext.textContent = "You reached Wave " + waveReached;
   overlayBtn.textContent = "RESTART";
   overlay.style.display = "flex";
 }
-
 export function showVictory(waveReached) {
   if (!overlay) return;
   overlayTitle.textContent = "VICTORY";
-  overlayTitle.style.color = "#44dd66";
+  overlayTitle.style.color = C.greenBright;
   overlaySubtext.textContent = "All " + waveReached + " waves survived!";
   overlayBtn.textContent = "CONTINUE";
   overlay.style.display = "flex";
 }
-
 export function hideOverlay() {
   if (!overlay) return;
   overlay.style.display = "none";
 }
 
-export function updateHUD(speedRatio, displaySpeed, heading, ammo, maxAmmo, hp, maxHp, fuel, maxFuel, parts, wave, waveState, dt, salvage, weaponInfo, abilityInfo, weatherText, autofireOn, portInfo) {
-  if (!container) return;
-  var pct = Math.min(1, speedRatio) * 100;
-  speedBar.style.width = pct + "%";
-  speedLabel.textContent = displaySpeed.toFixed(1) + " kn";
-  var deg = ((heading * 180 / Math.PI) % 360 + 360) % 360;
-  var dirs = ["N", "NE", "E", "SE", "S", "SW", "W", "NW"];
-  var idx = Math.round(deg / 45) % 8;
-  compassLabel.textContent = dirs[idx] + " " + Math.round(deg) + "\u00B0";
+export function updateMinimap(playerX, playerZ, playerHeading, enemies, pickups, ports) {
+  renderMinimap(playerX, playerZ, playerHeading, enemies, pickups, ports);
+}
 
-  if (weaponInfo && weaponItems.length > 0) {
-    var ammoCosts = weaponInfo.ammoCosts;
-    for (var w = 0; w < weaponItems.length; w++) {
-      var item = weaponItems[w];
-      var isActive = w === weaponInfo.activeIndex;
-      item.el.style.background = isActive ? "rgba(40,60,90,0.6)" : "rgba(20,30,50,0.7)";
-      item.el.style.border = isActive ? "1px solid " + item.color : "1px solid transparent";
-      var cost = ammoCosts[w];
-      var canAfford = ammo >= cost;
-      item.label.textContent = "x" + cost;
-      item.label.style.color = canAfford ? "#8899aa" : "#cc4444";
-      item.nameEl.style.opacity = isActive ? "1" : "0.5";
-    }
-  }
-  if (ammo !== undefined) {
-    ammoLabel.textContent = "AMMO: " + ammo + " / " + maxAmmo;
-    ammoLabel.style.color = ammo <= 5 ? "#cc6644" : ammo === 0 ? "#cc2222" : "#8899aa";
-  }
-  if (fuel !== undefined && fuelBar) {
-    var fuelPct = Math.max(0, fuel / maxFuel) * 100;
-    fuelBar.style.width = fuelPct + "%";
-    fuelBar.style.background = fuelPct > 30 ? "#2288cc" : fuelPct > 15 ? "#cc8822" : "#cc4444";
-    fuelLabel.textContent = "FUEL: " + Math.round(fuel) + "%";
-    fuelLabel.style.color = fuelPct > 15 ? "#667788" : "#cc4444";
-  }
-  if (parts !== undefined && partsLabel) {
-    partsLabel.textContent = "PARTS: " + parts;
-    partsLabel.style.color = parts > 0 ? "#44dd66" : "#8899aa";
-  }
-  if (salvage !== undefined && salvageLabel) {
-    salvageLabel.textContent = "SALVAGE: " + salvage;
-  }
+// --- main HUD update ---
+export function updateHUD(speedRatio, displaySpeed, heading, ammo, maxAmmo, hp, maxHp, fuel, maxFuel, parts, wave, waveState, dt, salvage, weaponInfo, abilityInfo, weatherText, autofireOn, portInfo) {
+  if (!topLeftPanel) return;
+  // HP bar
   if (hp !== undefined && hpBar) {
     var hpPct = Math.max(0, hp / maxHp) * 100;
     hpBar.style.width = hpPct + "%";
-    hpBar.style.background = hpPct > 50 ? "#44aa66" : hpPct > 25 ? "#aaaa44" : "#cc4444";
+    hpBar.style.background = hpPct > 50 ? C.green : hpPct > 25 ? "#aaaa44" : C.red;
     hpLabel.textContent = "HP: " + Math.round(hp) + " / " + Math.round(maxHp);
-    hpLabel.style.color = hpPct > 25 ? "#667788" : "#cc4444";
+    hpLabel.style.color = hpPct > 25 ? C.textDim : C.red;
   }
-  if (wave !== undefined && waveLabel) {
-    if (waveState === "SPAWNING" || waveState === "ACTIVE") {
-      waveLabel.textContent = "WAVE " + wave;
-      waveLabel.style.color = "#8899aa";
-    } else if (waveState === "WAITING") {
-      waveLabel.textContent = "REPAIRING...";
-      waveLabel.style.color = "#44dd66";
-    } else if (waveState === "WAVE_COMPLETE") {
-      waveLabel.textContent = "WAVE " + wave + " CLEAR";
-      waveLabel.style.color = "#44dd66";
-    } else {
-      waveLabel.textContent = "WAVE " + wave;
-      waveLabel.style.color = "#8899aa";
-    }
+  // Fuel bar
+  if (fuel !== undefined && fuelBar) {
+    var fuelPct = Math.max(0, fuel / maxFuel) * 100;
+    fuelBar.style.width = fuelPct + "%";
+    fuelBar.style.background = fuelPct > 30 ? C.blueBright : fuelPct > 15 ? C.orange : C.red;
+    fuelLabel.textContent = "FUEL: " + Math.round(fuel) + "%";
+    fuelLabel.style.color = fuelPct > 15 ? C.textDim : C.red;
   }
-  if (abilityInfo && abilityBtn) {
-    abilityBtn.textContent = abilityInfo.name;
-    abilityBtn.style.color = abilityInfo.color || "#cc66ff";
-    if (abilityInfo.active) {
-      var activePct = Math.max(0, abilityInfo.activeTimer / abilityInfo.duration) * 100;
-      abilityBar.style.width = activePct + "%";
-      abilityBar.style.background = abilityInfo.color || "#cc66ff";
-      abilityStatus.textContent = "ACTIVE";
-      abilityStatus.style.color = abilityInfo.color || "#cc66ff";
-      abilityBtn.style.borderColor = abilityInfo.color || "#cc66ff";
-    } else if (abilityInfo.cooldownTimer > 0) {
-      var cdPct = (1 - abilityInfo.cooldownTimer / abilityInfo.cooldown) * 100;
-      abilityBar.style.width = cdPct + "%";
-      abilityBar.style.background = "#556677";
-      abilityStatus.textContent = Math.ceil(abilityInfo.cooldownTimer) + "s";
-      abilityStatus.style.color = "#667788";
-      abilityBtn.style.borderColor = "rgba(80,100,130,0.5)";
-    } else {
-      abilityBar.style.width = "100%";
-      abilityBar.style.background = abilityInfo.color || "#cc66ff";
-      abilityStatus.textContent = "READY";
-      abilityStatus.style.color = abilityInfo.color || "#cc66ff";
-      abilityBtn.style.borderColor = abilityInfo.color || "#cc66ff";
-    }
-  }
+  // Resources
+  if (parts !== undefined && partsLabel) { partsLabel.textContent = "PARTS: " + parts; partsLabel.style.color = parts > 0 ? C.greenBright : C.text; }
+  if (salvage !== undefined && salvageLabel) salvageLabel.textContent = "SALVAGE: " + salvage;
+  // Weather + port
   if (weatherText && weatherLabel) {
     weatherLabel.textContent = "WEATHER: " + weatherText;
-    var wColors = { CALM: "#44aa66", ROUGH: "#ccaa44", STORM: "#cc4444" };
-    weatherLabel.style.color = wColors[weatherText] || "#667788";
-  }
-  if (autofireLabel) {
-    if (autofireOn) {
-      autofireLabel.textContent = "AUTOFIRE: ON [F]";
-      autofireLabel.style.color = "#44dd66";
-      autofireLabel.style.borderColor = "#44dd66";
-    } else {
-      autofireLabel.textContent = "AUTOFIRE: OFF [F]";
-      autofireLabel.style.color = "#667788";
-      autofireLabel.style.borderColor = "rgba(80,100,130,0.5)";
-    }
+    weatherLabel.style.color = ({ CALM: C.green, ROUGH: "#ccaa44", STORM: C.red })[weatherText] || C.textDim;
   }
   if (portLabel) {
     if (portInfo && portInfo.dist < 50) {
-      if (portInfo.available) {
-        portLabel.textContent = "PORT: " + Math.round(portInfo.dist) + "m";
-        portLabel.style.color = "#44ff88";
-      } else {
-        portLabel.textContent = "PORT: " + Math.ceil(portInfo.cooldown) + "s";
-        portLabel.style.color = "#884422";
-      }
+      portLabel.textContent = portInfo.available ? "PORT: " + Math.round(portInfo.dist) + "m" : "PORT: " + Math.ceil(portInfo.cooldown) + "s";
+      portLabel.style.color = portInfo.available ? C.portGreen : "#884422";
+    } else { portLabel.textContent = ""; }
+  }
+  // Wave info
+  if (wave !== undefined && waveLabel) {
+    if (waveState === "WAITING") { waveLabel.textContent = "REPAIRING..."; waveLabel.style.color = C.greenBright; }
+    else if (waveState === "WAVE_COMPLETE") { waveLabel.textContent = "WAVE " + wave + " CLEAR"; waveLabel.style.color = C.greenBright; }
+    else { waveLabel.textContent = "WAVE " + wave; waveLabel.style.color = C.text; }
+  }
+  // Compass
+  var deg = ((heading * 180 / Math.PI) % 360 + 360) % 360;
+  var dirs = ["N", "NE", "E", "SE", "S", "SW", "W", "NW"];
+  compassLabel.textContent = dirs[Math.round(deg / 45) % 8] + " " + Math.round(deg) + "\u00B0";
+  // Weapons
+  if (weaponInfo && weaponItems.length > 0) {
+    for (var w = 0; w < weaponItems.length; w++) {
+      var item = weaponItems[w], isActive = w === weaponInfo.activeIndex, cost = weaponInfo.ammoCosts[w];
+      item.el.style.background = isActive ? "rgba(40,60,90,0.6)" : C.bgLight;
+      item.el.style.border = isActive ? "1px solid " + item.color : "1px solid transparent";
+      item.label.textContent = "x" + cost;
+      item.label.style.color = ammo >= cost ? C.text : C.red;
+      item.nameEl.style.opacity = isActive ? "1" : "0.5";
+    }
+  }
+  if (ammo !== undefined) { ammoLabel.textContent = "AMMO: " + ammo + " / " + maxAmmo; ammoLabel.style.color = ammo <= 5 ? "#cc6644" : ammo === 0 ? "#cc2222" : C.text; }
+  // Speed
+  speedBar.style.width = Math.min(1, speedRatio) * 100 + "%";
+  speedLabel.textContent = displaySpeed.toFixed(1) + " kn";
+  // Autofire
+  if (autofireLabel) {
+    autofireLabel.textContent = autofireOn ? "AUTOFIRE: ON [F]" : "AUTOFIRE: OFF [F]";
+    autofireLabel.style.color = autofireOn ? C.greenBright : C.textDim;
+    autofireLabel.style.borderColor = autofireOn ? C.greenBright : C.borderActive;
+  }
+  // Ability
+  if (abilityInfo && abilityBtn) {
+    var ac = abilityInfo.color || C.purple;
+    abilityBtn.textContent = abilityInfo.name;
+    abilityBtn.style.color = ac;
+    if (abilityInfo.active) {
+      abilityBar.style.width = Math.max(0, abilityInfo.activeTimer / abilityInfo.duration) * 100 + "%";
+      abilityBar.style.background = ac;
+      abilityStatus.textContent = "ACTIVE"; abilityStatus.style.color = ac; abilityBtn.style.borderColor = ac;
+    } else if (abilityInfo.cooldownTimer > 0) {
+      abilityBar.style.width = (1 - abilityInfo.cooldownTimer / abilityInfo.cooldown) * 100 + "%";
+      abilityBar.style.background = "#556677";
+      abilityStatus.textContent = Math.ceil(abilityInfo.cooldownTimer) + "s"; abilityStatus.style.color = C.textDim; abilityBtn.style.borderColor = C.borderActive;
     } else {
-      portLabel.textContent = "";
+      abilityBar.style.width = "100%"; abilityBar.style.background = ac;
+      abilityStatus.textContent = "READY"; abilityStatus.style.color = ac; abilityBtn.style.borderColor = ac;
     }
   }
   updateBanner(dt || 0.016);

--- a/js/minimap.js
+++ b/js/minimap.js
@@ -1,0 +1,127 @@
+// minimap.js — radar-style minimap showing player, enemies, pickups, ports
+
+var minimapCanvas = null;
+var minimapCtx = null;
+var MINIMAP_SIZE = 140;
+var MINIMAP_RANGE = 120;
+
+export function createMinimap(parentEl) {
+  minimapCanvas = document.createElement("canvas");
+  minimapCanvas.width = MINIMAP_SIZE;
+  minimapCanvas.height = MINIMAP_SIZE;
+  minimapCanvas.style.cssText = [
+    "width:" + MINIMAP_SIZE + "px", "height:" + MINIMAP_SIZE + "px",
+    "border-radius:50%", "border:2px solid rgba(80,100,130,0.4)",
+    "background:rgba(5,10,20,0.7)"
+  ].join(";");
+  minimapCtx = minimapCanvas.getContext("2d");
+  parentEl.appendChild(minimapCanvas);
+}
+
+export function updateMinimap(playerX, playerZ, playerHeading, enemies, pickups, ports) {
+  if (!minimapCtx) return;
+  var ctx = minimapCtx;
+  var cx = MINIMAP_SIZE / 2;
+  var cy = MINIMAP_SIZE / 2;
+  var radius = MINIMAP_SIZE / 2 - 4;
+
+  ctx.clearRect(0, 0, MINIMAP_SIZE, MINIMAP_SIZE);
+
+  // background circle
+  ctx.save();
+  ctx.beginPath();
+  ctx.arc(cx, cy, radius, 0, Math.PI * 2);
+  ctx.fillStyle = "rgba(5,10,20,0.8)";
+  ctx.fill();
+  ctx.strokeStyle = "rgba(80,100,130,0.5)";
+  ctx.lineWidth = 1;
+  ctx.stroke();
+  ctx.clip();
+
+  // range rings
+  ctx.strokeStyle = "rgba(80,100,130,0.2)";
+  ctx.lineWidth = 0.5;
+  for (var r = 1; r <= 3; r++) {
+    ctx.beginPath();
+    ctx.arc(cx, cy, radius * r / 3, 0, Math.PI * 2);
+    ctx.stroke();
+  }
+
+  // crosshair
+  ctx.beginPath();
+  ctx.moveTo(cx - 6, cy);
+  ctx.lineTo(cx + 6, cy);
+  ctx.moveTo(cx, cy - 6);
+  ctx.lineTo(cx, cy + 6);
+  ctx.strokeStyle = "rgba(80,100,130,0.4)";
+  ctx.lineWidth = 1;
+  ctx.stroke();
+
+  var scale = radius / MINIMAP_RANGE;
+
+  // ports — blue squares
+  if (ports) {
+    ctx.fillStyle = "#4488cc";
+    for (var pi = 0; pi < ports.length; pi++) {
+      var p = ports[pi];
+      var pdx = (p.x - playerX) * scale;
+      var pdz = (p.z - playerZ) * scale;
+      if (pdx * pdx + pdz * pdz < radius * radius) {
+        ctx.fillRect(cx + pdx - 2, cy + pdz - 2, 4, 4);
+      }
+    }
+  }
+
+  // pickups — green dots
+  if (pickups) {
+    ctx.fillStyle = "#44dd66";
+    for (var ki = 0; ki < pickups.length; ki++) {
+      var pk = pickups[ki];
+      if (!pk.mesh) continue;
+      var kdx = (pk.mesh.position.x - playerX) * scale;
+      var kdz = (pk.mesh.position.z - playerZ) * scale;
+      if (kdx * kdx + kdz * kdz < radius * radius) {
+        ctx.beginPath();
+        ctx.arc(cx + kdx, cy + kdz, 2, 0, Math.PI * 2);
+        ctx.fill();
+      }
+    }
+  }
+
+  // enemies — red dots
+  if (enemies) {
+    ctx.fillStyle = "#ff4444";
+    for (var ei = 0; ei < enemies.length; ei++) {
+      var e = enemies[ei];
+      if (!e.alive) continue;
+      var edx = (e.posX - playerX) * scale;
+      var edz = (e.posZ - playerZ) * scale;
+      if (edx * edx + edz * edz < radius * radius) {
+        ctx.beginPath();
+        ctx.arc(cx + edx, cy + edz, 3, 0, Math.PI * 2);
+        ctx.fill();
+      }
+    }
+  }
+
+  // player — white triangle
+  ctx.save();
+  ctx.translate(cx, cy);
+  ctx.rotate(-playerHeading);
+  ctx.fillStyle = "#ffffff";
+  ctx.beginPath();
+  ctx.moveTo(0, -5);
+  ctx.lineTo(-3, 4);
+  ctx.lineTo(3, 4);
+  ctx.closePath();
+  ctx.fill();
+  ctx.restore();
+
+  // heading indicator
+  ctx.fillStyle = "rgba(136,153,170,0.6)";
+  ctx.font = "9px monospace";
+  ctx.textAlign = "center";
+  ctx.fillText("N", cx, 14);
+
+  ctx.restore();
+}

--- a/js/uiEffects.js
+++ b/js/uiEffects.js
@@ -1,0 +1,266 @@
+// uiEffects.js — damage indicators, floating damage numbers, kill feed, fade transitions
+
+var COLORS = {
+  bg: "rgba(5,10,20,0.7)",
+  border: "rgba(80,100,130,0.4)",
+  textMuted: "#667788",
+  textNormal: "#8899aa",
+  damage: "#ff4444",
+  heal: "#44dd66",
+  kill: "#ffcc44",
+  event: "#44aaff"
+};
+
+// --- damage direction indicators ---
+var indicators = [];
+var indicatorContainer = null;
+
+function ensureIndicatorContainer() {
+  if (indicatorContainer) return;
+  indicatorContainer = document.createElement("div");
+  indicatorContainer.style.cssText = [
+    "position:fixed", "top:0", "left:0", "width:100%", "height:100%",
+    "pointer-events:none", "z-index:15"
+  ].join(";");
+  document.body.appendChild(indicatorContainer);
+}
+
+export function showDamageIndicator(angle) {
+  ensureIndicatorContainer();
+  var el = document.createElement("div");
+  // angle: radians, 0 = from front, PI = from behind
+  // map to screen edge position
+  var deg = ((angle * 180 / Math.PI) % 360 + 360) % 360;
+  var w = 120, h = 60;
+  var css = [
+    "position:absolute", "width:" + w + "px", "height:" + h + "px",
+    "pointer-events:none", "opacity:0.8",
+    "transition:opacity 0.3s"
+  ];
+
+  // position on screen edge based on angle
+  if (deg >= 315 || deg < 45) {
+    // top (hit from front)
+    css.push("top:0", "left:50%", "transform:translateX(-50%)");
+    css.push("background:linear-gradient(to bottom, rgba(255,50,50,0.6), transparent)");
+  } else if (deg >= 45 && deg < 135) {
+    // right
+    css.push("top:50%", "right:0", "transform:translateY(-50%)");
+    css.push("width:" + h + "px", "height:" + w + "px");
+    css.push("background:linear-gradient(to left, rgba(255,50,50,0.6), transparent)");
+  } else if (deg >= 135 && deg < 225) {
+    // bottom
+    css.push("bottom:0", "left:50%", "transform:translateX(-50%)");
+    css.push("background:linear-gradient(to top, rgba(255,50,50,0.6), transparent)");
+  } else {
+    // left
+    css.push("top:50%", "left:0", "transform:translateY(-50%)");
+    css.push("width:" + h + "px", "height:" + w + "px");
+    css.push("background:linear-gradient(to right, rgba(255,50,50,0.6), transparent)");
+  }
+
+  el.style.cssText = css.join(";");
+  indicatorContainer.appendChild(el);
+  indicators.push({ el: el, life: 0.5 });
+}
+
+export function updateIndicators(dt) {
+  var alive = [];
+  for (var i = 0; i < indicators.length; i++) {
+    var ind = indicators[i];
+    ind.life -= dt;
+    if (ind.life <= 0) {
+      if (ind.el.parentNode) ind.el.parentNode.removeChild(ind.el);
+    } else {
+      ind.el.style.opacity = String(Math.min(0.8, ind.life / 0.3));
+      alive.push(ind);
+    }
+  }
+  indicators = alive;
+}
+
+// --- floating damage numbers ---
+var floatingNumbers = [];
+var numberContainer = null;
+
+function ensureNumberContainer() {
+  if (numberContainer) return;
+  numberContainer = document.createElement("div");
+  numberContainer.style.cssText = [
+    "position:fixed", "top:0", "left:0", "width:100%", "height:100%",
+    "pointer-events:none", "z-index:16", "overflow:hidden"
+  ].join(";");
+  document.body.appendChild(numberContainer);
+}
+
+export function showFloatingNumber(screenX, screenY, text, color) {
+  ensureNumberContainer();
+  var el = document.createElement("div");
+  el.textContent = text;
+  el.style.cssText = [
+    "position:absolute", "font-family:monospace", "font-weight:bold",
+    "font-size:16px", "color:" + (color || COLORS.damage),
+    "text-shadow:0 0 6px " + (color || COLORS.damage),
+    "pointer-events:none", "white-space:nowrap",
+    "left:" + screenX + "px", "top:" + screenY + "px",
+    "transform:translate(-50%,-50%)"
+  ].join(";");
+  numberContainer.appendChild(el);
+  floatingNumbers.push({ el: el, life: 1.0, startY: screenY });
+}
+
+export function updateFloatingNumbers(dt) {
+  var alive = [];
+  for (var i = 0; i < floatingNumbers.length; i++) {
+    var num = floatingNumbers[i];
+    num.life -= dt;
+    if (num.life <= 0) {
+      if (num.el.parentNode) num.el.parentNode.removeChild(num.el);
+    } else {
+      var progress = 1 - num.life;
+      var yOffset = progress * 40;
+      num.el.style.top = (num.startY - yOffset) + "px";
+      num.el.style.opacity = String(Math.min(1, num.life / 0.3));
+      var scale = 1 + progress * 0.3;
+      num.el.style.transform = "translate(-50%,-50%) scale(" + scale + ")";
+      alive.push(num);
+    }
+  }
+  floatingNumbers = alive;
+}
+
+// --- kill feed ---
+var killFeedContainer = null;
+var killFeedItems = [];
+var MAX_FEED_ITEMS = 5;
+
+function ensureKillFeed() {
+  if (killFeedContainer) return;
+  killFeedContainer = document.createElement("div");
+  killFeedContainer.style.cssText = [
+    "position:fixed", "bottom:20px", "right:20px",
+    "font-family:monospace", "font-size:12px",
+    "pointer-events:none", "z-index:10",
+    "display:flex", "flex-direction:column-reverse", "gap:3px",
+    "max-width:280px"
+  ].join(";");
+  document.body.appendChild(killFeedContainer);
+}
+
+export function addKillFeedEntry(text, color) {
+  ensureKillFeed();
+  var el = document.createElement("div");
+  el.textContent = text;
+  el.style.cssText = [
+    "padding:3px 8px", "background:" + COLORS.bg,
+    "border:1px solid " + COLORS.border, "border-radius:3px",
+    "color:" + (color || COLORS.textNormal),
+    "opacity:1", "transition:opacity 0.3s",
+    "white-space:nowrap", "overflow:hidden", "text-overflow:ellipsis"
+  ].join(";");
+  killFeedContainer.appendChild(el);
+  killFeedItems.push({ el: el, life: 5.0 });
+
+  // limit visible items
+  while (killFeedItems.length > MAX_FEED_ITEMS) {
+    var old = killFeedItems.shift();
+    if (old.el.parentNode) old.el.parentNode.removeChild(old.el);
+  }
+}
+
+export function updateKillFeed(dt) {
+  var alive = [];
+  for (var i = 0; i < killFeedItems.length; i++) {
+    var item = killFeedItems[i];
+    item.life -= dt;
+    if (item.life <= 0) {
+      if (item.el.parentNode) item.el.parentNode.removeChild(item.el);
+    } else {
+      item.el.style.opacity = String(Math.min(1, item.life / 0.5));
+      alive.push(item);
+    }
+  }
+  killFeedItems = alive;
+}
+
+// --- fade transition overlay ---
+var fadeOverlay = null;
+var fadeState = { active: false, direction: "in", progress: 0, duration: 0.5, callback: null };
+
+function ensureFadeOverlay() {
+  if (fadeOverlay) return;
+  fadeOverlay = document.createElement("div");
+  fadeOverlay.style.cssText = [
+    "position:fixed", "top:0", "left:0", "width:100%", "height:100%",
+    "background:#0a0e1a", "pointer-events:none", "z-index:200",
+    "opacity:0"
+  ].join(";");
+  document.body.appendChild(fadeOverlay);
+}
+
+export function fadeOut(duration, callback) {
+  ensureFadeOverlay();
+  fadeState.active = true;
+  fadeState.direction = "out";
+  fadeState.progress = 0;
+  fadeState.duration = duration || 0.5;
+  fadeState.callback = callback || null;
+}
+
+export function fadeIn(duration, callback) {
+  ensureFadeOverlay();
+  fadeState.active = true;
+  fadeState.direction = "in";
+  fadeState.progress = 0;
+  fadeState.duration = duration || 0.5;
+  fadeState.callback = callback || null;
+  fadeOverlay.style.opacity = "1";
+}
+
+export function updateFade(dt) {
+  if (!fadeState.active || !fadeOverlay) return;
+  fadeState.progress += dt;
+  var t = Math.min(1, fadeState.progress / fadeState.duration);
+  if (fadeState.direction === "out") {
+    fadeOverlay.style.opacity = String(t);
+  } else {
+    fadeOverlay.style.opacity = String(1 - t);
+  }
+  if (t >= 1) {
+    fadeState.active = false;
+    if (fadeState.callback) fadeState.callback();
+  }
+}
+
+// --- screen shake state ---
+var shakeState = { offsetX: 0, offsetY: 0, intensity: 0, decay: 8 };
+
+export function triggerScreenShake(intensity) {
+  shakeState.intensity = Math.max(shakeState.intensity, intensity);
+}
+
+export function updateScreenShake(dt) {
+  if (shakeState.intensity < 0.01) {
+    shakeState.intensity = 0;
+    shakeState.offsetX = 0;
+    shakeState.offsetY = 0;
+    return shakeState;
+  }
+  shakeState.offsetX = (Math.random() - 0.5) * 2 * shakeState.intensity;
+  shakeState.offsetY = (Math.random() - 0.5) * 2 * shakeState.intensity;
+  shakeState.intensity *= Math.exp(-shakeState.decay * dt);
+  return shakeState;
+}
+
+export function getShakeOffset() {
+  return shakeState;
+}
+
+// --- update all UI effects ---
+export function updateUIEffects(dt) {
+  updateIndicators(dt);
+  updateFloatingNumbers(dt);
+  updateKillFeed(dt);
+  updateFade(dt);
+  updateScreenShake(dt);
+}


### PR DESCRIPTION
Closes #18

## Acceptance Criteria

- [x] HUD layout: HP bar (top-left), ammo/weapons (bottom), minimap (top-right), wave info (top-center)
- [x] Minimap: shows player, enemies, pickups as dots on radar-style circle
- [x] Damage indicators: screen edge flash in direction of hit
- [x] Kill feed: small text log of recent events (bottom-right)
- [x] Floating damage numbers on hit
- [x] Screen shake on big hits
- [x] Smooth transitions between game states (fade in/out)
- [x] Consistent color scheme and typography

## Changes

- **js/hud.js** — Complete rewrite: HP bar (top-left), wave info (top-center), minimap (top-right), weapons/ammo (bottom-center), ability (bottom-left). Shared color palette constants.
- **js/minimap.js** — New: radar-style canvas 2D minimap showing player (white triangle), enemies (red dots), pickups (green dots), ports (blue squares).
- **js/uiEffects.js** — New: damage direction indicators, floating damage numbers, kill feed, screen shake, fade transitions.
- **js/main.js** — Wire up minimap, damage indicators, floating numbers, kill feed, screen shake, and fade transitions.
- **js/enemy.js** — Added `onHitCallback` for floating damage numbers.