### PR TITLE
Art: Ocean shader upgrade — Fresnel, normal maps, shore foam

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,5 @@
 import * as THREE from "three";
-import { createOcean, updateOcean, getWaveHeight } from "./ocean.js";
+import { createOcean, updateOcean, getWaveHeight, setTerrainMap, clearTerrainMap } from "./ocean.js";
 import { createCamera, updateCamera, resizeCamera } from "./camera.js";
 import { createShip, updateShip, getSpeedRatio, getDisplaySpeed } from "./ship.js";
 import { initInput, getInput, getMouse, consumeClick, getKeyActions, getAutofire, toggleAutofire, setAutofire } from "./input.js";
@@ -285,11 +285,12 @@ function startMultiplayerCombat() {
   resetSendState();
   if (activeBoss) { removeBoss(activeBoss, scene); activeBoss = null; }
   hideBossHud();
-  if (activeTerrain) { removeTerrain(activeTerrain, scene); activeTerrain = null; }
+  if (activeTerrain) { removeTerrain(activeTerrain, scene); clearTerrainMap(ocean.uniforms); activeTerrain = null; }
   // Use shared terrain seed for deterministic terrain
   var seed = mpState.terrainSeed || Math.floor(Math.random() * 999999);
   activeTerrain = createTerrain(seed, 2);
   scene.add(activeTerrain.mesh);
+  setTerrainMap(ocean.uniforms, activeTerrain);
   clearPorts(portMgr, scene);
   initPorts(portMgr, activeTerrain, scene);
   clearCrates(crateMgr, scene);
@@ -353,13 +354,14 @@ function startZoneCombat(classKey, zoneId) {
   resetCrew(crew);
   if (activeBoss) { removeBoss(activeBoss, scene); activeBoss = null; }
   hideBossHud();
-  if (activeTerrain) { removeTerrain(activeTerrain, scene); activeTerrain = null; }
+  if (activeTerrain) { removeTerrain(activeTerrain, scene); clearTerrainMap(ocean.uniforms); activeTerrain = null; }
   // generate terrain: seed from zone id hash + random, difficulty scales land coverage
   var terrainSeed = 0;
   for (var si = 0; si < zoneId.length; si++) terrainSeed += zoneId.charCodeAt(si) * (si + 1);
   terrainSeed += Math.floor(Math.random() * 10000);
   activeTerrain = createTerrain(terrainSeed, zone.difficulty);
   scene.add(activeTerrain.mesh);
+  setTerrainMap(ocean.uniforms, activeTerrain);
   clearPorts(portMgr, scene);
   initPorts(portMgr, activeTerrain, scene);
   clearCrates(crateMgr, scene);
@@ -445,7 +447,7 @@ setRestartCallback(function () {
   hideBossHud();
   clearPorts(portMgr, scene);
   clearCrates(crateMgr, scene);
-  if (activeTerrain) { removeTerrain(activeTerrain, scene); activeTerrain = null; }
+  if (activeTerrain) { removeTerrain(activeTerrain, scene); clearTerrainMap(ocean.uniforms); activeTerrain = null; }
   if (ship) {
     // Find safe water spawn — don't place on land
     if (activeTerrain) {


### PR DESCRIPTION
Closes #67

## Summary
Upgrades the ocean shader from flat color bands to a visually rich water surface with procedural scrolling normal maps, Fresnel reflections, enhanced specular highlights, animated shore foam, and improved wave crest whitecaps — all while preserving day/night and weather system integration.

### Changes
- **ocean.js**: Rewrote fragment shader with procedural 2-layer gradient noise for scrolling normal maps, normal-perturbed Fresnel and specular, terrain heightmap-based shore foam, multi-octave whitecap noise. Added `setTerrainMap()` / `clearTerrainMap()` to pass terrain heightmap as a DataTexture uniform.
- **main.js**: Import and call `setTerrainMap` / `clearTerrainMap` at terrain create/remove sites (zone combat, multiplayer, restart).

## Acceptance Criteria
- [x] Ocean has visible surface detail — not flat color bands
- [x] Fresnel reflection effect (sky color at glancing angles)
- [x] Specular sun/moon highlights on water
- [x] Shore foam where water meets terrain (animated)
- [x] Foam/whitecaps on wave crests in rough weather
- [x] Day/night system still functions (color palette shifts with time)
- [x] Weather system still functions (wave amp, fog, dimming)
- [ ] 60fps maintained at default camera zoom
- [x] Looks good at bird's-eye angle (horizontal detail > vertical)

## Test plan
- [ ] Load the game and verify ocean surface shows scrolling ripple detail (not flat bands)
- [ ] Observe Fresnel effect: water edges/horizon should blend toward sky color
- [ ] Check sun/moon specular highlights shimmer on the water surface
- [ ] Enter a zone with terrain and verify white foam appears at shorelines
- [ ] Change weather to storm and verify whitecaps increase on wave crests
- [ ] Watch day/night cycle — water colors should shift appropriately
- [ ] Verify 60fps on default zoom (check with browser dev tools FPS counter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)