### PR TITLE
Art: Terrain rebalance — open ocean, small islands, fog boundaries

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -30,7 +30,7 @@ import { createCrewState, resetCrew, generateOfficerReward, addOfficer, getCrewB
 import { createCrewScreen, showCrewScreen, hideCrewScreen } from "./crewScreen.js";
 import { loadTechState, getTechBonuses } from "./techTree.js";
 import { createTechScreen, showTechScreen, hideTechScreen } from "./techScreen.js";
-import { createTerrain, removeTerrain, collideWithTerrain, isLand, findWaterPosition } from "./terrain.js";
+import { createTerrain, removeTerrain, collideWithTerrain, isLand, findWaterPosition, getEdgeFactor } from "./terrain.js";
 import { createPortManager, initPorts, clearPorts, updatePorts, getPortsInfo } from "./port.js";
 import { createCrateManager, clearCrates, updateCrates } from "./crate.js";
 import { createMultiplayerState, createRoom, joinRoom, setReady, setShipClass, startGame, allPlayersReady, leaveRoom, isMultiplayerActive, broadcast, getPlayerCount } from "./multiplayer.js";
@@ -543,6 +543,11 @@ function animate() {
     var wDim = getWeatherDim(weather);
     var lightDim = weather.lightningActive ? 3.0 : wDim;
     applyDayNight(dayNight, ambient, sun, hemi, scene.fog, renderer, lightDim);
+    // edge fog: increase fog density as ship approaches map boundary
+    var edgeFog = getEdgeFactor(ship.posX, ship.posZ);
+    if (edgeFog > 0) {
+      scene.fog.density += edgeFog * 0.04;  // layer on top of day/night fog
+    }
     updateStars(stars, dayNight.timeOfDay);
     // ocean must update before ships so wave height is current-frame
     updateOcean(ocean.uniforms, elapsed, wp.waveAmplitude, wp.waterTint, dayNight, cam.camera, wDim, getWeatherFoam(weather), getWeatherCloudShadow(weather));

--- a/js/ship.js
+++ b/js/ship.js
@@ -1,7 +1,7 @@
 // ship.js — procedural ship model, physics state, update loop
 import * as THREE from "three";
 import { buildClassMesh } from "./shipModels.js";
-import { collideWithTerrain } from "./terrain.js";
+import { collideWithTerrain, applyEdgeBoundary } from "./terrain.js";
 
 // --- default physics tuning (used as fallback) ---
 var DEFAULT_MAX_SPEED = 10;
@@ -231,6 +231,14 @@ export function updateShip(ship, input, dt, getWaveHeight, elapsed, fuelMult, up
       ship.speed *= -0.3;  // bounce back
       if (ship.navTarget) ship.navTarget = null;  // cancel nav on collision
     }
+  }
+
+  // map edge boundary — soft push-back toward center
+  var edge = applyEdgeBoundary(ship.posX, ship.posZ);
+  if (edge.pushed) {
+    ship.posX = edge.posX;
+    ship.posZ = edge.posZ;
+    ship.speed *= 0.95;  // gentle slowdown near edge
   }
 
   ship.mesh.position.x = ship.posX;


### PR DESCRIPTION
Closes #68

## Acceptance Criteria

- [x] Map is 90%+ open ocean
- [x] Islands are small and scattered (archipelago feel)
- [x] No thick land border at map edges
- [x] Soft fog boundary at map edges (or open horizon)
- [x] Player cannot sail infinitely — soft boundary pushes back or blocks
- [x] Spawn area is clear open water
- [x] Islands still provide tactical cover (ship/projectile collision works)
- [x] Terrain difficulty scaling still works (more complex later waves)
- [x] Supply ports (#36) still place correctly on island coastlines
- [x] Flood-fill navigability guarantee still holds