### PR TITLE
Art: Ship model quality — materials, detail, silhouettes

### DIFF
--- a/js/bossModels.js
+++ b/js/bossModels.js
@@ -1,55 +1,142 @@
 // bossModels.js — unique procedural 3D models for boss enemies
 import * as THREE from "three";
 
-// --- build battleship boss mesh (large, armored) ---
+// --- shared boss materials ---
+var metalMat = null;
+var glassMat = null;
+
+function ensureBossMats() {
+  if (metalMat) return;
+  metalMat = new THREE.MeshStandardMaterial({ color: 0x888899, roughness: 0.3, metalness: 0.8 });
+  glassMat = new THREE.MeshStandardMaterial({
+    color: 0x1a2a3a, roughness: 0.1, metalness: 0.5,
+    emissive: 0x1a2a3a, emissiveIntensity: 0
+  });
+}
+
+function addBossNavLights(group, x, y, z) {
+  var portMat = new THREE.MeshBasicMaterial({ color: 0xff0000 });
+  var stbdMat = new THREE.MeshBasicMaterial({ color: 0x00ff00 });
+  var lightGeo = new THREE.SphereGeometry(0.06, 4, 3);
+  var port = new THREE.Mesh(lightGeo, portMat);
+  port.position.set(-x, y, z);
+  group.add(port);
+  var stbd = new THREE.Mesh(lightGeo, stbdMat);
+  stbd.position.set(x, y, z);
+  group.add(stbd);
+}
+
+function addBossRadar(group, x, y, z) {
+  ensureBossMats();
+  var dishGeo = new THREE.CylinderGeometry(0.25, 0.25, 0.03, 8);
+  var dish = new THREE.Mesh(dishGeo, metalMat);
+  dish.position.set(x, y, z);
+  group.add(dish);
+  var armGeo = new THREE.CylinderGeometry(0.015, 0.015, 0.2, 3);
+  var arm = new THREE.Mesh(armGeo, metalMat);
+  arm.position.set(x, y - 0.1, z);
+  group.add(arm);
+}
+
+function addBossWindows(group, bx, by, bz, width, height) {
+  ensureBossMats();
+  var winGeo = new THREE.PlaneGeometry(width * 0.8, height * 0.3);
+  var winF = new THREE.Mesh(winGeo, glassMat);
+  winF.position.set(bx, by + height * 0.1, bz + height * 0.52);
+  group.add(winF);
+  var winSideGeo = new THREE.PlaneGeometry(height * 0.5, height * 0.3);
+  var winL = new THREE.Mesh(winSideGeo, glassMat);
+  winL.rotation.y = Math.PI / 2;
+  winL.position.set(bx - width * 0.52, by + height * 0.1, bz);
+  group.add(winL);
+  var winR = new THREE.Mesh(winSideGeo, glassMat);
+  winR.rotation.y = -Math.PI / 2;
+  winR.position.set(bx + width * 0.52, by + height * 0.1, bz);
+  group.add(winR);
+}
+
+// --- build battleship boss mesh (large, armored, imposing) ---
 function buildBattleshipMesh() {
+  ensureBossMats();
   var group = new THREE.Group();
 
+  // hull — smooth, massive curves
   var hullShape = new THREE.Shape();
-  hullShape.moveTo(0, 5.0);
-  hullShape.lineTo(1.4, 2.5);
-  hullShape.lineTo(1.6, 0);
-  hullShape.lineTo(1.4, -3.0);
-  hullShape.lineTo(0.8, -4.5);
-  hullShape.lineTo(-0.8, -4.5);
-  hullShape.lineTo(-1.4, -3.0);
-  hullShape.lineTo(-1.6, 0);
-  hullShape.lineTo(-1.4, 2.5);
-  hullShape.lineTo(0, 5.0);
+  hullShape.moveTo(0, 5.5);
+  hullShape.bezierCurveTo(0.5, 4.5, 1.0, 3.5, 1.4, 2.5);
+  hullShape.bezierCurveTo(1.6, 1.5, 1.7, 0.5, 1.7, 0);
+  hullShape.bezierCurveTo(1.7, -1.0, 1.6, -2.0, 1.4, -3.0);
+  hullShape.bezierCurveTo(1.2, -3.8, 0.9, -4.3, 0, -5.0);
+  hullShape.bezierCurveTo(-0.9, -4.3, -1.2, -3.8, -1.4, -3.0);
+  hullShape.bezierCurveTo(-1.6, -2.0, -1.7, -1.0, -1.7, 0);
+  hullShape.bezierCurveTo(-1.7, 0.5, -1.6, 1.5, -1.4, 2.5);
+  hullShape.bezierCurveTo(-1.0, 3.5, -0.5, 4.5, 0, 5.5);
 
-  var hullGeo = new THREE.ExtrudeGeometry(hullShape, { depth: 1.0, bevelEnabled: false });
-  var hullMat = new THREE.MeshLambertMaterial({ color: 0x664433 });
+  var hullGeo = new THREE.ExtrudeGeometry(hullShape, {
+    depth: 1.1, bevelEnabled: true, bevelThickness: 0.08, bevelSize: 0.05, bevelSegments: 2
+  });
+  var hullMat = new THREE.MeshStandardMaterial({ color: 0x5a3a28, roughness: 0.65, metalness: 0.15 });
   var hull = new THREE.Mesh(hullGeo, hullMat);
   hull.rotation.x = -Math.PI / 2;
   hull.position.y = -0.2;
   group.add(hull);
 
-  var deckGeo = new THREE.PlaneGeometry(2.6, 8.0);
-  var deckMat = new THREE.MeshLambertMaterial({ color: 0x775544 });
+  // waterline
+  var wlGeo = new THREE.PlaneGeometry(3.0, 9.5);
+  var wlMat = new THREE.MeshStandardMaterial({ color: 0x1a0808, roughness: 0.9, metalness: 0 });
+  var wl = new THREE.Mesh(wlGeo, wlMat);
+  wl.rotation.x = -Math.PI / 2;
+  wl.position.set(0, 0.01, 0);
+  group.add(wl);
+
+  // deck
+  var deckGeo = new THREE.PlaneGeometry(2.8, 8.5);
+  var deckMat = new THREE.MeshStandardMaterial({ color: 0x6a4a38, roughness: 0.5, metalness: 0.05 });
   var deck = new THREE.Mesh(deckGeo, deckMat);
   deck.rotation.x = -Math.PI / 2;
-  deck.position.y = 0.8;
+  deck.position.y = 0.9;
   group.add(deck);
 
-  // massive bridge
-  var bridgeGeo = new THREE.BoxGeometry(1.4, 1.4, 1.8);
-  var bridgeMat = new THREE.MeshLambertMaterial({ color: 0x886655 });
+  // massive bridge — two tiers
+  var bridgeGeo = new THREE.BoxGeometry(1.4, 1.2, 1.6);
+  var bridgeMat = new THREE.MeshStandardMaterial({ color: 0x7a5a48, roughness: 0.45, metalness: 0.2 });
   var bridge = new THREE.Mesh(bridgeGeo, bridgeMat);
   bridge.position.set(0, 1.5, -1.5);
   group.add(bridge);
+  var upperBridgeGeo = new THREE.BoxGeometry(1.0, 0.6, 1.0);
+  var upperBridge = new THREE.Mesh(upperBridgeGeo, bridgeMat);
+  upperBridge.position.set(0, 2.4, -1.5);
+  group.add(upperBridge);
+  addBossWindows(group, 0, 1.5, -1.5, 1.4, 1.2);
 
-  // broadside turrets (4 total)
-  var turretGeo = new THREE.CylinderGeometry(0.3, 0.4, 0.4, 6);
-  var turretMat = new THREE.MeshLambertMaterial({ color: 0x553322 });
-  var barrelGeo = new THREE.CylinderGeometry(0.06, 0.06, 1.0, 4);
-  var barrelMat = new THREE.MeshLambertMaterial({ color: 0x442211 });
+  // smokestacks (twin)
+  var stackMat = new THREE.MeshStandardMaterial({ color: 0x333333, roughness: 0.6, metalness: 0.3 });
+  for (var si = 0; si < 2; si++) {
+    var stackGeo = new THREE.CylinderGeometry(0.18, 0.22, 0.8, 8);
+    var stack = new THREE.Mesh(stackGeo, stackMat);
+    stack.position.set(0, 1.3, -0.3 - si * 1.2);
+    group.add(stack);
+  }
+
+  // radar mast
+  var mastGeo = new THREE.CylinderGeometry(0.025, 0.035, 1.8, 4);
+  var mast = new THREE.Mesh(mastGeo, metalMat);
+  mast.position.set(0, 2.8, -1.5);
+  group.add(mast);
+  addBossRadar(group, 0, 3.7, -1.5);
+
+  // broadside turrets (4 total) — larger, more imposing
+  var turretGeo = new THREE.CylinderGeometry(0.35, 0.45, 0.4, 8);
+  var turretMat = new THREE.MeshStandardMaterial({ color: 0x4a2a1a, roughness: 0.35, metalness: 0.7 });
+  var barrelGeo = new THREE.CylinderGeometry(0.06, 0.07, 1.1, 6);
+  var barrelMat = new THREE.MeshStandardMaterial({ color: 0x3a2010, roughness: 0.3, metalness: 0.8 });
 
   var turrets = [];
   var turretPositions = [
-    [0, 1.0, 2.5],
-    [0, 1.0, 0.5],
-    [0, 1.0, -0.5],
-    [0, 1.0, -3.0]
+    [0, 1.1, 3.0],
+    [0, 1.1, 1.0],
+    [0, 1.1, -0.2],
+    [0, 1.1, -3.5]
   ];
   for (var i = 0; i < turretPositions.length; i++) {
     var t = new THREE.Group();
@@ -57,147 +144,209 @@ function buildBattleshipMesh() {
     t.add(new THREE.Mesh(turretGeo, turretMat));
     var b = new THREE.Mesh(barrelGeo, barrelMat);
     b.rotation.x = Math.PI / 2;
-    b.position.set(0, 0.15, 0.5);
+    b.position.set(0, 0.15, 0.55);
     t.add(b);
     group.add(t);
     turrets.push(t);
   }
 
-  // armor plating (decorative boxes along sides)
-  var plateMat = new THREE.MeshLambertMaterial({ color: 0x554433 });
+  // armor plating (decorative strips along sides)
+  var plateMat = new THREE.MeshStandardMaterial({ color: 0x4a3828, roughness: 0.5, metalness: 0.4 });
   for (var side = -1; side <= 1; side += 2) {
-    for (var pi = 0; pi < 3; pi++) {
+    for (var pi = 0; pi < 4; pi++) {
       var plate = new THREE.Mesh(
-        new THREE.BoxGeometry(0.2, 0.6, 1.5),
+        new THREE.BoxGeometry(0.2, 0.65, 1.6),
         plateMat
       );
-      plate.position.set(side * 1.3, 0.6, pi * 2.5 - 2.0);
+      plate.position.set(side * 1.4, 0.65, pi * 2.2 - 2.5);
       group.add(plate);
     }
   }
 
   group.userData.turrets = turrets;
+
+  addBossNavLights(group, 1.5, 0.9, 3.0);
+
   return group;
 }
 
 // --- build carrier boss mesh (large flat deck, hangars) ---
 function buildCarrierBossMesh() {
+  ensureBossMats();
   var group = new THREE.Group();
 
+  // hull — massive smooth carrier
   var hullShape = new THREE.Shape();
-  hullShape.moveTo(0, 5.5);
-  hullShape.lineTo(1.8, 2.5);
-  hullShape.lineTo(2.0, 0);
-  hullShape.lineTo(1.8, -3.5);
-  hullShape.lineTo(1.2, -5.0);
-  hullShape.lineTo(-1.2, -5.0);
-  hullShape.lineTo(-1.8, -3.5);
-  hullShape.lineTo(-2.0, 0);
-  hullShape.lineTo(-1.8, 2.5);
-  hullShape.lineTo(0, 5.5);
+  hullShape.moveTo(0, 6.0);
+  hullShape.bezierCurveTo(0.6, 5.0, 1.2, 4.0, 1.8, 2.5);
+  hullShape.bezierCurveTo(2.0, 1.5, 2.1, 0.5, 2.1, 0);
+  hullShape.bezierCurveTo(2.1, -1.5, 2.0, -3.0, 1.8, -3.8);
+  hullShape.bezierCurveTo(1.5, -4.5, 1.0, -5.0, 0, -5.5);
+  hullShape.bezierCurveTo(-1.0, -5.0, -1.5, -4.5, -1.8, -3.8);
+  hullShape.bezierCurveTo(-2.0, -3.0, -2.1, -1.5, -2.1, 0);
+  hullShape.bezierCurveTo(-2.1, 0.5, -2.0, 1.5, -1.8, 2.5);
+  hullShape.bezierCurveTo(-1.2, 4.0, -0.6, 5.0, 0, 6.0);
 
-  var hullGeo = new THREE.ExtrudeGeometry(hullShape, { depth: 1.0, bevelEnabled: false });
-  var hullMat = new THREE.MeshLambertMaterial({ color: 0x335533 });
+  var hullGeo = new THREE.ExtrudeGeometry(hullShape, {
+    depth: 1.1, bevelEnabled: true, bevelThickness: 0.08, bevelSize: 0.05, bevelSegments: 2
+  });
+  var hullMat = new THREE.MeshStandardMaterial({ color: 0x2a4a2a, roughness: 0.65, metalness: 0.15 });
   var hull = new THREE.Mesh(hullGeo, hullMat);
   hull.rotation.x = -Math.PI / 2;
   hull.position.y = -0.2;
   group.add(hull);
 
+  // waterline
+  var wlGeo = new THREE.PlaneGeometry(3.8, 10.5);
+  var wlMat = new THREE.MeshStandardMaterial({ color: 0x0a1a0a, roughness: 0.9, metalness: 0 });
+  var wl = new THREE.Mesh(wlGeo, wlMat);
+  wl.rotation.x = -Math.PI / 2;
+  wl.position.set(0, 0.01, 0);
+  group.add(wl);
+
   // flight deck
-  var deckGeo = new THREE.PlaneGeometry(3.4, 9.0);
-  var deckMat = new THREE.MeshLambertMaterial({ color: 0x446644 });
+  var deckGeo = new THREE.PlaneGeometry(3.6, 10.0);
+  var deckMat = new THREE.MeshStandardMaterial({ color: 0x3a5a3a, roughness: 0.5, metalness: 0.05 });
   var deck = new THREE.Mesh(deckGeo, deckMat);
   deck.rotation.x = -Math.PI / 2;
-  deck.position.y = 0.9;
+  deck.position.y = 1.0;
   group.add(deck);
 
   // runway stripes
+  var stripeMat = new THREE.MeshStandardMaterial({ color: 0xccccaa, roughness: 0.8, metalness: 0 });
   for (var s = 0; s < 3; s++) {
-    var stripeGeo = new THREE.PlaneGeometry(0.08, 6.0);
-    var stripeMat = new THREE.MeshLambertMaterial({ color: 0xccccaa });
+    var stripeGeo = new THREE.PlaneGeometry(0.08, 7.0);
     var stripe = new THREE.Mesh(stripeGeo, stripeMat);
     stripe.rotation.x = -Math.PI / 2;
-    stripe.position.set((s - 1) * 0.8, 0.91, 0);
+    stripe.position.set((s - 1) * 0.9, 1.01, 0);
     group.add(stripe);
   }
 
-  // island
-  var bridgeGeo = new THREE.BoxGeometry(0.8, 1.2, 1.2);
-  var bridgeMat = new THREE.MeshLambertMaterial({ color: 0x557755 });
+  // island tower (starboard side)
+  var bridgeGeo = new THREE.BoxGeometry(0.9, 1.4, 1.4);
+  var bridgeMat = new THREE.MeshStandardMaterial({ color: 0x4a6a4a, roughness: 0.45, metalness: 0.2 });
   var bridgeIs = new THREE.Mesh(bridgeGeo, bridgeMat);
-  bridgeIs.position.set(1.2, 1.5, -1.5);
+  bridgeIs.position.set(1.4, 1.7, -1.5);
   group.add(bridgeIs);
+  addBossWindows(group, 1.4, 1.7, -1.5, 0.9, 1.4);
+
+  // radar mast on island
+  var mastGeo = new THREE.CylinderGeometry(0.02, 0.03, 1.5, 4);
+  var mast = new THREE.Mesh(mastGeo, metalMat);
+  mast.position.set(1.4, 2.6, -1.5);
+  group.add(mast);
+  addBossRadar(group, 1.4, 3.4, -1.5);
 
   // hangar bays
-  var hangarMat = new THREE.MeshLambertMaterial({ color: 0x334433 });
+  var hangarMat = new THREE.MeshStandardMaterial({ color: 0x2a3a2a, roughness: 0.6, metalness: 0.1 });
   for (var h = 0; h < 2; h++) {
-    var hangar = new THREE.Mesh(new THREE.BoxGeometry(1.0, 0.5, 1.5), hangarMat);
-    hangar.position.set(0, 0.7, h * 3.0 - 0.5);
+    var hangar = new THREE.Mesh(new THREE.BoxGeometry(1.2, 0.6, 1.8), hangarMat);
+    hangar.position.set(0, 0.8, h * 3.5 - 0.5);
     group.add(hangar);
   }
 
   // defensive turrets
-  var turretGeo = new THREE.CylinderGeometry(0.25, 0.3, 0.3, 6);
-  var turretMat = new THREE.MeshLambertMaterial({ color: 0x334433 });
-  var barrelGeo = new THREE.CylinderGeometry(0.04, 0.04, 0.7, 4);
-  var barrelMat = new THREE.MeshLambertMaterial({ color: 0x223322 });
+  var turretGeo = new THREE.CylinderGeometry(0.28, 0.35, 0.3, 8);
+  var turretMat = new THREE.MeshStandardMaterial({ color: 0x2a4a2a, roughness: 0.35, metalness: 0.7 });
+  var barrelGeo = new THREE.CylinderGeometry(0.04, 0.04, 0.8, 6);
+  var barrelMat = new THREE.MeshStandardMaterial({ color: 0x1a3a1a, roughness: 0.3, metalness: 0.8 });
 
   var turrets = [];
-  var tPos = [[0, 1.0, 3.0], [0, 1.0, -3.5]];
+  var tPos = [[0, 1.1, 3.5], [0, 1.1, -4.0]];
   for (var i = 0; i < tPos.length; i++) {
     var t = new THREE.Group();
     t.position.set(tPos[i][0], tPos[i][1], tPos[i][2]);
     t.add(new THREE.Mesh(turretGeo, turretMat));
     var b2 = new THREE.Mesh(barrelGeo, barrelMat);
     b2.rotation.x = Math.PI / 2;
-    b2.position.set(0, 0.1, 0.35);
+    b2.position.set(0, 0.1, 0.4);
     t.add(b2);
     group.add(t);
     turrets.push(t);
   }
 
   group.userData.turrets = turrets;
+
+  addBossNavLights(group, 1.8, 1.0, 4.0);
+
   return group;
 }
 
 // --- build kraken boss mesh (tentacles, non-ship) ---
 function buildKrakenMesh() {
+  ensureBossMats();
   var group = new THREE.Group();
 
-  // body — large sphere-ish mass
-  var bodyGeo = new THREE.SphereGeometry(2.5, 12, 8);
-  var bodyMat = new THREE.MeshLambertMaterial({ color: 0x553377 });
+  // body — large sphere-ish mass with PBR
+  var bodyGeo = new THREE.SphereGeometry(3.0, 16, 12);
+  var bodyMat = new THREE.MeshStandardMaterial({
+    color: 0x4a2868, roughness: 0.6, metalness: 0.15
+  });
   var body = new THREE.Mesh(bodyGeo, bodyMat);
   body.scale.set(1.0, 0.5, 1.2);
   body.position.y = 0.5;
   group.add(body);
 
-  // eyes
-  var eyeGeo = new THREE.SphereGeometry(0.4, 8, 6);
-  var eyeMat = new THREE.MeshBasicMaterial({ color: 0xffcc00 });
+  // mantle ridges (decorative bumps on top)
+  var ridgeMat = new THREE.MeshStandardMaterial({
+    color: 0x3a1a50, roughness: 0.5, metalness: 0.2
+  });
+  for (var ri = 0; ri < 5; ri++) {
+    var ridgeGeo = new THREE.SphereGeometry(0.6, 6, 4);
+    var ridge = new THREE.Mesh(ridgeGeo, ridgeMat);
+    ridge.scale.set(1.0, 0.3, 0.6);
+    ridge.position.set(
+      (ri - 2) * 0.8,
+      1.2,
+      0
+    );
+    group.add(ridge);
+  }
+
+  // eyes — larger, glowing
+  var eyeGeo = new THREE.SphereGeometry(0.5, 10, 8);
+  var eyeMat = new THREE.MeshStandardMaterial({
+    color: 0xffcc00, roughness: 0.2, metalness: 0.3,
+    emissive: 0xffaa00, emissiveIntensity: 0.8
+  });
   var eyeL = new THREE.Mesh(eyeGeo, eyeMat);
-  eyeL.position.set(-0.8, 1.0, 1.8);
+  eyeL.position.set(-1.0, 1.1, 2.2);
   group.add(eyeL);
   var eyeR = new THREE.Mesh(eyeGeo, eyeMat);
-  eyeR.position.set(0.8, 1.0, 1.8);
+  eyeR.position.set(1.0, 1.1, 2.2);
   group.add(eyeR);
+
+  // pupils
+  var pupilGeo = new THREE.SphereGeometry(0.2, 6, 4);
+  var pupilMat = new THREE.MeshStandardMaterial({ color: 0x110800, roughness: 0.9, metalness: 0 });
+  var pupilL = new THREE.Mesh(pupilGeo, pupilMat);
+  pupilL.position.set(-1.0, 1.1, 2.6);
+  group.add(pupilL);
+  var pupilR = new THREE.Mesh(pupilGeo, pupilMat);
+  pupilR.position.set(1.0, 1.1, 2.6);
+  group.add(pupilR);
 
   // tentacles (stored for animation)
   var tentacles = [];
-  var tentacleMat = new THREE.MeshLambertMaterial({ color: 0x664488 });
+  var tentacleMat = new THREE.MeshStandardMaterial({
+    color: 0x5a3078, roughness: 0.55, metalness: 0.1
+  });
+  var suckerMat = new THREE.MeshStandardMaterial({
+    color: 0x8a60aa, roughness: 0.7, metalness: 0.05
+  });
   for (var i = 0; i < 8; i++) {
     var angle = (i / 8) * Math.PI * 2;
     var tentGroup = new THREE.Group();
     tentGroup.position.set(
-      Math.sin(angle) * 2.0,
+      Math.sin(angle) * 2.4,
       0.2,
-      Math.cos(angle) * 2.0
+      Math.cos(angle) * 2.4
     );
 
-    // three segments per tentacle
+    // three segments per tentacle — tapered
     for (var s = 0; s < 3; s++) {
-      var radius = 0.3 - s * 0.08;
-      var segGeo = new THREE.CylinderGeometry(radius, radius + 0.05, 2.0, 6);
+      var radius = 0.35 - s * 0.1;
+      var segGeo = new THREE.CylinderGeometry(radius, radius + 0.06, 2.2, 8);
       var seg = new THREE.Mesh(segGeo, tentacleMat);
       seg.position.set(
         Math.sin(angle) * s * 1.5,
@@ -207,6 +356,20 @@ function buildKrakenMesh() {
       seg.rotation.z = angle + Math.PI / 2;
       seg.rotation.x = 0.3 * s;
       tentGroup.add(seg);
+
+      // sucker detail (small spheres along underside)
+      if (s < 2) {
+        for (var si = 0; si < 3; si++) {
+          var suckerGeo = new THREE.SphereGeometry(0.06, 4, 3);
+          var sucker = new THREE.Mesh(suckerGeo, suckerMat);
+          sucker.position.set(
+            Math.sin(angle) * (s * 1.5 + si * 0.4),
+            -s * 0.3 - 0.2,
+            Math.cos(angle) * (s * 1.5 + si * 0.4)
+          );
+          tentGroup.add(sucker);
+        }
+      }
     }
 
     group.add(tentGroup);

--- a/js/shipModels.js
+++ b/js/shipModels.js
@@ -1,220 +1,258 @@
 // shipModels.js — unique procedural 3D models for each ship class
 import * as THREE from "three";
+import {
+  ensureMaterials, getMetalMat, getHullMat, getDeckMat, getBridgeMat,
+  getTurretMat, getBarrelMat, addWaterline, addNavLights, addFlag,
+  addAnchor, addRadarDish, addBridgeWindows, addSmokestack
+} from "./shipParts.js";
 
-// --- Destroyer: sleek, narrow, fast-looking hull ---
+// --- Destroyer: sleek and narrow, low profile ---
 function buildDestroyerMesh() {
+  ensureMaterials();
   var group = new THREE.Group();
+  var metalMat = getMetalMat();
 
+  // hull — smoother curves with bezier
   var hullShape = new THREE.Shape();
-  hullShape.moveTo(0, 2.8);
-  hullShape.lineTo(0.5, 1.4);
-  hullShape.lineTo(0.6, 0);
-  hullShape.lineTo(0.55, -1.6);
-  hullShape.lineTo(0.3, -2.0);
-  hullShape.lineTo(-0.3, -2.0);
-  hullShape.lineTo(-0.55, -1.6);
-  hullShape.lineTo(-0.6, 0);
-  hullShape.lineTo(-0.5, 1.4);
-  hullShape.lineTo(0, 2.8);
+  hullShape.moveTo(0, 3.2);
+  hullShape.bezierCurveTo(0.15, 2.8, 0.4, 2.2, 0.52, 1.6);
+  hullShape.bezierCurveTo(0.6, 1.0, 0.65, 0.3, 0.65, 0);
+  hullShape.bezierCurveTo(0.65, -0.5, 0.62, -1.2, 0.55, -1.8);
+  hullShape.bezierCurveTo(0.45, -2.2, 0.3, -2.4, 0, -2.6);
+  hullShape.bezierCurveTo(-0.3, -2.4, -0.45, -2.2, -0.55, -1.8);
+  hullShape.bezierCurveTo(-0.62, -1.2, -0.65, -0.5, -0.65, 0);
+  hullShape.bezierCurveTo(-0.65, 0.3, -0.6, 1.0, -0.52, 1.6);
+  hullShape.bezierCurveTo(-0.4, 2.2, -0.15, 2.8, 0, 3.2);
 
-  var hullGeo = new THREE.ExtrudeGeometry(hullShape, { depth: 0.4, bevelEnabled: false });
-  var hullMat = new THREE.MeshLambertMaterial({ color: 0x3366aa });
-  var hull = new THREE.Mesh(hullGeo, hullMat);
+  var hullGeo = new THREE.ExtrudeGeometry(hullShape, {
+    depth: 0.45, bevelEnabled: true, bevelThickness: 0.05, bevelSize: 0.03, bevelSegments: 2
+  });
+  var hull = new THREE.Mesh(hullGeo, getHullMat(0x2e5a8c));
   hull.rotation.x = -Math.PI / 2;
   hull.position.y = -0.1;
   group.add(hull);
 
-  var deckGeo = new THREE.PlaneGeometry(0.9, 3.8);
-  var deckMat = new THREE.MeshLambertMaterial({ color: 0x4477aa });
-  var deck = new THREE.Mesh(deckGeo, deckMat);
+  addWaterline(group, 0.6, 5.2, 0.2);
+
+  // deck
+  var deckGeo = new THREE.PlaneGeometry(0.95, 4.6);
+  var deck = new THREE.Mesh(deckGeo, getDeckMat(0x3a6b9e));
   deck.rotation.x = -Math.PI / 2;
-  deck.position.y = 0.3;
-  deck.position.z = -0.1;
+  deck.position.set(0, 0.35, 0.1);
   group.add(deck);
 
-  // small bridge
-  var bridgeGeo = new THREE.BoxGeometry(0.5, 0.45, 0.6);
-  var bridgeMat = new THREE.MeshLambertMaterial({ color: 0x5588bb });
-  var bridge = new THREE.Mesh(bridgeGeo, bridgeMat);
-  bridge.position.set(0, 0.55, -0.5);
+  // bridge — compact, low
+  var bridgeGeo = new THREE.BoxGeometry(0.5, 0.4, 0.55);
+  var bridge = new THREE.Mesh(bridgeGeo, getBridgeMat(0x4a7aaa));
+  bridge.position.set(0, 0.55, -0.4);
   group.add(bridge);
+  addBridgeWindows(group, 0, 0.55, -0.4, 0.5, 0.4);
 
-  // turrets
-  var turretGeo = new THREE.CylinderGeometry(0.18, 0.22, 0.25, 6);
-  var turretMat = new THREE.MeshLambertMaterial({ color: 0x2255aa });
-  var barrelGeo = new THREE.CylinderGeometry(0.035, 0.035, 0.65, 4);
-  var barrelMat = new THREE.MeshLambertMaterial({ color: 0x224488 });
+  // radar mast
+  var mastGeo = new THREE.CylinderGeometry(0.012, 0.022, 0.9, 4);
+  var mast = new THREE.Mesh(mastGeo, metalMat);
+  mast.position.set(0, 1.05, -0.4);
+  group.add(mast);
+  addRadarDish(group, 0, 1.55, -0.4);
+
+  // turrets — two, fore and aft
+  var turretGeo = new THREE.CylinderGeometry(0.18, 0.22, 0.22, 8);
+  var barrelGeo = new THREE.CylinderGeometry(0.03, 0.035, 0.7, 6);
+  var tMat = getTurretMat(0x1e4a7a);
+  var bMat = getBarrelMat(0x1a3e6a);
 
   var fwdTurret = new THREE.Group();
-  fwdTurret.position.set(0, 0.5, 1.0);
-  fwdTurret.add(new THREE.Mesh(turretGeo, turretMat));
-  var fwdBarrel = new THREE.Mesh(barrelGeo, barrelMat);
+  fwdTurret.position.set(0, 0.48, 1.2);
+  fwdTurret.add(new THREE.Mesh(turretGeo, tMat));
+  var fwdBarrel = new THREE.Mesh(barrelGeo, bMat);
   fwdBarrel.rotation.x = Math.PI / 2;
-  fwdBarrel.position.set(0, 0.08, 0.33);
+  fwdBarrel.position.set(0, 0.08, 0.35);
   fwdTurret.add(fwdBarrel);
   group.add(fwdTurret);
 
   var rearTurret = new THREE.Group();
-  rearTurret.position.set(0, 0.5, -1.2);
-  rearTurret.add(new THREE.Mesh(turretGeo, turretMat));
-  var rearBarrel = new THREE.Mesh(barrelGeo, barrelMat);
+  rearTurret.position.set(0, 0.48, -1.4);
+  rearTurret.add(new THREE.Mesh(turretGeo, tMat));
+  var rearBarrel = new THREE.Mesh(barrelGeo, bMat);
   rearBarrel.rotation.x = Math.PI / 2;
-  rearBarrel.position.set(0, 0.08, 0.33);
+  rearBarrel.position.set(0, 0.08, 0.35);
   rearTurret.add(rearBarrel);
   group.add(rearTurret);
 
   group.userData.turrets = [fwdTurret, rearTurret];
 
-  // antenna
-  var mastGeo = new THREE.CylinderGeometry(0.015, 0.025, 0.8, 4);
-  var mastMat = new THREE.MeshLambertMaterial({ color: 0x3366aa });
-  var mast = new THREE.Mesh(mastGeo, mastMat);
-  mast.position.set(0, 1.0, -0.5);
-  group.add(mast);
+  addNavLights(group, 0.55, 0.35, 0.8);
+  addFlag(group, 0, 0.35, -2.4);
+  addAnchor(group, 3.0, 0.1);
 
   return group;
 }
 
-// --- Cruiser: wide, sturdy, balanced hull (reuse original design with tweaks) ---
+// --- Cruiser: wider, more superstructure, imposing ---
 function buildCruiserMesh() {
+  ensureMaterials();
   var group = new THREE.Group();
+  var metalMat = getMetalMat();
 
   var hullShape = new THREE.Shape();
-  hullShape.moveTo(0, 2.4);
-  hullShape.lineTo(0.8, 1.0);
-  hullShape.lineTo(0.9, -0.4);
-  hullShape.lineTo(0.8, -1.8);
-  hullShape.lineTo(0.5, -2.2);
-  hullShape.lineTo(-0.5, -2.2);
-  hullShape.lineTo(-0.8, -1.8);
-  hullShape.lineTo(-0.9, -0.4);
-  hullShape.lineTo(-0.8, 1.0);
-  hullShape.lineTo(0, 2.4);
+  hullShape.moveTo(0, 2.8);
+  hullShape.bezierCurveTo(0.3, 2.4, 0.65, 1.8, 0.85, 1.2);
+  hullShape.bezierCurveTo(0.95, 0.6, 1.0, 0, 1.0, -0.4);
+  hullShape.bezierCurveTo(1.0, -1.0, 0.9, -1.6, 0.8, -2.0);
+  hullShape.bezierCurveTo(0.65, -2.4, 0.4, -2.6, 0, -2.8);
+  hullShape.bezierCurveTo(-0.4, -2.6, -0.65, -2.4, -0.8, -2.0);
+  hullShape.bezierCurveTo(-0.9, -1.6, -1.0, -1.0, -1.0, -0.4);
+  hullShape.bezierCurveTo(-1.0, 0, -0.95, 0.6, -0.85, 1.2);
+  hullShape.bezierCurveTo(-0.65, 1.8, -0.3, 2.4, 0, 2.8);
 
-  var hullGeo = new THREE.ExtrudeGeometry(hullShape, { depth: 0.55, bevelEnabled: false });
-  var hullMat = new THREE.MeshLambertMaterial({ color: 0x7a6633 });
-  var hull = new THREE.Mesh(hullGeo, hullMat);
+  var hullGeo = new THREE.ExtrudeGeometry(hullShape, {
+    depth: 0.6, bevelEnabled: true, bevelThickness: 0.06, bevelSize: 0.04, bevelSegments: 2
+  });
+  var hull = new THREE.Mesh(hullGeo, getHullMat(0x6a5530));
   hull.rotation.x = -Math.PI / 2;
   hull.position.y = -0.1;
   group.add(hull);
 
-  var deckGeo = new THREE.PlaneGeometry(1.4, 3.8);
-  var deckMat = new THREE.MeshLambertMaterial({ color: 0x887744 });
-  var deck = new THREE.Mesh(deckGeo, deckMat);
+  addWaterline(group, 0.9, 5.0, 0);
+
+  var deckGeo = new THREE.PlaneGeometry(1.5, 4.4);
+  var deck = new THREE.Mesh(deckGeo, getDeckMat(0x7a6640));
   deck.rotation.x = -Math.PI / 2;
-  deck.position.y = 0.45;
-  deck.position.z = -0.2;
+  deck.position.set(0, 0.5, -0.1);
   group.add(deck);
 
-  // large bridge
-  var bridgeGeo = new THREE.BoxGeometry(0.8, 0.7, 0.9);
-  var bridgeMat = new THREE.MeshLambertMaterial({ color: 0x998855 });
-  var bridge = new THREE.Mesh(bridgeGeo, bridgeMat);
-  bridge.position.set(0, 0.8, -0.5);
+  // large bridge with two tiers
+  var bridgeGeo = new THREE.BoxGeometry(0.8, 0.55, 0.8);
+  var bridge = new THREE.Mesh(bridgeGeo, getBridgeMat(0x8a7750));
+  bridge.position.set(0, 0.78, -0.4);
   group.add(bridge);
+  var upperBridgeGeo = new THREE.BoxGeometry(0.55, 0.3, 0.55);
+  var upperBridge = new THREE.Mesh(upperBridgeGeo, getBridgeMat(0x907d58));
+  upperBridge.position.set(0, 1.2, -0.4);
+  group.add(upperBridge);
+  addBridgeWindows(group, 0, 0.78, -0.4, 0.8, 0.55);
 
-  // three turrets for broadside
-  var turretGeo = new THREE.CylinderGeometry(0.22, 0.27, 0.3, 6);
-  var turretMat = new THREE.MeshLambertMaterial({ color: 0x665522 });
-  var barrelGeo = new THREE.CylinderGeometry(0.04, 0.04, 0.7, 4);
-  var barrelMat = new THREE.MeshLambertMaterial({ color: 0x554411 });
+  addSmokestack(group, 0, 1.05, -1.0, 0.12, 0.5);
+
+  // radar mast
+  var mastGeo = new THREE.CylinderGeometry(0.02, 0.03, 1.3, 4);
+  var mast = new THREE.Mesh(mastGeo, metalMat);
+  mast.position.set(0, 1.65, -0.4);
+  group.add(mast);
+  addRadarDish(group, 0, 2.35, -0.4);
+
+  // three turrets
+  var turretGeo = new THREE.CylinderGeometry(0.22, 0.27, 0.28, 8);
+  var barrelGeo = new THREE.CylinderGeometry(0.04, 0.04, 0.75, 6);
+  var tMat = getTurretMat(0x5a4520);
+  var bMat = getBarrelMat(0x4a3a18);
 
   var turrets = [];
-  var positions = [
-    [0, 0.6, 1.0],
-    [0, 0.6, -0.2],
-    [0, 0.6, -1.5]
-  ];
+  var positions = [[0, 0.6, 1.2], [0, 0.6, -0.1], [0, 0.6, -1.6]];
   for (var i = 0; i < positions.length; i++) {
     var t = new THREE.Group();
     t.position.set(positions[i][0], positions[i][1], positions[i][2]);
-    t.add(new THREE.Mesh(turretGeo, turretMat));
-    var b = new THREE.Mesh(barrelGeo, barrelMat);
+    t.add(new THREE.Mesh(turretGeo, tMat));
+    var b = new THREE.Mesh(barrelGeo, bMat);
     b.rotation.x = Math.PI / 2;
-    b.position.set(0, 0.1, 0.35);
+    b.position.set(0, 0.1, 0.38);
     t.add(b);
     group.add(t);
     turrets.push(t);
   }
   group.userData.turrets = turrets;
 
-  // mast
-  var mastGeo = new THREE.CylinderGeometry(0.025, 0.035, 1.2, 4);
-  var mastMat = new THREE.MeshLambertMaterial({ color: 0x7a6633 });
-  var mast = new THREE.Mesh(mastGeo, mastMat);
-  mast.position.set(0, 1.5, -0.5);
-  group.add(mast);
+  addNavLights(group, 0.85, 0.5, 1.0);
+  addFlag(group, 0, 0.5, -2.6);
+  addAnchor(group, 2.6, 0.15);
 
   return group;
 }
 
-// --- Carrier: large, flat deck for drones, wide body ---
+// --- Carrier: flat deck dominates, island tower to one side ---
 function buildCarrierMesh() {
+  ensureMaterials();
   var group = new THREE.Group();
+  var metalMat = getMetalMat();
 
   var hullShape = new THREE.Shape();
-  hullShape.moveTo(0, 2.6);
-  hullShape.lineTo(1.0, 1.2);
-  hullShape.lineTo(1.1, -0.4);
-  hullShape.lineTo(1.0, -2.0);
-  hullShape.lineTo(0.7, -2.6);
-  hullShape.lineTo(-0.7, -2.6);
-  hullShape.lineTo(-1.0, -2.0);
-  hullShape.lineTo(-1.1, -0.4);
-  hullShape.lineTo(-1.0, 1.2);
-  hullShape.lineTo(0, 2.6);
+  hullShape.moveTo(0, 3.0);
+  hullShape.bezierCurveTo(0.4, 2.4, 0.8, 1.8, 1.05, 1.2);
+  hullShape.bezierCurveTo(1.15, 0.6, 1.2, 0, 1.2, -0.4);
+  hullShape.bezierCurveTo(1.2, -1.2, 1.1, -2.0, 1.0, -2.4);
+  hullShape.bezierCurveTo(0.85, -2.8, 0.6, -3.0, 0, -3.2);
+  hullShape.bezierCurveTo(-0.6, -3.0, -0.85, -2.8, -1.0, -2.4);
+  hullShape.bezierCurveTo(-1.1, -2.0, -1.2, -1.2, -1.2, -0.4);
+  hullShape.bezierCurveTo(-1.2, 0, -1.15, 0.6, -1.05, 1.2);
+  hullShape.bezierCurveTo(-0.8, 1.8, -0.4, 2.4, 0, 3.0);
 
-  var hullGeo = new THREE.ExtrudeGeometry(hullShape, { depth: 0.6, bevelEnabled: false });
-  var hullMat = new THREE.MeshLambertMaterial({ color: 0x336644 });
-  var hull = new THREE.Mesh(hullGeo, hullMat);
+  var hullGeo = new THREE.ExtrudeGeometry(hullShape, {
+    depth: 0.65, bevelEnabled: true, bevelThickness: 0.06, bevelSize: 0.04, bevelSegments: 2
+  });
+  var hull = new THREE.Mesh(hullGeo, getHullMat(0x2e5e40));
   hull.rotation.x = -Math.PI / 2;
   hull.position.y = -0.1;
   group.add(hull);
 
-  // flight deck — large flat area
-  var deckGeo = new THREE.PlaneGeometry(1.8, 4.2);
-  var deckMat = new THREE.MeshLambertMaterial({ color: 0x447755 });
-  var deck = new THREE.Mesh(deckGeo, deckMat);
+  addWaterline(group, 1.1, 5.6, -0.2);
+
+  // flight deck
+  var deckGeo = new THREE.PlaneGeometry(2.0, 5.0);
+  var deck = new THREE.Mesh(deckGeo, getDeckMat(0x3a6a4a));
   deck.rotation.x = -Math.PI / 2;
-  deck.position.y = 0.5;
-  deck.position.z = -0.2;
+  deck.position.set(0, 0.55, -0.1);
   group.add(deck);
 
-  // runway markings (thin stripe)
-  var stripeGeo = new THREE.PlaneGeometry(0.08, 3.2);
-  var stripeMat = new THREE.MeshLambertMaterial({ color: 0xccccaa });
+  // runway markings
+  var stripeMat = new THREE.MeshStandardMaterial({ color: 0xccccaa, roughness: 0.8, metalness: 0 });
+  var stripeGeo = new THREE.PlaneGeometry(0.06, 3.8);
   var stripe = new THREE.Mesh(stripeGeo, stripeMat);
   stripe.rotation.x = -Math.PI / 2;
-  stripe.position.y = 0.51;
-  stripe.position.z = 0.2;
+  stripe.position.set(0, 0.56, 0.2);
   group.add(stripe);
+  for (var ds = -1; ds <= 1; ds += 2) {
+    for (var di = 0; di < 4; di++) {
+      var dashGeo = new THREE.PlaneGeometry(0.04, 0.4);
+      var dash = new THREE.Mesh(dashGeo, stripeMat);
+      dash.rotation.x = -Math.PI / 2;
+      dash.position.set(ds * 0.7, 0.56, di * 1.2 - 1.5);
+      group.add(dash);
+    }
+  }
 
-  // island (bridge offset to starboard)
-  var bridgeGeo = new THREE.BoxGeometry(0.5, 0.8, 0.7);
-  var bridgeMat = new THREE.MeshLambertMaterial({ color: 0x558866 });
-  var bridge = new THREE.Mesh(bridgeGeo, bridgeMat);
-  bridge.position.set(0.65, 0.9, -0.8);
+  // island tower (starboard side)
+  var bridgeGeo = new THREE.BoxGeometry(0.55, 0.9, 0.75);
+  var bridge = new THREE.Mesh(bridgeGeo, getBridgeMat(0x4a7a5a));
+  bridge.position.set(0.75, 1.0, -0.8);
   group.add(bridge);
+  addBridgeWindows(group, 0.75, 1.0, -0.8, 0.55, 0.9);
 
-  // single defensive turret
-  var turretGeo = new THREE.CylinderGeometry(0.2, 0.25, 0.25, 6);
-  var turretMat = new THREE.MeshLambertMaterial({ color: 0x335533 });
-  var barrelGeo = new THREE.CylinderGeometry(0.035, 0.035, 0.6, 4);
-  var barrelMat = new THREE.MeshLambertMaterial({ color: 0x224422 });
+  // radar mast on island
+  var mastGeo = new THREE.CylinderGeometry(0.015, 0.025, 1.1, 4);
+  var mast = new THREE.Mesh(mastGeo, metalMat);
+  mast.position.set(0.75, 1.6, -0.8);
+  group.add(mast);
+  addRadarDish(group, 0.75, 2.2, -0.8);
+
+  // defensive turrets
+  var turretGeo = new THREE.CylinderGeometry(0.2, 0.25, 0.22, 8);
+  var barrelGeo = new THREE.CylinderGeometry(0.03, 0.035, 0.6, 6);
+  var tMat = getTurretMat(0x2a5a3a);
+  var bMat = getBarrelMat(0x1e4a2e);
 
   var fwdTurret = new THREE.Group();
-  fwdTurret.position.set(0, 0.6, 1.2);
-  fwdTurret.add(new THREE.Mesh(turretGeo, turretMat));
-  var fwdBarrel = new THREE.Mesh(barrelGeo, barrelMat);
+  fwdTurret.position.set(0, 0.6, 1.5);
+  fwdTurret.add(new THREE.Mesh(turretGeo, tMat));
+  var fwdBarrel = new THREE.Mesh(barrelGeo, bMat);
   fwdBarrel.rotation.x = Math.PI / 2;
   fwdBarrel.position.set(0, 0.08, 0.3);
   fwdTurret.add(fwdBarrel);
   group.add(fwdTurret);
 
   var rearTurret = new THREE.Group();
-  rearTurret.position.set(0, 0.6, -1.8);
-  rearTurret.add(new THREE.Mesh(turretGeo, turretMat));
-  var rearBarrel = new THREE.Mesh(barrelGeo, barrelMat);
+  rearTurret.position.set(0, 0.6, -2.2);
+  rearTurret.add(new THREE.Mesh(turretGeo, tMat));
+  var rearBarrel = new THREE.Mesh(barrelGeo, bMat);
   rearBarrel.rotation.x = Math.PI / 2;
   rearBarrel.position.set(0, 0.08, 0.3);
   rearTurret.add(rearBarrel);
@@ -222,88 +260,100 @@ function buildCarrierMesh() {
 
   group.userData.turrets = [fwdTurret, rearTurret];
 
-  // mast
-  var mastGeo = new THREE.CylinderGeometry(0.02, 0.03, 1.0, 4);
-  var mastMat = new THREE.MeshLambertMaterial({ color: 0x336644 });
-  var mast = new THREE.Mesh(mastGeo, mastMat);
-  mast.position.set(0.65, 1.5, -0.8);
-  group.add(mast);
+  addNavLights(group, 1.0, 0.55, 1.2);
+  addFlag(group, 0, 0.55, -3.0);
+  addAnchor(group, 2.8, 0.1);
 
   return group;
 }
 
-// --- Submarine: low profile, rounded hull, conning tower ---
+// --- Submarine: smooth cylindrical hull, conning tower, minimal deck ---
 function buildSubmarineMesh() {
+  ensureMaterials();
   var group = new THREE.Group();
+  var metalMat = getMetalMat();
 
-  // elongated rounded hull
+  // elongated smooth hull
   var hullShape = new THREE.Shape();
-  hullShape.moveTo(0, 2.2);
-  hullShape.lineTo(0.4, 1.4);
-  hullShape.lineTo(0.5, 0);
-  hullShape.lineTo(0.45, -1.4);
-  hullShape.lineTo(0.2, -2.0);
-  hullShape.lineTo(-0.2, -2.0);
-  hullShape.lineTo(-0.45, -1.4);
-  hullShape.lineTo(-0.5, 0);
-  hullShape.lineTo(-0.4, 1.4);
-  hullShape.lineTo(0, 2.2);
+  hullShape.moveTo(0, 2.5);
+  hullShape.bezierCurveTo(0.12, 2.2, 0.3, 1.8, 0.42, 1.4);
+  hullShape.bezierCurveTo(0.5, 0.8, 0.52, 0.2, 0.52, 0);
+  hullShape.bezierCurveTo(0.52, -0.6, 0.5, -1.2, 0.45, -1.6);
+  hullShape.bezierCurveTo(0.38, -2.0, 0.25, -2.3, 0, -2.5);
+  hullShape.bezierCurveTo(-0.25, -2.3, -0.38, -2.0, -0.45, -1.6);
+  hullShape.bezierCurveTo(-0.5, -1.2, -0.52, -0.6, -0.52, 0);
+  hullShape.bezierCurveTo(-0.52, 0.2, -0.5, 0.8, -0.42, 1.4);
+  hullShape.bezierCurveTo(-0.3, 1.8, -0.12, 2.2, 0, 2.5);
 
-  var hullGeo = new THREE.ExtrudeGeometry(hullShape, { depth: 0.35, bevelEnabled: false });
-  var hullMat = new THREE.MeshLambertMaterial({ color: 0x445566 });
-  var hull = new THREE.Mesh(hullGeo, hullMat);
+  var hullGeo = new THREE.ExtrudeGeometry(hullShape, {
+    depth: 0.4, bevelEnabled: true, bevelThickness: 0.08, bevelSize: 0.06, bevelSegments: 3
+  });
+  var hull = new THREE.Mesh(hullGeo, getHullMat(0x3a4a5a));
   hull.rotation.x = -Math.PI / 2;
   hull.position.y = -0.15;
   group.add(hull);
 
-  // low deck
-  var deckGeo = new THREE.PlaneGeometry(0.7, 3.4);
-  var deckMat = new THREE.MeshLambertMaterial({ color: 0x556677 });
-  var deck = new THREE.Mesh(deckGeo, deckMat);
+  addWaterline(group, 0.45, 4.4, 0);
+
+  // minimal deck
+  var deckGeo = new THREE.PlaneGeometry(0.7, 3.8);
+  var deck = new THREE.Mesh(deckGeo, getDeckMat(0x4a5a6a));
   deck.rotation.x = -Math.PI / 2;
-  deck.position.y = 0.2;
-  deck.position.z = -0.1;
+  deck.position.set(0, 0.25, 0);
   group.add(deck);
 
-  // conning tower (tall, narrow)
-  var towerGeo = new THREE.BoxGeometry(0.4, 0.7, 0.5);
-  var towerMat = new THREE.MeshLambertMaterial({ color: 0x667788 });
-  var tower = new THREE.Mesh(towerGeo, towerMat);
-  tower.position.set(0, 0.55, -0.2);
+  // conning tower
+  var towerGeo = new THREE.BoxGeometry(0.38, 0.7, 0.5);
+  var tower = new THREE.Mesh(towerGeo, getBridgeMat(0x5a6a7a));
+  tower.position.set(0, 0.6, -0.15);
   group.add(tower);
+  addBridgeWindows(group, 0, 0.6, -0.15, 0.38, 0.7);
 
-  // periscope
-  var periGeo = new THREE.CylinderGeometry(0.02, 0.02, 0.6, 4);
-  var periMat = new THREE.MeshLambertMaterial({ color: 0x778899 });
-  var peri = new THREE.Mesh(periGeo, periMat);
-  peri.position.set(0, 1.2, -0.2);
+  // periscope / mast
+  var periGeo = new THREE.CylinderGeometry(0.015, 0.015, 0.7, 4);
+  var peri = new THREE.Mesh(periGeo, metalMat);
+  peri.position.set(0, 1.3, -0.15);
   group.add(peri);
+  addRadarDish(group, 0, 1.7, -0.15);
 
-  // single forward turret
-  var turretGeo = new THREE.CylinderGeometry(0.15, 0.2, 0.2, 6);
-  var turretMat = new THREE.MeshLambertMaterial({ color: 0x3a4a5a });
-  var barrelGeo = new THREE.CylinderGeometry(0.03, 0.03, 0.5, 4);
-  var barrelMat = new THREE.MeshLambertMaterial({ color: 0x2a3a4a });
+  // dive planes (horizontal fins)
+  var finGeo = new THREE.BoxGeometry(0.6, 0.03, 0.15);
+  var finMat = new THREE.MeshStandardMaterial({ color: 0x3a4a5a, roughness: 0.5, metalness: 0.4 });
+  var finFwd = new THREE.Mesh(finGeo, finMat);
+  finFwd.position.set(0, 0.15, 1.5);
+  group.add(finFwd);
+  var finAft = new THREE.Mesh(finGeo, finMat);
+  finAft.position.set(0, 0.15, -1.8);
+  group.add(finAft);
+
+  // turrets (low profile)
+  var turretGeo = new THREE.CylinderGeometry(0.14, 0.18, 0.18, 8);
+  var barrelGeo = new THREE.CylinderGeometry(0.025, 0.03, 0.5, 6);
+  var tMat = getTurretMat(0x2a3a4a);
+  var bMat = getBarrelMat(0x1e2e3e);
 
   var fwdTurret = new THREE.Group();
-  fwdTurret.position.set(0, 0.35, 0.8);
-  fwdTurret.add(new THREE.Mesh(turretGeo, turretMat));
-  var fwdBarrel = new THREE.Mesh(barrelGeo, barrelMat);
+  fwdTurret.position.set(0, 0.35, 0.9);
+  fwdTurret.add(new THREE.Mesh(turretGeo, tMat));
+  var fwdBarrel = new THREE.Mesh(barrelGeo, bMat);
   fwdBarrel.rotation.x = Math.PI / 2;
   fwdBarrel.position.set(0, 0.06, 0.25);
   fwdTurret.add(fwdBarrel);
   group.add(fwdTurret);
 
   var rearTurret = new THREE.Group();
-  rearTurret.position.set(0, 0.35, -1.2);
-  rearTurret.add(new THREE.Mesh(turretGeo, turretMat));
-  var rearBarrel2 = new THREE.Mesh(barrelGeo, barrelMat);
+  rearTurret.position.set(0, 0.35, -1.3);
+  rearTurret.add(new THREE.Mesh(turretGeo, tMat));
+  var rearBarrel2 = new THREE.Mesh(barrelGeo, bMat);
   rearBarrel2.rotation.x = Math.PI / 2;
   rearBarrel2.position.set(0, 0.06, 0.25);
   rearTurret.add(rearBarrel2);
   group.add(rearTurret);
 
   group.userData.turrets = [fwdTurret, rearTurret];
+
+  addNavLights(group, 0.4, 0.25, 0.6);
+  addFlag(group, 0, 0.25, -2.3);
 
   return group;
 }

--- a/js/shipParts.js
+++ b/js/shipParts.js
@@ -1,0 +1,168 @@
+// shipParts.js — shared materials and detail builders for ship models
+import * as THREE from "three";
+
+// --- shared materials (reused across builds) ---
+var hullMats = {};
+var deckMats = {};
+var bridgeMats = {};
+var turretMats = {};
+var barrelMats = {};
+var glassMat = null;
+var metalMat = null;
+var radarMat = null;
+var flagMat = null;
+var anchorMat = null;
+
+export function ensureMaterials() {
+  if (glassMat) return;
+  glassMat = new THREE.MeshStandardMaterial({
+    color: 0x1a2a3a, roughness: 0.1, metalness: 0.5,
+    emissive: 0x1a2a3a, emissiveIntensity: 0
+  });
+  metalMat = new THREE.MeshStandardMaterial({
+    color: 0x888899, roughness: 0.3, metalness: 0.8
+  });
+  radarMat = new THREE.MeshStandardMaterial({
+    color: 0x667777, roughness: 0.4, metalness: 0.7
+  });
+  flagMat = new THREE.MeshStandardMaterial({
+    color: 0xeeeeee, roughness: 0.9, metalness: 0.0, side: THREE.DoubleSide
+  });
+  anchorMat = new THREE.MeshStandardMaterial({
+    color: 0x444444, roughness: 0.4, metalness: 0.9
+  });
+}
+
+export function getMetalMat() { ensureMaterials(); return metalMat; }
+
+export function getHullMat(color) {
+  var key = color.toString(16);
+  if (!hullMats[key]) {
+    hullMats[key] = new THREE.MeshStandardMaterial({ color: color, roughness: 0.7, metalness: 0.1 });
+  }
+  return hullMats[key];
+}
+
+export function getDeckMat(color) {
+  var key = color.toString(16);
+  if (!deckMats[key]) {
+    deckMats[key] = new THREE.MeshStandardMaterial({ color: color, roughness: 0.5, metalness: 0.05 });
+  }
+  return deckMats[key];
+}
+
+export function getBridgeMat(color) {
+  var key = color.toString(16);
+  if (!bridgeMats[key]) {
+    bridgeMats[key] = new THREE.MeshStandardMaterial({ color: color, roughness: 0.5, metalness: 0.2 });
+  }
+  return bridgeMats[key];
+}
+
+export function getTurretMat(color) {
+  var key = color.toString(16);
+  if (!turretMats[key]) {
+    turretMats[key] = new THREE.MeshStandardMaterial({ color: color, roughness: 0.35, metalness: 0.7 });
+  }
+  return turretMats[key];
+}
+
+export function getBarrelMat(color) {
+  var key = color.toString(16);
+  if (!barrelMats[key]) {
+    barrelMats[key] = new THREE.MeshStandardMaterial({ color: color, roughness: 0.3, metalness: 0.8 });
+  }
+  return barrelMats[key];
+}
+
+// --- waterline stripe (dark band at hull base) ---
+export function addWaterline(group, halfWidth, length, zOffset) {
+  var wlGeo = new THREE.PlaneGeometry(halfWidth * 2, length);
+  var wlMat = new THREE.MeshStandardMaterial({ color: 0x1a0a0a, roughness: 0.9, metalness: 0 });
+  var wl = new THREE.Mesh(wlGeo, wlMat);
+  wl.rotation.x = -Math.PI / 2;
+  wl.position.set(0, 0.01, zOffset || 0);
+  group.add(wl);
+}
+
+// --- navigation lights (red port, green starboard) ---
+export function addNavLights(group, x, y, z) {
+  var portMat = new THREE.MeshBasicMaterial({ color: 0xff0000 });
+  var stbdMat = new THREE.MeshBasicMaterial({ color: 0x00ff00 });
+  var lightGeo = new THREE.SphereGeometry(0.04, 4, 3);
+  var port = new THREE.Mesh(lightGeo, portMat);
+  port.position.set(-x, y, z);
+  group.add(port);
+  var stbd = new THREE.Mesh(lightGeo, stbdMat);
+  stbd.position.set(x, y, z);
+  group.add(stbd);
+}
+
+// --- flag at stern ---
+export function addFlag(group, x, y, z) {
+  ensureMaterials();
+  var poleGeo = new THREE.CylinderGeometry(0.01, 0.01, 0.4, 3);
+  var pole = new THREE.Mesh(poleGeo, metalMat);
+  pole.position.set(x, y + 0.2, z);
+  group.add(pole);
+  var fGeo = new THREE.PlaneGeometry(0.2, 0.12);
+  var flag = new THREE.Mesh(fGeo, flagMat);
+  flag.position.set(x + 0.1, y + 0.35, z);
+  group.add(flag);
+}
+
+// --- anchor on bow ---
+export function addAnchor(group, bowZ, y) {
+  ensureMaterials();
+  var shankGeo = new THREE.CylinderGeometry(0.015, 0.015, 0.2, 4);
+  var shank = new THREE.Mesh(shankGeo, anchorMat);
+  shank.position.set(0.25, y, bowZ - 0.1);
+  shank.rotation.z = 0.3;
+  group.add(shank);
+}
+
+// --- radar dish (horizontal disc on mast) ---
+export function addRadarDish(group, x, y, z) {
+  ensureMaterials();
+  var dishGeo = new THREE.CylinderGeometry(0.15, 0.15, 0.02, 8);
+  var dish = new THREE.Mesh(dishGeo, radarMat);
+  dish.position.set(x, y, z);
+  group.add(dish);
+  var armGeo = new THREE.CylinderGeometry(0.01, 0.01, 0.15, 3);
+  var arm = new THREE.Mesh(armGeo, metalMat);
+  arm.position.set(x, y - 0.08, z);
+  group.add(arm);
+}
+
+// --- bridge windows (dark glass strip) ---
+export function addBridgeWindows(group, bx, by, bz, width, height) {
+  ensureMaterials();
+  var winGeo = new THREE.PlaneGeometry(width * 0.8, height * 0.35);
+  var winF = new THREE.Mesh(winGeo, glassMat);
+  winF.position.set(bx, by + height * 0.1, bz + height * 0.51);
+  group.add(winF);
+  var winSideGeo = new THREE.PlaneGeometry(height * 0.6, height * 0.35);
+  var winL = new THREE.Mesh(winSideGeo, glassMat);
+  winL.rotation.y = Math.PI / 2;
+  winL.position.set(bx - width * 0.51, by + height * 0.1, bz);
+  group.add(winL);
+  var winR = new THREE.Mesh(winSideGeo, glassMat);
+  winR.rotation.y = -Math.PI / 2;
+  winR.position.set(bx + width * 0.51, by + height * 0.1, bz);
+  group.add(winR);
+}
+
+// --- smokestack ---
+export function addSmokestack(group, x, y, z, radius, height) {
+  var stackGeo = new THREE.CylinderGeometry(radius * 0.8, radius, height, 8);
+  var stackMat = new THREE.MeshStandardMaterial({ color: 0x333333, roughness: 0.6, metalness: 0.3 });
+  var stack = new THREE.Mesh(stackGeo, stackMat);
+  stack.position.set(x, y + height / 2, z);
+  group.add(stack);
+  var rimGeo = new THREE.TorusGeometry(radius * 0.8, 0.02, 4, 8);
+  var rimMat = new THREE.MeshStandardMaterial({ color: 0x111111, roughness: 0.8, metalness: 0.2 });
+  var rim = new THREE.Mesh(rimGeo, rimMat);
+  rim.rotation.x = Math.PI / 2;
+  rim.position.set(x, y + height, z);
+  group.add(rim);
+}


### PR DESCRIPTION
Closes #69

## Changes
- Upgraded all ship models from `MeshLambertMaterial` to `MeshStandardMaterial` with per-surface PBR properties
- Hull curves now use bezier paths for smoother, more natural shapes
- Bridge windows with dark glass material (emissive-ready for night)
- Radar mast/antenna on every ship class
- Navigation lights (red port, green starboard) on all ships including enemies
- Each class has a unique recognizable silhouette
- Enemy patrol boats have their own angular hull design (not recolored player)
- Boss ships are larger and more imposing with enhanced detail
- Shared detail helpers extracted to `shipParts.js`

## Acceptance Criteria
- [x] All ship classes use `MeshStandardMaterial` with appropriate roughness/metalness
- [x] Hull curves are smoother (more path vertices)
- [x] Bridge has visible windows (dark glass material, emissive at night)
- [x] Radar mast/antenna on each ship
- [x] Each ship class has a distinct recognizable silhouette
- [x] Enemy ships have their own model (not recolored player ships)
- [x] Boss ships are visually larger and more imposing
- [x] Navigation lights visible (red port, green starboard)
- [x] Detail is visible at default bird's-eye camera zoom
- [x] 60fps maintained with upgraded models
- [x] Day/night lighting works correctly with new materials