### PR TITLE
Mute game sounds during upgrade screen

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -5,7 +5,7 @@ import { createShip, updateShip, getSpeedRatio, getDisplaySpeed } from "./ship.j
 import { initInput, getInput, getMouse, consumeClick, getKeyActions, getAutofire, toggleAutofire, setAutofire } from "./input.js";
 import { createHUD, updateHUD, updateMinimap, showBanner, showGameOver, showVictory, setRestartCallback, hideOverlay, setWeaponSwitchCallback, setAbilityCallback, setAutofireToggleCallback, setMuteCallback, setVolumeCallback, updateMuteButton, updateVolumeSlider } from "./hud.js";
 import { showDamageIndicator, showFloatingNumber, addKillFeedEntry, triggerScreenShake, updateUIEffects, getShakeOffset, fadeOut, fadeIn } from "./uiEffects.js";
-import { unlockAudio, updateEngine, setEngineClass, updateAmbience, updateMusic, updateLowHpWarning, toggleMute, setMasterVolume, isMuted } from "./sound.js";
+import { unlockAudio, updateEngine, setEngineClass, updateAmbience, updateMusic, updateLowHpWarning, toggleMute, setMasterVolume, isMuted, fadeGameAudio, resumeGameAudio } from "./sound.js";
 import { playWeaponSound, playExplosion, playPlayerHit, playClick, playUpgrade, playWaveHorn, playHitConfirm, playKillConfirm } from "./soundFx.js";
 import { initNav, updateNav, handleClick, getCombatTarget, setCombatTarget } from "./nav.js";
 import { createWeaponState, fireWeapon, updateWeapons, switchWeapon, getWeaponOrder, getWeaponConfig, findNearestEnemy, getActiveWeaponRange, aimAtEnemy } from "./weapon.js";
@@ -714,12 +714,14 @@ function animate() {
         performAutoSave();
         if (waveMgr.wave < waveMgr.maxWave) {
           upgradeScreenOpen = true;
+          fadeGameAudio();
           showUpgradeScreen(upgrades, function () {
             upgradeScreenOpen = false;
             applyUpgrades();
             crewScreenOpen = true;
             showCrewScreen(crew, function () {
               crewScreenOpen = false;
+              resumeGameAudio();
             });
           });
         }

--- a/js/sound.js
+++ b/js/sound.js
@@ -137,6 +137,31 @@ export function toggleMute() {
   return muted;
 }
 
+// --- fade game audio for menu screens ---
+var savedAmbienceVol = 0.3;
+var savedMusicVol = 0.18;
+var gameAudioFaded = false;
+
+export function fadeGameAudio() {
+  if (gameAudioFaded) return;
+  gameAudioFaded = true;
+  if (ambienceGain) {
+    savedAmbienceVol = ambienceGain.gain.value;
+    ambienceGain.gain.value = 0;
+  }
+  if (musicGain) {
+    savedMusicVol = musicGain.gain.value;
+    musicGain.gain.value = 0;
+  }
+}
+
+export function resumeGameAudio() {
+  if (!gameAudioFaded) return;
+  gameAudioFaded = false;
+  if (ambienceGain) ambienceGain.gain.value = savedAmbienceVol;
+  if (musicGain) musicGain.gain.value = savedMusicVol;
+}
+
 // --- layered engine: rumble + mechanical chug + whine + wake ---
 export function setEngineClass(classKey) {
   engineClassKey = classKey || "cruiser";


### PR DESCRIPTION
Closes #86

## Summary
- Added `fadeGameAudio()` / `resumeGameAudio()` to `sound.js` that zero out the ambience and music gain nodes
- Called `fadeGameAudio()` when upgrade screen opens between waves
- Called `resumeGameAudio()` when crew screen closes and gameplay resumes
- SFX gain is untouched so UI click/upgrade sounds still play

## Acceptance Criteria
- [x] Mute or fade out all game audio when upgrade screen opens
- [x] Resume audio when upgrade screen closes and gameplay resumes

## Test plan
- [ ] Complete a wave and verify engine/ocean/wind/music go silent on upgrade screen
- [ ] Verify UI click sounds (upgrade apply, continue button) still play
- [ ] Verify audio resumes after closing crew screen
- [ ] Verify manual mute toggle still works independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)