### PR TITLE
Upgrade screen: click-to-apply with undo/confirm instead of separate Apply + Continue

### DIFF
--- a/game/js/upgrade.js
+++ b/game/js/upgrade.js
@@ -200,6 +200,18 @@ export function respecUpgrades(state) {
   return refund;
 }
 
+// --- undo a single upgrade tier (refund cost, decrement level) ---
+export function undoUpgrade(state, key) {
+  var info = findUpgrade(key);
+  if (!info) return false;
+  var level = state.levels[key] || 0;
+  if (level <= 0) return false;
+  var cost = info.costs[level - 1];
+  state.salvage += cost;
+  state.levels[key] = level - 1;
+  return true;
+}
+
 // --- get the multiplier for a single upgrade key at a given level ---
 export function getMultiplierForKey(state, key, extraLevels) {
   var info = findUpgrade(key);


### PR DESCRIPTION
Closes #83

## Summary
- Clicking an upgrade now **applies it immediately** (buys the tier) instead of requiring a separate Apply button
- Shows **Undo** button (reverts salvage + upgrade level) and **Confirm** button after purchase
- Continue button is **disabled** while an upgrade is pending confirmation
- If no upgrade is selected, Continue proceeds normally (skips upgrade)

## Acceptance Criteria
- [x] Clicking an upgrade applies it immediately
- [x] Show Undo button (reverts salvage + upgrade)
- [x] Show Confirm/Continue button
- [x] No more separate Apply step — one click applies, second click confirms
- [x] If player hasn't selected anything, Continue skips the upgrade

## Changes
- `game/js/upgrade.js` — Added `undoUpgrade()` function to reverse a single tier purchase
- `game/js/upgradeScreen.js` — Replaced select+Apply flow with click-to-apply+undo/confirm flow