### PR TITLE
Main menu permanent upgrades not working — salvage collected but can't spend

### DIFF
--- a/game/js/main.js
+++ b/game/js/main.js
@@ -186,6 +186,7 @@ createSettingsMenu({
     resetResources(resources);
     resetEnemyManager(enemyMgr, scene);
     resetUpgrades(upgrades);
+    upgrades.salvage = 0;
     resetDrones(droneMgr, scene);
     resetCrew(crew);
     clearRemoteShips(scene);
@@ -385,6 +386,7 @@ function openTechThenMap() {
     spend: function (cost) { upgrades.salvage -= cost; }
   }, function () {
     techScreenOpen = false;
+    performAutoSave();
     openMap();
   });
 }

--- a/game/js/upgrade.js
+++ b/game/js/upgrade.js
@@ -58,9 +58,8 @@ export function createUpgradeState() {
   return state;
 }
 
-// --- reset upgrades (on game over restart) ---
+// --- reset upgrades (on new zone/restart) — keeps salvage (persistent currency) ---
 export function resetUpgrades(state) {
-  state.salvage = 0;
   var keys = Object.keys(state.levels);
   for (var i = 0; i < keys.length; i++) {
     state.levels[keys[i]] = 0;


### PR DESCRIPTION
Closes #84

## Summary
`resetUpgrades()` was zeroing `salvage` on every zone start and game over restart, making it impossible to accumulate salvage for tech tree purchases. This fix makes salvage a persistent currency that survives run resets.

### Changes
- **`upgrade.js`**: `resetUpgrades()` no longer zeroes salvage — only resets run-scoped tier levels
- **`main.js`**: Explicitly zero salvage only in "New Game" handler (full progression wipe alongside tech tree and map reset)
- **`main.js`**: Auto-save after tech screen closes so salvage spent on tech nodes persists to localStorage

## Acceptance Criteria (from #84 and #15)

- [x] Salvage persists across runs (saved to localStorage)
- [x] Tech tree with 3 branches lets you spend accumulated salvage on permanent unlocks
- [x] Unlocks persist and apply to all future runs
- [x] Visual node-graph showing locked/unlocked states

### Tech Tree Detail (from #15)
- [x] Tech tree screen with 3 branches: Offense, Defense, Utility
- [x] Each branch has 5 nodes (linear unlock path)
- [x] Research costs salvage points (same currency as upgrades)
- [x] Offense: advanced weapons, crit chance, splash damage
- [x] Defense: shields, auto-repair, damage reflection
- [x] Utility: larger radar, faster pickup collection, bonus salvage
- [x] Tech persists across runs (permanent progression)
- [x] Visual: node-graph with connecting lines, locked/unlocked states