### PR TITLE
UI clicks propagate to game — clicking buttons moves ship or fires

### DIFF
--- a/game/js/input.js
+++ b/game/js/input.js
@@ -13,13 +13,20 @@ var keyActions = [];
 // autofire state
 var autofire = false;
 
+// game canvas reference — only clicks on canvas register as game input
+var gameCanvas = null;
+
+function isGameTarget(e) {
+  return gameCanvas && e.target === gameCanvas;
+}
+
 function onMouseMove(e) {
   mouse.x = e.clientX;
   mouse.y = e.clientY;
 }
 
 function onMouseDown(e) {
-  if (e.button === 0) {
+  if (e.button === 0 && isGameTarget(e)) {
     mouse.clicked = true;
     mouse.clickConsumed = false;
   }
@@ -29,8 +36,10 @@ function onTouchStart(e) {
   var touch = e.touches[0];
   mouse.x = touch.clientX;
   mouse.y = touch.clientY;
-  mouse.clicked = true;
-  mouse.clickConsumed = false;
+  if (isGameTarget(e)) {
+    mouse.clicked = true;
+    mouse.clickConsumed = false;
+  }
 }
 
 function onTouchMove(e) {
@@ -61,7 +70,8 @@ function onKeyDown(e) {
   }
 }
 
-export function initInput() {
+export function initInput(canvas) {
+  gameCanvas = canvas || null;
   window.addEventListener("mousemove", onMouseMove);
   window.addEventListener("mousedown", onMouseDown);
   window.addEventListener("touchstart", onTouchStart, { passive: true });

--- a/game/js/main.js
+++ b/game/js/main.js
@@ -136,7 +136,7 @@ setOnHitCallback(enemyMgr, function (x, y, z, dmg) {
 });
 
 var waveMgr = createWaveManager();
-initInput();
+initInput(renderer.domElement);
 createHUD();
 
 var audioUnlockHandler = function () {


### PR DESCRIPTION
Closes #91

## Summary
- Modified `input.js` to only register mouse/touch clicks as game input when `e.target` is the WebGL canvas element
- Passed `renderer.domElement` (canvas) to `initInput()` in `main.js`
- This prevents ALL UI clicks (upgrade, menu, settings, ability, weapon switch, autofire, etc.) from propagating to game systems

## Acceptance Criteria
- [x] Clicking UI buttons (upgrade, menu, settings, ability, weapon switch, etc.) no longer moves the ship
- [x] Clicking UI buttons no longer fires weapons
- [x] Normal gameplay clicks on the canvas still work (navigation, targeting, firing)
- [x] Touch input on UI elements no longer triggers game actions
- [x] Touch input on the game canvas still works normally

## Test Plan
- [ ] Click weapon switch buttons — ship should not move, weapons should not fire
- [ ] Click ability button — ship should not move
- [ ] Click autofire toggle — ship should not move
- [ ] Click mute/volume controls — ship should not move or fire
- [ ] Click on game canvas — ship should navigate to click point as before
- [ ] On mobile: tap UI buttons — no game action should occur
- [ ] On mobile: tap game canvas — navigation/targeting should work