### PR TITLE
HUD declutter — minimal in-game UI, move info to menus

### DIFF
--- a/game/js/main.js
+++ b/game/js/main.js
@@ -3,7 +3,7 @@ import { createOcean, updateOcean, getWaveHeight, setTerrainMap, clearTerrainMap
 import { createCamera, updateCamera, resizeCamera } from "./camera.js";
 import { createShip, updateShip, getSpeedRatio, getDisplaySpeed } from "./ship.js";
 import { initInput, getInput, getMouse, consumeClick, getKeyActions, getAutofire, toggleAutofire, setAutofire } from "./input.js";
-import { createHUD, updateHUD, updateMinimap, showBanner, showGameOver, showVictory, setRestartCallback, hideOverlay, setWeaponSwitchCallback, setAbilityCallback, setAutofireToggleCallback, setMuteCallback, setVolumeCallback, updateMuteButton, updateVolumeSlider } from "./hud.js";
+import { createHUD, updateHUD, updateMinimap, showBanner, showGameOver, showVictory, setRestartCallback, hideOverlay, setWeaponSwitchCallback, setAbilityCallback, setAutofireToggleCallback, setMuteCallback, setVolumeCallback, setSettingsDataCallback } from "./hud.js";
 import { showDamageIndicator, showFloatingNumber, addKillFeedEntry, triggerScreenShake, updateUIEffects, getShakeOffset, fadeOut, fadeIn } from "./uiEffects.js";
 import { unlockAudio, updateEngine, setEngineClass, updateAmbience, updateMusic, updateLowHpWarning, toggleMute, setMasterVolume, isMuted, fadeGameAudio, resumeGameAudio } from "./sound.js";
 import { playWeaponSound, playExplosion, playPlayerHit, playClick, playUpgrade, playWaveHorn, playHitConfirm, playKillConfirm } from "./soundFx.js";
@@ -37,7 +37,7 @@ import { createMultiplayerState, createRoom, joinRoom, setReady, setShipClass, s
 import { sendShipState, sendEnemyState, sendWaveStart, sendPickupClaim, sendFireEvent, sendAbilityEvent, sendGameEvent, handleBroadcastMessage, updateRemoteShips, getRemoteShipsForMinimap, clearRemoteShips, resetSendState } from "./netSync.js";
 import { createLobbyScreen, createMultiplayerButton, showLobbyChoice, showLobby, hideLobbyScreen, updatePlayerList, updateReadyButton, updateStartButton, setLobbyCallbacks } from "./lobbyScreen.js";
 import { autoSave, loadSave, hasSave, deleteSave, exportSave, importSave } from "./save.js";
-import { createSettingsMenu, isSettingsOpen } from "./settingsMenu.js";
+import { createSettingsMenu, isSettingsOpen, updateSettingsData, updateMuteButton, updateVolumeSlider } from "./settingsMenu.js";
 import { getQualityConfig, createOrientationPrompt, onQualityChange } from "./mobile.js";
 import { seedRNG, nextRandom, getRNGState, getRNGCount } from "./rng.js";
 
@@ -171,6 +171,7 @@ setAutofireToggleCallback(function () {
   toggleAutofire();
   playClick();
 });
+setSettingsDataCallback(function (data) { updateSettingsData(data); });
 
 initHealthBars();
 createBossHud();
@@ -180,6 +181,9 @@ createShipSelectScreen();
 
 // --- settings menu ---
 createSettingsMenu({
+  onMute: function () { updateMuteButton(toggleMute()); },
+  onVolume: function (vol) { setMasterVolume(vol); },
+  onAutofireToggle: function () { toggleAutofire(); playClick(); },
   onNewGame: function () {
     gameFrozen = true;
     gameStarted = false;

--- a/game/js/minimap.js
+++ b/game/js/minimap.js
@@ -1,8 +1,9 @@
 // minimap.js — radar-style minimap showing player, enemies, pickups, ports
+import { isMobile } from "./mobile.js";
 
 var minimapCanvas = null;
 var minimapCtx = null;
-var MINIMAP_SIZE = 140;
+var MINIMAP_SIZE = isMobile() ? 100 : 110;
 var MINIMAP_RANGE = 120;
 
 export function createMinimap(parentEl) {

--- a/game/js/settingsMenu.js
+++ b/game/js/settingsMenu.js
@@ -1,4 +1,5 @@
-// settingsMenu.js — settings gear menu: new game, export/import save, install prompt
+// settingsMenu.js — settings/pause menu: game info, music/volume, autofire,
+// fuel, parts, weather, compass, speed + existing save/quality/new-game
 
 import { exportSave, importSave, deleteSave, hasSave } from "./save.js";
 import { getQuality, setQuality, isMobile } from "./mobile.js";
@@ -8,9 +9,12 @@ var C = {
   bgLight: "rgba(20,30,50,0.8)",
   border: "rgba(80,100,130,0.4)",
   text: "#8899aa",
+  textDim: "#667788",
   yellow: "#ffcc44",
   red: "#cc4444",
-  green: "#44aa66"
+  green: "#44aa66",
+  blueBright: "#2288cc",
+  orange: "#cc8822"
 };
 
 var BTN = [
@@ -21,11 +25,33 @@ var BTN = [
   "color:" + C.text, "margin:6px 0"
 ].join(";");
 
+var INFO_ROW = [
+  "font-family:monospace", "font-size:13px", "color:" + C.text,
+  "padding:3px 0", "text-align:left"
+].join(";");
+
 var gearBtn = null;
 var menuPanel = null;
 var menuOpen = false;
 var onNewGameCallback = null;
 var confirmOverlay = null;
+
+// --- game info labels (moved from HUD) ---
+var infoSection = null;
+var fuelInfo = null, partsInfo = null, salvageInfo = null;
+var weatherInfo = null, speedInfo = null, compassInfo = null;
+var waveInfo = null, ammoInfo = null;
+
+// --- sound controls (moved from HUD) ---
+var muteBtn = null, volumeSlider = null;
+var onMuteCallback = null, onVolumeCallback = null;
+
+// --- autofire toggle (moved from HUD) ---
+var autofireBtn = null;
+var onAutofireToggleCallback = null;
+
+// --- game data from HUD ---
+var _gameData = null;
 
 // --- PWA install prompt ---
 var deferredPrompt = null;
@@ -39,13 +65,20 @@ window.addEventListener("beforeinstallprompt", function (e) {
 
 export function createSettingsMenu(callbacks) {
   onNewGameCallback = callbacks.onNewGame || null;
+  onMuteCallback = callbacks.onMute || null;
+  onVolumeCallback = callbacks.onVolume || null;
+  onAutofireToggleCallback = callbacks.onAutofireToggle || null;
 
-  // gear button (top-right, below minimap area)
+  var _mob = isMobile();
+
+  // gear button (top-right, beside minimap)
   gearBtn = document.createElement("div");
   gearBtn.textContent = "\u2699";
-  var gearSize = isMobile() ? "min-width:44px;min-height:44px;font-size:28px;padding:8px;display:flex;align-items:center;justify-content:center;" : "font-size:24px;padding:4px;";
+  var minimapWidth = _mob ? 100 : 110;
+  var gearRight = minimapWidth + 16 + 8;
+  var gearSize = _mob ? "min-width:44px;min-height:44px;font-size:28px;padding:8px;display:flex;align-items:center;justify-content:center;" : "font-size:24px;padding:4px;";
   gearBtn.style.cssText = [
-    "position:fixed", "top:16px", "right:180px",
+    "position:fixed", "top:16px", "right:" + gearRight + "px",
     "color:" + C.text, "cursor:pointer",
     "pointer-events:auto", "user-select:none", "z-index:15",
     "font-family:monospace", "line-height:1",
@@ -67,88 +100,102 @@ export function createSettingsMenu(callbacks) {
     "border-radius:8px", "padding:24px 32px",
     "font-family:monospace", "color:" + C.text,
     "z-index:200", "display:none", "text-align:center",
-    "min-width:280px", "pointer-events:auto"
+    "min-width:280px", "max-height:80vh", "overflow-y:auto",
+    "pointer-events:auto"
   ].join(";");
 
   var title = document.createElement("div");
   title.textContent = "SETTINGS";
-  title.style.cssText = "font-size:20px;font-weight:bold;color:" + C.yellow + ";margin-bottom:20px;";
+  title.style.cssText = "font-size:20px;font-weight:bold;color:" + C.yellow + ";margin-bottom:16px;";
   menuPanel.appendChild(title);
 
-  // New Game button
-  var newGameBtn = makeButton("NEW GAME", C.red, function () {
-    showConfirm("Start a new game? This will erase your current save.", function () {
-      deleteSave();
-      closeMenu();
-      if (onNewGameCallback) onNewGameCallback();
-    });
-  });
-  menuPanel.appendChild(newGameBtn);
+  // === GAME INFO SECTION (moved from HUD) ===
+  infoSection = document.createElement("div");
+  infoSection.style.cssText = [
+    "background:" + C.bgLight, "border:1px solid " + C.border,
+    "border-radius:6px", "padding:10px 14px", "margin-bottom:12px",
+    "text-align:left"
+  ].join(";");
 
-  // Export Save button
-  var exportBtn = makeButton("EXPORT SAVE", C.text, function () {
-    var data = exportSave();
-    if (!data) {
-      showNotice("No save data to export.");
-      return;
-    }
-    // copy to clipboard and offer download
-    try {
-      navigator.clipboard.writeText(data);
-    } catch (e) {
-      // fallback: create download
-    }
-    var blob = new Blob([data], { type: "application/json" });
-    var url = URL.createObjectURL(blob);
-    var a = document.createElement("a");
-    a.href = url;
-    a.download = "ocean-outlaws-save.json";
-    a.click();
-    URL.revokeObjectURL(url);
-    showNotice("Save exported!");
-  });
-  menuPanel.appendChild(exportBtn);
+  waveInfo = document.createElement("div");
+  waveInfo.style.cssText = INFO_ROW + ";font-weight:bold;";
+  waveInfo.textContent = "WAVE 1";
+  infoSection.appendChild(waveInfo);
 
-  // Import Save button
-  var importBtn = makeButton("IMPORT SAVE", C.text, function () {
-    var input = document.createElement("input");
-    input.type = "file";
-    input.accept = ".json,application/json";
-    input.style.display = "none";
-    input.addEventListener("change", function () {
-      if (!input.files || !input.files[0]) return;
-      var reader = new FileReader();
-      reader.onload = function (ev) {
-        var success = importSave(ev.target.result);
-        if (success) {
-          showNotice("Save imported! Reload to apply.");
-          setTimeout(function () { location.reload(); }, 1500);
-        } else {
-          showNotice("Invalid save file.");
-        }
-      };
-      reader.readAsText(input.files[0]);
-    });
-    document.body.appendChild(input);
-    input.click();
-    document.body.removeChild(input);
-  });
-  menuPanel.appendChild(importBtn);
+  fuelInfo = document.createElement("div");
+  fuelInfo.style.cssText = INFO_ROW;
+  fuelInfo.textContent = "FUEL: 100%";
+  infoSection.appendChild(fuelInfo);
 
-  // Install App button (PWA)
-  installBtn = makeButton("INSTALL APP", C.green, function () {
-    if (deferredPrompt) {
-      deferredPrompt.prompt();
-      deferredPrompt.userChoice.then(function () {
-        deferredPrompt = null;
-        installBtn.style.display = "none";
-      });
-    }
-  });
-  installBtn.style.display = deferredPrompt ? "block" : "none";
-  menuPanel.appendChild(installBtn);
+  ammoInfo = document.createElement("div");
+  ammoInfo.style.cssText = INFO_ROW;
+  ammoInfo.textContent = "AMMO: --";
+  infoSection.appendChild(ammoInfo);
 
-  // Quality toggle (Low / Medium / High)
+  partsInfo = document.createElement("div");
+  partsInfo.style.cssText = INFO_ROW;
+  partsInfo.textContent = "PARTS: 0";
+  infoSection.appendChild(partsInfo);
+
+  salvageInfo = document.createElement("div");
+  salvageInfo.style.cssText = INFO_ROW + ";color:" + C.yellow;
+  salvageInfo.textContent = "SALVAGE: 0";
+  infoSection.appendChild(salvageInfo);
+
+  weatherInfo = document.createElement("div");
+  weatherInfo.style.cssText = INFO_ROW;
+  weatherInfo.textContent = "WEATHER: CALM";
+  infoSection.appendChild(weatherInfo);
+
+  speedInfo = document.createElement("div");
+  speedInfo.style.cssText = INFO_ROW;
+  speedInfo.textContent = "SPEED: 0.0 kn";
+  infoSection.appendChild(speedInfo);
+
+  compassInfo = document.createElement("div");
+  compassInfo.style.cssText = INFO_ROW;
+  compassInfo.textContent = "HEADING: N 0\u00B0";
+  infoSection.appendChild(compassInfo);
+
+  menuPanel.appendChild(infoSection);
+
+  // === AUTOFIRE TOGGLE ===
+  autofireBtn = makeButton("AUTOFIRE: OFF [F]", C.textDim, function () {
+    if (onAutofireToggleCallback) onAutofireToggleCallback();
+  });
+  menuPanel.appendChild(autofireBtn);
+
+  // === SOUND CONTROLS ===
+  var soundRow = document.createElement("div");
+  soundRow.style.cssText = [
+    BTN, "display:flex", "align-items:center", "justify-content:center", "gap:8px"
+  ].join(";");
+  muteBtn = document.createElement("span");
+  muteBtn.textContent = "\u266A";
+  muteBtn.style.cssText = "cursor:pointer;font-size:18px;color:" + C.text + ";min-width:28px;text-align:center;";
+  muteBtn.addEventListener("click", function (e) {
+    e.stopPropagation();
+    if (onMuteCallback) onMuteCallback();
+  });
+  soundRow.appendChild(muteBtn);
+  var volLabel = document.createElement("span");
+  volLabel.textContent = "VOL";
+  volLabel.style.cssText = "font-size:12px;color:" + C.textDim;
+  soundRow.appendChild(volLabel);
+  volumeSlider = document.createElement("input");
+  volumeSlider.type = "range";
+  volumeSlider.min = "0";
+  volumeSlider.max = "100";
+  volumeSlider.value = "50";
+  volumeSlider.style.cssText = "width:100px;cursor:pointer;pointer-events:auto;accent-color:#4477aa;";
+  volumeSlider.addEventListener("input", function (e) {
+    e.stopPropagation();
+    if (onVolumeCallback) onVolumeCallback(parseFloat(volumeSlider.value) / 100);
+  });
+  soundRow.appendChild(volumeSlider);
+  menuPanel.appendChild(soundRow);
+
+  // === QUALITY TOGGLE ===
   var qualityRow = document.createElement("div");
   qualityRow.style.cssText = [
     BTN, "display:flex", "align-items:center", "justify-content:center", "gap:8px"
@@ -197,6 +244,76 @@ export function createSettingsMenu(callbacks) {
   }
   updateQualityBtns();
 
+  // === SAVE MANAGEMENT ===
+  var newGameBtn = makeButton("NEW GAME", C.red, function () {
+    showConfirm("Start a new game? This will erase your current save.", function () {
+      deleteSave();
+      closeMenu();
+      if (onNewGameCallback) onNewGameCallback();
+    });
+  });
+  menuPanel.appendChild(newGameBtn);
+
+  var exportBtn = makeButton("EXPORT SAVE", C.text, function () {
+    var data = exportSave();
+    if (!data) {
+      showNotice("No save data to export.");
+      return;
+    }
+    try {
+      navigator.clipboard.writeText(data);
+    } catch (e) {
+      // fallback: create download
+    }
+    var blob = new Blob([data], { type: "application/json" });
+    var url = URL.createObjectURL(blob);
+    var a = document.createElement("a");
+    a.href = url;
+    a.download = "ocean-outlaws-save.json";
+    a.click();
+    URL.revokeObjectURL(url);
+    showNotice("Save exported!");
+  });
+  menuPanel.appendChild(exportBtn);
+
+  var importBtn = makeButton("IMPORT SAVE", C.text, function () {
+    var input = document.createElement("input");
+    input.type = "file";
+    input.accept = ".json,application/json";
+    input.style.display = "none";
+    input.addEventListener("change", function () {
+      if (!input.files || !input.files[0]) return;
+      var reader = new FileReader();
+      reader.onload = function (ev) {
+        var success = importSave(ev.target.result);
+        if (success) {
+          showNotice("Save imported! Reload to apply.");
+          setTimeout(function () { location.reload(); }, 1500);
+        } else {
+          showNotice("Invalid save file.");
+        }
+      };
+      reader.readAsText(input.files[0]);
+    });
+    document.body.appendChild(input);
+    input.click();
+    document.body.removeChild(input);
+  });
+  menuPanel.appendChild(importBtn);
+
+  // Install App button (PWA)
+  installBtn = makeButton("INSTALL APP", C.green, function () {
+    if (deferredPrompt) {
+      deferredPrompt.prompt();
+      deferredPrompt.userChoice.then(function () {
+        deferredPrompt = null;
+        installBtn.style.display = "none";
+      });
+    }
+  });
+  installBtn.style.display = deferredPrompt ? "block" : "none";
+  menuPanel.appendChild(installBtn);
+
   // Close button
   var closeBtn = makeButton("CLOSE", C.text, function () {
     closeMenu();
@@ -215,6 +332,65 @@ export function createSettingsMenu(callbacks) {
     "z-index:300", "font-family:monospace"
   ].join(";");
   document.body.appendChild(confirmOverlay);
+}
+
+// --- receive game data from HUD to display in menu ---
+export function updateSettingsData(data) {
+  _gameData = data;
+  if (!menuOpen) return;
+  refreshInfoLabels();
+}
+
+function refreshInfoLabels() {
+  if (!_gameData || !infoSection) return;
+  var d = _gameData;
+  if (d.wave !== undefined && waveInfo) {
+    if (d.waveState === "WAITING") { waveInfo.textContent = "REPAIRING..."; waveInfo.style.color = C.green; }
+    else if (d.waveState === "WAVE_COMPLETE") { waveInfo.textContent = "WAVE " + d.wave + " CLEAR"; waveInfo.style.color = C.green; }
+    else { waveInfo.textContent = "WAVE " + d.wave; waveInfo.style.color = C.text; }
+  }
+  if (d.fuel !== undefined && fuelInfo) {
+    var fuelPct = Math.max(0, d.fuel / d.maxFuel) * 100;
+    fuelInfo.textContent = "FUEL: " + Math.round(d.fuel) + "%";
+    fuelInfo.style.color = fuelPct > 30 ? C.blueBright : fuelPct > 15 ? C.orange : C.red;
+  }
+  if (d.ammo !== undefined && ammoInfo) {
+    ammoInfo.textContent = "AMMO: " + d.ammo + " / " + d.maxAmmo;
+    ammoInfo.style.color = d.ammo <= 5 ? C.red : C.text;
+  }
+  if (d.parts !== undefined && partsInfo) {
+    partsInfo.textContent = "PARTS: " + d.parts;
+    partsInfo.style.color = d.parts > 0 ? C.green : C.text;
+  }
+  if (d.salvage !== undefined && salvageInfo) {
+    salvageInfo.textContent = "SALVAGE: " + d.salvage;
+  }
+  if (d.weatherText && weatherInfo) {
+    weatherInfo.textContent = "WEATHER: " + d.weatherText;
+    weatherInfo.style.color = ({ CALM: C.green, ROUGH: C.yellow, STORM: C.red })[d.weatherText] || C.textDim;
+  }
+  if (d.displaySpeed !== undefined && speedInfo) {
+    speedInfo.textContent = "SPEED: " + d.displaySpeed.toFixed(1) + " kn";
+  }
+  if (d.heading !== undefined && compassInfo) {
+    var deg = ((d.heading * 180 / Math.PI) % 360 + 360) % 360;
+    var dirs = ["N", "NE", "E", "SE", "S", "SW", "W", "NW"];
+    compassInfo.textContent = "HEADING: " + dirs[Math.round(deg / 45) % 8] + " " + Math.round(deg) + "\u00B0";
+  }
+  if (autofireBtn && d.autofireOn !== undefined) {
+    autofireBtn.textContent = d.autofireOn ? "AUTOFIRE: ON [F]" : "AUTOFIRE: OFF [F]";
+    autofireBtn.style.color = d.autofireOn ? C.green : C.textDim;
+  }
+}
+
+export function updateMuteButton(m) {
+  if (!muteBtn) return;
+  muteBtn.textContent = m ? "\u266A\u2715" : "\u266A";
+  muteBtn.style.color = m ? C.red : C.text;
+}
+
+export function updateVolumeSlider(v) {
+  if (volumeSlider) volumeSlider.value = String(Math.round(v * 100));
 }
 
 function makeButton(text, color, onClick) {
@@ -236,8 +412,8 @@ function toggleMenu() {
 function openMenu() {
   menuOpen = true;
   menuPanel.style.display = "block";
-  // show install btn if prompt available
   if (installBtn) installBtn.style.display = deferredPrompt ? "block" : "none";
+  refreshInfoLabels();
 }
 
 function closeMenu() {


### PR DESCRIPTION
Closes #90

## Summary
- Decluttered the in-game HUD to show only essential combat info
- Moved secondary info (fuel, parts, weather, speed, compass, music/volume, autofire) to the settings/pause menu
- Reduced visual noise on both desktop and mobile

## Acceptance Criteria

- [x] **HP bar always visible (no numbers unless damaged)** — HP bar shows in top-left; numbers only appear when HP < max
- [x] **Weapon selector uses icons, not text** — Bottom-center shows 3 icon buttons (bullet, diamond, bar) with colored borders for active weapon
- [x] **Minimap smaller** — Reduced from 140px to 110px desktop / 100px mobile
- [x] **Wave banner shows on change, fades after 2-3s** — Already worked this way via showBanner; duplicate top-center wave label removed
- [x] **Ammo shows on change, fades after 2-3s** — Ammo popup appears on fire/reload, fades after 2.5s
- [x] **Salvage shows on change, fades after 2-3s** — Salvage popup appears on pickup, fades after 2.5s
- [x] **Fuel gauge moved to pause/settings menu** — Displayed in info section of settings panel
- [x] **Parts count moved to pause/settings menu** — Displayed in info section of settings panel
- [x] **Weather indicator moved to pause/settings menu** — Displayed in info section of settings panel
- [x] **Music/volume controls moved to pause/settings menu** — Sound controls with mute button and volume slider in settings panel
- [x] **Autofire toggle moved to pause/settings menu** — Clickable autofire button in settings panel; popup notification on change
- [x] **Speed readout moved to pause/settings menu** — Displayed in info section of settings panel
- [x] **Compass bearing moved to pause/settings menu** — Displayed in info section of settings panel
- [x] **Duplicate wave notification removed** — Removed top-center persistent wave label; only center banner remains
- [x] **AUTOFIRE text consolidated** — Replaced with brief popup notification that fades
- [x] **Ability button replaced with cooldown ring** — Small canvas ring in bottom-left shows Q label, cooldown arc, active state
- [x] **Mobile: even more minimal** — Smaller minimap, icon-only weapons, no text labels; all info in pause menu