### PR TITLE
Pirate reskin: rename ship classes, weapons, and all UI text

### DIFF
--- a/game/js/boss.js
+++ b/game/js/boss.js
@@ -7,7 +7,7 @@ import { collideWithTerrain, isLand } from "./terrain.js";
 // --- boss definitions ---
 var BOSS_DEFS = {
   battleship: {
-    name: "Iron Leviathan",
+    name: "Blackthorn the Relentless",
     hp: 80,
     hitRadius: 5.0,
     speed: 6,
@@ -20,7 +20,7 @@ var BOSS_DEFS = {
     color: 0x884444
   },
   carrier: {
-    name: "Swarm Mother",
+    name: "The Widow's Galleon",
     hp: 60,
     hitRadius: 6.0,
     speed: 5,
@@ -520,7 +520,7 @@ var LOOT_TABLE = [
   { type: "upgrade", label: "+30% Max HP", stat: "maxHp", value: 0.30 },
   { type: "upgrade", label: "+20% Fire Rate", stat: "fireRate", value: 0.20 },
   { type: "upgrade", label: "+20% Speed", stat: "maxSpeed", value: 0.20 },
-  { type: "salvage", label: "+100 Salvage", value: 100 },
+  { type: "salvage", label: "+100 Gold", value: 100 },
   { type: "repair", label: "Full Repair", value: 1.0 }
 ];
 

--- a/game/js/hud.js
+++ b/game/js/hud.js
@@ -329,7 +329,7 @@ export function showGameOver(waveReached) {
   if (!overlay) return;
   overlayTitle.textContent = "GAME OVER";
   overlayTitle.style.color = C.red;
-  overlaySubtext.textContent = "You reached Wave " + waveReached;
+  overlaySubtext.textContent = "You reached Fleet " + waveReached;
   overlayBtn.textContent = "RESTART";
   overlay.style.display = "flex";
 }
@@ -337,7 +337,7 @@ export function showVictory(waveReached) {
   if (!overlay) return;
   overlayTitle.textContent = "VICTORY";
   overlayTitle.style.color = C.greenBright;
-  overlaySubtext.textContent = "All " + waveReached + " waves survived!";
+  overlaySubtext.textContent = "All " + waveReached + " fleets defeated!";
   overlayBtn.textContent = "CONTINUE";
   overlay.style.display = "flex";
 }
@@ -489,7 +489,7 @@ export function updateHUD(speedRatio, displaySpeed, heading, ammo, maxAmmo, hp, 
 
   // Salvage popup — show on change, fade after 2.5s
   if (salvage !== undefined && prevSalvage >= 0 && salvage !== prevSalvage) {
-    salvagePopup.textContent = "SALVAGE +" + (salvage - prevSalvage);
+    salvagePopup.textContent = "GOLD +" + (salvage - prevSalvage);
     salvagePopup.style.color = C.yellow;
     salvagePopupTimer = 2.5;
   }

--- a/game/js/main.js
+++ b/game/js/main.js
@@ -119,7 +119,7 @@ setOnDeathCallback(enemyMgr, function (x, y, z) {
   addSalvage(upgrades, sal);
   playExplosion();
   playKillConfirm();
-  addKillFeedEntry("Enemy destroyed  +" + sal + " salvage", "#ffcc44");
+  addKillFeedEntry("Enemy destroyed  +" + sal + " gold", "#ffcc44");
   triggerScreenShake(0.3);
 });
 
@@ -364,7 +364,7 @@ function startMultiplayerCombat() {
   upgradeScreenOpen = false;
   activeZoneId = null;
   fadeIn(0.6);
-  showBanner("Multiplayer — Wave 1", 3);
+  showBanner("Multiplayer — Fleet Approaching!", 3);
 }
 
 function handleShipSelect(classKey) {
@@ -447,7 +447,7 @@ function startZoneCombat(classKey, zoneId) {
   gameStarted = true;
   upgradeScreenOpen = false;
   fadeIn(0.6);
-  showBanner(zone.name + " — Wave 1", 3);
+  showBanner(zone.name + " — Fleet Approaching!", 3);
 }
 
 function handleZoneVictory() {
@@ -717,8 +717,8 @@ function animate() {
 
     if (event) {
       if (event === "wave_start") {
-        showBanner("Wave " + waveMgr.wave + " incoming!", 3);
-        addKillFeedEntry("Wave " + waveMgr.wave + " incoming!", "#44aaff");
+        showBanner("Fleet " + waveMgr.wave + " Approaching!", 3);
+        addKillFeedEntry("Fleet " + waveMgr.wave + " Approaching!", "#44aaff");
         playWaveHorn();
       } else if (event.indexOf("wave_start_boss:") === 0) {
         var bossType = event.split(":")[1];
@@ -731,11 +731,11 @@ function animate() {
           showBossHud(activeBoss.def.name);
           showBanner("BOSS: " + activeBoss.def.name + "!", 4);
         } else {
-          showBanner("Wave " + waveMgr.wave + " incoming!", 3);
+          showBanner("Fleet " + waveMgr.wave + " Approaching!", 3);
         }
       } else if (event === "wave_complete") {
-        showBanner("Wave " + waveMgr.wave + " cleared!", 2.5);
-        addKillFeedEntry("Wave " + waveMgr.wave + " cleared!", "#44dd66");
+        showBanner("Fleet " + waveMgr.wave + " defeated!", 2.5);
+        addKillFeedEntry("Fleet " + waveMgr.wave + " defeated!", "#44dd66");
         clearPickups(pickupMgr, scene);
         clearCrates(crateMgr, scene);
         if (activeBoss) {

--- a/game/js/settingsMenu.js
+++ b/game/js/settingsMenu.js
@@ -119,7 +119,7 @@ export function createSettingsMenu(callbacks) {
 
   waveInfo = document.createElement("div");
   waveInfo.style.cssText = INFO_ROW + ";font-weight:bold;";
-  waveInfo.textContent = "WAVE 1";
+  waveInfo.textContent = "FLEET 1";
   infoSection.appendChild(waveInfo);
 
   fuelInfo = document.createElement("div");
@@ -139,7 +139,7 @@ export function createSettingsMenu(callbacks) {
 
   salvageInfo = document.createElement("div");
   salvageInfo.style.cssText = INFO_ROW + ";color:" + C.yellow;
-  salvageInfo.textContent = "SALVAGE: 0";
+  salvageInfo.textContent = "GOLD: 0";
   infoSection.appendChild(salvageInfo);
 
   weatherInfo = document.createElement("div");
@@ -346,8 +346,8 @@ function refreshInfoLabels() {
   var d = _gameData;
   if (d.wave !== undefined && waveInfo) {
     if (d.waveState === "WAITING") { waveInfo.textContent = "REPAIRING..."; waveInfo.style.color = C.green; }
-    else if (d.waveState === "WAVE_COMPLETE") { waveInfo.textContent = "WAVE " + d.wave + " CLEAR"; waveInfo.style.color = C.green; }
-    else { waveInfo.textContent = "WAVE " + d.wave; waveInfo.style.color = C.text; }
+    else if (d.waveState === "WAVE_COMPLETE") { waveInfo.textContent = "FLEET " + d.wave + " CLEAR"; waveInfo.style.color = C.green; }
+    else { waveInfo.textContent = "FLEET " + d.wave; waveInfo.style.color = C.text; }
   }
   if (d.fuel !== undefined && fuelInfo) {
     var fuelPct = Math.max(0, d.fuel / d.maxFuel) * 100;
@@ -363,7 +363,7 @@ function refreshInfoLabels() {
     partsInfo.style.color = d.parts > 0 ? C.green : C.text;
   }
   if (d.salvage !== undefined && salvageInfo) {
-    salvageInfo.textContent = "SALVAGE: " + d.salvage;
+    salvageInfo.textContent = "GOLD: " + d.salvage;
   }
   if (d.weatherText && weatherInfo) {
     weatherInfo.textContent = "WEATHER: " + d.weatherText;

--- a/game/js/shipClass.js
+++ b/game/js/shipClass.js
@@ -4,7 +4,7 @@
 var SHIP_CLASSES = {
   destroyer: {
     key: "destroyer",
-    name: "Destroyer",
+    name: "Sloop",
     description: "Fast and agile, but fragile",
     color: "#44aaff",
     stats: {
@@ -24,7 +24,7 @@ var SHIP_CLASSES = {
   },
   cruiser: {
     key: "cruiser",
-    name: "Cruiser",
+    name: "Brigantine",
     description: "Balanced all-rounder",
     color: "#ffcc44",
     stats: {
@@ -44,7 +44,7 @@ var SHIP_CLASSES = {
   },
   carrier: {
     key: "carrier",
-    name: "Carrier",
+    name: "Galleon",
     description: "Slow but launches attack drones",
     color: "#44dd66",
     stats: {
@@ -64,8 +64,8 @@ var SHIP_CLASSES = {
   },
   submarine: {
     key: "submarine",
-    name: "Submarine",
-    description: "Stealth vessel with torpedo focus",
+    name: "Man-o'-War",
+    description: "Stealth vessel with fire bomb focus",
     color: "#cc66ff",
     stats: {
       hp: 9,

--- a/game/js/shipSelect.js
+++ b/game/js/shipSelect.js
@@ -189,7 +189,7 @@ function showResetConfirm() {
   var refund = getTotalSpent(currentUpgradeState);
   var refundLabel = confirmDialog.querySelector("#reset-refund-label");
   if (refundLabel) {
-    refundLabel.textContent = "Refund: " + refund + " salvage";
+    refundLabel.textContent = "Refund: " + refund + " gold";
   }
   confirmDialog.style.display = "flex";
 }

--- a/game/js/techScreen.js
+++ b/game/js/techScreen.js
@@ -288,7 +288,7 @@ function refreshUI() {
   if (!currentState || !root) return;
 
   var salvage = currentSalvage ? currentSalvage.get() : 0;
-  salvageLabel.textContent = "Salvage: " + salvage;
+  salvageLabel.textContent = "Gold: " + salvage;
 
   var branches = getTechBranches();
   var branchKeys = Object.keys(branches);
@@ -328,7 +328,7 @@ function refreshUI() {
         nEl.icon.style.borderColor = bPanel.color + "88";
         nEl.icon.style.color = bPanel.color;
         nEl.nameEl.style.color = "#aabbcc";
-        nEl.costLabel.textContent = node.cost + " salvage";
+        nEl.costLabel.textContent = node.cost + " gold";
         nEl.costLabel.style.color = affordable ? "#aabbcc" : "#556677";
         nEl.statusLabel.textContent = affordable ? "UNLOCK" : "LOCKED";
         nEl.statusLabel.style.color = affordable ? "#44dd66" : "#556677";
@@ -341,7 +341,7 @@ function refreshUI() {
         nEl.icon.style.borderColor = "#333344";
         nEl.icon.style.color = "#444455";
         nEl.nameEl.style.color = "#445566";
-        nEl.costLabel.textContent = node.cost + " salvage";
+        nEl.costLabel.textContent = node.cost + " gold";
         nEl.costLabel.style.color = "#334455";
         nEl.statusLabel.textContent = "LOCKED";
         nEl.statusLabel.style.color = "#334455";

--- a/game/js/techTree.js
+++ b/game/js/techTree.js
@@ -33,9 +33,9 @@ var TECH_BRANCHES = {
     nodes: [
       { key: "wide_radar",    label: "Wide Radar",       desc: "+30% radar range",        cost: 40,  stat: "enemyRange",   bonus: 0.30 },
       { key: "mag_pickup",    label: "Mag. Pickup",      desc: "+40% pickup range",       cost: 80,  stat: "pickupRange",  bonus: 0.40 },
-      { key: "salvage_bonus", label: "Salvage Bonus",    desc: "+25% salvage earned",     cost: 120, stat: "salvageBonus", bonus: 0.25 },
+      { key: "salvage_bonus", label: "Gold Bonus",       desc: "+25% gold earned",        cost: 120, stat: "salvageBonus", bonus: 0.25 },
       { key: "swift_nav",     label: "Swift Nav",        desc: "+15% max speed",          cost: 180, stat: "maxSpeed",     bonus: 0.15 },
-      { key: "master_loot",   label: "Master Loot",      desc: "+50% salvage, +20% range", cost: 260, stat: "masterLoot",  bonus: 1    }
+      { key: "master_loot",   label: "Master Loot",      desc: "+50% gold, +20% range",   cost: 260, stat: "masterLoot",  bonus: 1    }
     ]
   }
 };

--- a/game/js/upgradeScreen.js
+++ b/game/js/upgradeScreen.js
@@ -556,13 +556,13 @@ function renderInlineDetail(row) {
 
     // cost line
     var costLine = document.createElement("div");
-    costLine.textContent = "Cost: " + cost + " salvage";
+    costLine.textContent = "Cost: " + cost + " gold";
     costLine.style.cssText = "font-size:" + (_mob ? "12px" : "11px") + ";color:" + (affordable ? "#ffcc44" : "#664422") + ";margin-top:2px";
     detail.appendChild(costLine);
 
     if (!affordable) {
       var hint = document.createElement("div");
-      hint.textContent = "Not enough salvage";
+      hint.textContent = "Not enough gold";
       hint.style.cssText = "font-size:11px;color:#664422;margin-top:2px";
       detail.appendChild(hint);
     } else {
@@ -578,7 +578,7 @@ function renderInlineDetail(row) {
 function refreshUI() {
   if (!currentState || !root) return;
 
-  salvageLabel.textContent = "Salvage: " + currentState.salvage;
+  salvageLabel.textContent = "Gold: " + currentState.salvage;
 
   var tree = getUpgradeTree();
   var cats = Object.keys(tree);
@@ -627,7 +627,7 @@ function refreshUI() {
         row.costLabel.textContent = "N/A";
         row.costLabel.style.color = "#445566";
       } else {
-        row.costLabel.textContent = cost + " salvage";
+        row.costLabel.textContent = cost + " gold";
         row.costLabel.style.color = affordable ? "#aabbcc" : "#556677";
       }
 

--- a/game/js/weapon.js
+++ b/game/js/weapon.js
@@ -8,19 +8,19 @@ import { playImpactSound } from "./soundFx.js";
 
 var WEAPON_TYPES = {
   turret: {
-    name: "Turret", key: 0, fireRate: 1.0, damage: 1, projSpeed: 35,
+    name: "Cannon", key: 0, fireRate: 1.0, damage: 1, projSpeed: 35,
     ammoCost: 1, color: 0xffcc44, trailColor: 0xffcc44, projRadius: 0.12,
     gravity: 9.8, loft: 0.08, maxRange: 40, homing: false,
     waterLevel: false, splashScale: 1.0
   },
   missile: {
-    name: "Missile", key: 1, fireRate: 2.5, damage: 3, projSpeed: 28,
+    name: "Chain Shot", key: 1, fireRate: 2.5, damage: 3, projSpeed: 28,
     ammoCost: 3, color: 0xff6644, trailColor: 0xff8844, projRadius: 0.2,
     gravity: 2.0, loft: 0.15, maxRange: 50, homing: true,
     homingTurnRate: 1.8, waterLevel: false, splashScale: 2.0
   },
   torpedo: {
-    name: "Torpedo", key: 2, fireRate: 4.0, damage: 6, projSpeed: 18,
+    name: "Fire Bomb", key: 2, fireRate: 4.0, damage: 6, projSpeed: 18,
     ammoCost: 5, color: 0x44aaff, trailColor: 0x88ccff, projRadius: 0.25,
     gravity: 0, loft: 0, maxRange: 35, homing: false,
     waterLevel: true, splashScale: 3.5, wakeTrail: true

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <meta name="theme-color" content="#0a0e1a">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <meta name="description" content="Ocean Outlaws — browser-based naval combat. Build your fleet, upgrade your ship, survive the waves.">
+  <meta name="description" content="Ocean Outlaws — browser-based naval combat. Build your fleet, upgrade your ship, defeat the enemy fleets.">
   <title>Ocean Outlaws</title>
   <link rel="icon" href="game/icons/icon-192.png" type="image/png">
   <link rel="apple-touch-icon" href="game/icons/icon-192.png">
@@ -307,7 +307,7 @@
       <div class="feature">
         <div class="feature-icon">⚓</div>
         <h3>4 Ship Classes</h3>
-        <p>Destroyer, Cruiser, Carrier, Submarine — each with unique abilities</p>
+        <p>Sloop, Brigantine, Galleon, Man-o'-War — each with unique abilities</p>
       </div>
       <div class="feature">
         <div class="feature-icon">🌊</div>
@@ -316,8 +316,8 @@
       </div>
       <div class="feature">
         <div class="feature-icon">⚔️</div>
-        <h3>Wave Survival</h3>
-        <p>Fight through enemy waves, hunt bosses, collect salvage</p>
+        <h3>Fleet Survival</h3>
+        <p>Fight through enemy fleets, hunt bosses, collect gold</p>
       </div>
       <div class="feature">
         <div class="feature-icon">🔧</div>


### PR DESCRIPTION
Closes #107

## Summary
- Rename all user-facing text to pirate theme — ship classes, weapons, bosses, currency, and wave announcements
- Pure text/naming pass across 11 files; no functionality changes
- Internal identifiers (object keys, variable names, property names) unchanged

## Acceptance Criteria
- [x] Ship classes renamed: Destroyer→Sloop, Cruiser→Brigantine, Carrier→Galleon, Submarine→Man-o'-War
- [x] Weapons renamed: Turret→Cannon, Missile→Chain Shot, Torpedo→Fire Bomb
- [x] All HUD text, upgrade screen labels, tech tree labels updated to pirate terminology
- [x] Ship select screen shows pirate names and descriptions
- [x] Boss names: Iron Leviathan→Blackthorn the Relentless, Swarm Mother→The Widow's Galleon, The Kraken unchanged
- [x] Wave announcements rethemed: "Fleet X Approaching!" instead of "Wave X incoming"
- [x] Currency: "salvage" renamed to "gold" everywhere in user-facing text
- [x] No functionality changes — pure text/naming pass

## Test plan
- [ ] Start game, verify ship select shows Sloop / Brigantine / Galleon / Man-o'-War
- [ ] Play a round, confirm HUD shows "GOLD" not "SALVAGE"
- [ ] Reach wave transition, confirm "Fleet X Approaching!" banner
- [ ] Open upgrade screen, verify costs show "gold" not "salvage"
- [ ] Open tech tree, verify "Gold Bonus" label and "gold" cost labels
- [ ] Open settings menu, verify "FLEET X" and "GOLD: X" labels
- [ ] Trigger boss encounter, verify renamed boss names appear
- [ ] Check landing page (index.html) shows updated ship class names and "Fleet Survival"

🤖 Generated with [Claude Code](https://claude.com/claude-code)