### PR TITLE
HUD: QWER ability bar (League-style) + fuel bar below HP

### DIFF
--- a/game/js/input.js
+++ b/game/js/input.js
@@ -1,4 +1,5 @@
 // input.js — click/tap + keyboard input handler
+// QWER ability bar: Q/W/E/R mapped to slot0-slot3
 
 var mouse = {
   x: 0,
@@ -10,8 +11,8 @@ var mouse = {
 // keyboard action queue — consumed once per frame
 var keyActions = [];
 
-// autofire state
-var autofire = false;
+// autofire state (always on — no toggle key)
+var autofire = true;
 
 // game canvas reference — only clicks on canvas register as game input
 var gameCanvas = null;
@@ -53,23 +54,14 @@ function onKeyDown(e) {
   var tag = e.target.tagName;
   if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
   var key = e.key;
-  if (key === " " || key === "f" || key === "F") {
-    e.preventDefault();
-    keyActions.push("toggleAutofire");
-  } else if (key === "1") {
-    keyActions.push("weapon0");
-  } else if (key === "2") {
-    keyActions.push("weapon1");
-  } else if (key === "3") {
-    keyActions.push("weapon2");
-  } else if (key === "q" || key === "Q") {
-    keyActions.push("weapon0");
+  if (key === "q" || key === "Q") {
+    keyActions.push("slot0");
   } else if (key === "w" || key === "W") {
-    keyActions.push("weapon1");
+    keyActions.push("slot1");
   } else if (key === "e" || key === "E") {
-    keyActions.push("weapon2");
-  } else if (key === "r" || key === "R" || key === "Shift") {
-    keyActions.push("ability");
+    keyActions.push("slot2");
+  } else if (key === "r" || key === "R") {
+    keyActions.push("slot3");
   }
 }
 


### PR DESCRIPTION
Closes #105

## Changes

### QWER Ability Bar
- [x] Abilities mapped to Q, W, E, R keys (like League of Legends)
- [x] Single horizontal row, centered bottom of screen
- [x] Each slot: icon + key label + cooldown overlay
- [x] Visual style: square icons with rounded corners, slight border, dim when on cooldown
- [x] Cooldown shown as radial sweep + seconds remaining

### Fuel Bar Below HP
- [x] Fuel bar displayed directly below the HP bar
- [x] Thinner than HP bar, different color (amber/yellow)
- [x] Shows current fuel level

### Remove old keybinds
- [x] Weapon switching (1/2/3) removed
- [x] F for autofire removed (autofire now always on; toggleable from settings menu)
- [x] QWER replaces the current ability system

## Files Changed
- `game/js/hud.js` — Replaced weapon panel + ability ring with QWER bar; added fuel bar
- `game/js/input.js` — Mapped Q/W/E/R to slot0-3; removed 1/2/3 and F/Space keybinds
- `game/js/main.js` — Wired QWER bar callbacks, builds abilityBarInfo for HUD