### PR TITLE
Node-based voyage chart (Slay the Spire style)

### DIFF
--- a/game/js/voyageChart.js
+++ b/game/js/voyageChart.js
@@ -1,0 +1,457 @@
+// voyageChart.js — canvas-rendered voyage chart overlay (Slay the Spire style)
+// Nautical/parchment aesthetic. Player clicks revealed nodes to navigate.
+
+import { getNodeTypes, getReachableNodes } from "./voyageData.js";
+import { isMobile } from "./mobile.js";
+import { T, FONT } from "./theme.js";
+
+var overlay = null;
+var chartCanvas = null;
+var chartCtx = null;
+var onSelectCallback = null;
+var currentChart = null;
+var currentState = null;
+var hoveredNodeId = null;
+var tooltipEl = null;
+var nodeHitAreas = []; // {id, cx, cy, r}
+var _touchStartPos = null;
+
+var NODE_ICONS = { fleet_battle: "\u2694", harbor_raid: "\u2693", merchant_chase: "\u26F5", salvage: "\u{1F4A0}", storm_crossing: "\u2601", event: "\u{1F4DC}", boss: "\u2620" };
+
+// --- create the chart overlay (call once) ---
+export function createVoyageChart() {
+  var _mob = isMobile();
+  overlay = document.createElement("div");
+  overlay.style.cssText = [
+    "position: fixed",
+    "top: 0",
+    "left: 0",
+    "width: 100%",
+    "height: 100%",
+    "display: none",
+    "flex-direction: column",
+    "align-items: center",
+    _mob ? "justify-content: flex-start" : "justify-content: center",
+    "background:" + T.bgOverlay,
+    "z-index: 150",
+    "font-family:" + FONT,
+    "user-select: none",
+    "overflow-y: auto",
+    _mob ? "padding: 12px 0" : ""
+  ].join(";");
+
+  var title = document.createElement("div");
+  title.textContent = "VOYAGE CHART";
+  title.style.cssText = "font-size:28px;font-weight:bold;color:" + T.gold + ";margin-bottom:6px;text-shadow:0 2px 4px rgba(0,0,0,0.6);letter-spacing:4px";
+  overlay.appendChild(title);
+  var subtitle = document.createElement("div");
+  subtitle.textContent = "Choose your path through these waters";
+  subtitle.style.cssText = "font-size:13px;color:" + T.textDim + ";margin-bottom:12px";
+  overlay.appendChild(subtitle);
+
+  var canvasWrap = document.createElement("div");
+  canvasWrap.style.cssText = "position:relative;width:700px;max-width:94vw;height:420px;max-height:60vh";
+  chartCanvas = document.createElement("canvas");
+  chartCanvas.width = 700;
+  chartCanvas.height = 420;
+  chartCanvas.style.cssText = "width:100%;height:100%;border:2px solid " + T.borderGold + ";border-radius:6px;cursor:pointer";
+  chartCtx = chartCanvas.getContext("2d");
+  canvasWrap.appendChild(chartCanvas);
+  tooltipEl = document.createElement("div");
+  tooltipEl.style.cssText = "position:absolute;padding:10px 14px;background:" + T.bgDark + ";border:1px solid " + T.borderGold + ";border-radius:4px;font-size:12px;font-family:" + FONT + ";color:" + T.text + ";pointer-events:none;display:none;" + (_mob ? "white-space:normal;max-width:200px" : "white-space:nowrap") + ";z-index:160";
+  canvasWrap.appendChild(tooltipEl);
+  overlay.appendChild(canvasWrap);
+
+  var legend = document.createElement("div");
+  legend.style.cssText = "margin-top:10px;font-size:11px;color:" + T.textDim + ";display:flex;flex-wrap:wrap;gap:12px;justify-content:center;font-family:" + FONT;
+  var types = getNodeTypes();
+  var typeKeys = ["fleet_battle", "harbor_raid", "merchant_chase", "salvage", "storm_crossing", "event", "boss"];
+  for (var i = 0; i < typeKeys.length; i++) {
+    var t = types[typeKeys[i]];
+    legend.innerHTML += '<span style="color:' + t.color + '">' + t.icon + " " + t.label + "</span>";
+  }
+  overlay.appendChild(legend);
+
+  chartCanvas.addEventListener("mousemove", onMouseMove);
+  chartCanvas.addEventListener("click", onClick);
+  chartCanvas.addEventListener("mouseleave", function () { hoveredNodeId = null; tooltipEl.style.display = "none"; drawChart(); });
+  chartCanvas.addEventListener("touchstart", onTouchStart, { passive: false });
+  chartCanvas.addEventListener("touchend", onTouchEnd, { passive: false });
+  document.body.appendChild(overlay);
+}
+
+// --- canvas coordinate helpers ---
+function getCanvasPos(e) {
+  var rect = chartCanvas.getBoundingClientRect();
+  var scaleX = chartCanvas.width / rect.width;
+  var scaleY = chartCanvas.height / rect.height;
+  return {
+    x: (e.clientX - rect.left) * scaleX,
+    y: (e.clientY - rect.top) * scaleY
+  };
+}
+
+function getCanvasPosFromTouch(touch) {
+  var rect = chartCanvas.getBoundingClientRect();
+  var scaleX = chartCanvas.width / rect.width;
+  var scaleY = chartCanvas.height / rect.height;
+  return {
+    x: (touch.clientX - rect.left) * scaleX,
+    y: (touch.clientY - rect.top) * scaleY
+  };
+}
+
+// --- hit detection ---
+function findNodeAt(px, py) {
+  for (var i = 0; i < nodeHitAreas.length; i++) {
+    var n = nodeHitAreas[i];
+    var dx = px - n.cx;
+    var dy = py - n.cy;
+    if (dx * dx + dy * dy <= n.r * n.r) return n.id;
+  }
+  return null;
+}
+
+// --- touch handling ---
+function onTouchStart(e) {
+  if (!e.touches.length) return;
+  _touchStartPos = { x: e.touches[0].clientX, y: e.touches[0].clientY };
+}
+
+function onTouchEnd(e) {
+  if (!e.changedTouches.length || !_touchStartPos) return;
+  var touch = e.changedTouches[0];
+  var dx = Math.abs(touch.clientX - _touchStartPos.x);
+  var dy = Math.abs(touch.clientY - _touchStartPos.y);
+  if (dx > 15 || dy > 15) return; // scroll, not tap
+
+  e.preventDefault();
+  var pos = getCanvasPosFromTouch(touch);
+  var nodeId = findNodeAt(pos.x, pos.y);
+
+  if (nodeId !== null && currentChart && currentState) {
+    var reachable = getReachableNodes(currentChart, currentState);
+    var isReachable = false;
+    for (var i = 0; i < reachable.length; i++) {
+      if (reachable[i] === nodeId) { isReachable = true; break; }
+    }
+
+    if (hoveredNodeId === nodeId && isReachable) {
+      // second tap — navigate
+      if (onSelectCallback) onSelectCallback(nodeId);
+      return;
+    }
+    // first tap — show tooltip
+    hoveredNodeId = nodeId;
+    showTooltipForNode(nodeId, touch.clientX, touch.clientY);
+    drawChart();
+  } else {
+    hoveredNodeId = null;
+    tooltipEl.style.display = "none";
+    drawChart();
+  }
+}
+
+// --- mouse handling ---
+function onMouseMove(e) {
+  var pos = getCanvasPos(e);
+  var nodeId = findNodeAt(pos.x, pos.y);
+  hoveredNodeId = nodeId;
+
+  if (nodeId !== null && currentChart && currentState) {
+    showTooltipForNode(nodeId, e.clientX, e.clientY);
+  } else {
+    tooltipEl.style.display = "none";
+  }
+  drawChart();
+}
+
+function onClick(e) {
+  var pos = getCanvasPos(e);
+  var nodeId = findNodeAt(pos.x, pos.y);
+  if (nodeId === null || !currentChart || !currentState) return;
+
+  var reachable = getReachableNodes(currentChart, currentState);
+  for (var i = 0; i < reachable.length; i++) {
+    if (reachable[i] === nodeId) {
+      if (onSelectCallback) onSelectCallback(nodeId);
+      return;
+    }
+  }
+}
+
+// --- tooltip ---
+function showTooltipForNode(nodeId, clientX, clientY) {
+  var node = getNode(nodeId);
+  if (!node) return;
+
+  var types = getNodeTypes();
+  var info = types[node.type] || { label: "Unknown", icon: "?", color: "#888" };
+  var isVisited = !!currentState.visited[nodeId];
+  var isRevealed = !!currentState.revealed[nodeId];
+  var isCurrent = currentState.currentNodeId === nodeId;
+  var reachable = getReachableNodes(currentChart, currentState);
+  var isReachable = false;
+  for (var i = 0; i < reachable.length; i++) {
+    if (reachable[i] === nodeId) { isReachable = true; break; }
+  }
+
+  var statusText = "";
+  if (isCurrent) statusText = '<div style="color:' + T.gold + ';margin-top:4px">You are here</div>';
+  else if (isReachable) statusText = '<div style="color:' + T.greenBright + ';margin-top:4px">Click to sail here</div>';
+  else if (isVisited) statusText = '<div style="color:' + T.textDim + ';margin-top:4px">Visited</div>';
+  else if (isRevealed) statusText = '<div style="color:' + T.textDim + ';margin-top:4px">Not reachable from here</div>';
+
+  tooltipEl.innerHTML =
+    '<div style="font-size:16px;margin-bottom:4px">' + info.icon + "</div>" +
+    '<div style="font-size:14px;font-weight:bold;color:' + info.color + ';margin-bottom:2px">' + info.label + "</div>" +
+    statusText;
+
+  var rect = chartCanvas.getBoundingClientRect();
+  var tx = clientX - rect.left + 16;
+  var ty = clientY - rect.top - 10;
+  if (tx + 180 > rect.width) tx = tx - 200;
+  if (ty < 0) ty = 10;
+  tooltipEl.style.left = tx + "px";
+  tooltipEl.style.top = ty + "px";
+  tooltipEl.style.display = "block";
+}
+
+function getNode(nodeId) {
+  if (!currentChart) return null;
+  for (var i = 0; i < currentChart.nodes.length; i++) {
+    if (currentChart.nodes[i].id === nodeId) return currentChart.nodes[i];
+  }
+  return null;
+}
+
+// --- draw the voyage chart ---
+function drawChart() {
+  if (!chartCtx || !currentChart || !currentState) return;
+
+  var W = chartCanvas.width;
+  var H = chartCanvas.height;
+  var ctx = chartCtx;
+  var chart = currentChart;
+  var state = currentState;
+  var types = getNodeTypes();
+  var reachable = getReachableNodes(chart, state);
+  var reachableSet = {};
+  for (var ri = 0; ri < reachable.length; ri++) reachableSet[reachable[ri]] = true;
+
+  // padded draw area
+  var padL = 50;
+  var padR = 50;
+  var padT = 30;
+  var padB = 30;
+  var drawW = W - padL - padR;
+  var drawH = H - padT - padB;
+
+  // clear
+  ctx.clearRect(0, 0, W, H);
+
+  // background — aged parchment
+  var bgGrad = ctx.createLinearGradient(0, 0, 0, H);
+  bgGrad.addColorStop(0, "#2a1e12");
+  bgGrad.addColorStop(0.5, "#241a10");
+  bgGrad.addColorStop(1, "#1e150c");
+  ctx.fillStyle = bgGrad;
+  ctx.fillRect(0, 0, W, H);
+
+  // grid lines
+  ctx.strokeStyle = "rgba(139, 109, 68, 0.10)";
+  ctx.lineWidth = 1;
+  for (var gx = 0; gx < W; gx += 40) {
+    ctx.beginPath(); ctx.moveTo(gx, 0); ctx.lineTo(gx, H); ctx.stroke();
+  }
+  for (var gy = 0; gy < H; gy += 40) {
+    ctx.beginPath(); ctx.moveTo(0, gy); ctx.lineTo(W, gy); ctx.stroke();
+  }
+
+  // compass rose
+  drawCompassRose(ctx, W - 40, 40, 24);
+
+  // helper: node position on canvas
+  function nodePos(n) {
+    return {
+      cx: padL + n.x * drawW,
+      cy: padT + n.y * drawH
+    };
+  }
+
+  // draw edges
+  ctx.lineWidth = 2;
+  for (var ei = 0; ei < chart.edges.length; ei++) {
+    var e = chart.edges[ei];
+    var fromN = getNode(e.from);
+    var toN = getNode(e.to);
+    if (!fromN || !toN) continue;
+
+    var fromRevealed = !!state.revealed[e.from];
+    var toRevealed = !!state.revealed[e.to];
+    if (!fromRevealed && !toRevealed) continue; // fully fogged
+
+    var p1 = nodePos(fromN);
+    var p2 = nodePos(toN);
+
+    var bothRevealed = fromRevealed && toRevealed;
+    var isPath = !!state.visited[e.from] && !!state.visited[e.to];
+
+    if (isPath) {
+      ctx.strokeStyle = "rgba(212, 164, 74, 0.6)";
+      ctx.setLineDash([]);
+    } else if (bothRevealed) {
+      ctx.strokeStyle = "rgba(212, 164, 74, 0.25)";
+      ctx.setLineDash([6, 4]);
+    } else {
+      ctx.strokeStyle = "rgba(80, 60, 35, 0.15)";
+      ctx.setLineDash([4, 6]);
+    }
+
+    ctx.beginPath();
+    ctx.moveTo(p1.cx, p1.cy);
+    ctx.lineTo(p2.cx, p2.cy);
+    ctx.stroke();
+    ctx.setLineDash([]);
+  }
+
+  // draw nodes
+  nodeHitAreas = [];
+  for (var ni = 0; ni < chart.nodes.length; ni++) {
+    var node = chart.nodes[ni];
+    var revealed = !!state.revealed[node.id];
+    if (!revealed) continue; // fogged — don't draw
+
+    var visited = !!state.visited[node.id];
+    var isCurrent = state.currentNodeId === node.id;
+    var isReachable = !!reachableSet[node.id];
+    var isHovered = hoveredNodeId === node.id;
+    var info = types[node.type] || { label: "?", icon: "?", color: "#888" };
+
+    var p = nodePos(node);
+    var r = node.type === "boss" ? 22 : 18;
+
+    nodeHitAreas.push({ id: node.id, cx: p.cx, cy: p.cy, r: r + 6 });
+
+    // glow for current / reachable / hovered
+    if (isCurrent || (isReachable && isHovered)) {
+      ctx.shadowColor = isCurrent ? T.gold : info.color;
+      ctx.shadowBlur = isCurrent ? 18 : 14;
+    }
+
+    // node circle
+    ctx.beginPath();
+    ctx.arc(p.cx, p.cy, r, 0, Math.PI * 2);
+
+    if (isCurrent) {
+      // current position — bright gold fill
+      ctx.fillStyle = "rgba(80, 60, 25, 0.95)";
+      ctx.fill();
+      ctx.strokeStyle = T.gold;
+      ctx.lineWidth = 3;
+      ctx.stroke();
+    } else if (visited) {
+      // visited — dimmed
+      ctx.fillStyle = "rgba(30, 22, 14, 0.7)";
+      ctx.fill();
+      ctx.strokeStyle = "rgba(100, 80, 50, 0.3)";
+      ctx.lineWidth = 1.5;
+      ctx.stroke();
+    } else if (isReachable) {
+      // reachable — highlighted
+      ctx.fillStyle = "rgba(45, 35, 20, 0.9)";
+      ctx.fill();
+      ctx.strokeStyle = info.color;
+      ctx.lineWidth = isHovered ? 3 : 2;
+      ctx.stroke();
+    } else {
+      // revealed but not reachable
+      ctx.fillStyle = "rgba(30, 22, 14, 0.6)";
+      ctx.fill();
+      ctx.strokeStyle = "rgba(80, 60, 35, 0.3)";
+      ctx.lineWidth = 1;
+      ctx.stroke();
+    }
+
+    ctx.shadowColor = "transparent";
+    ctx.shadowBlur = 0;
+
+    // icon
+    var iconAlpha = visited && !isCurrent ? 0.35 : 1.0;
+    ctx.globalAlpha = iconAlpha;
+    ctx.fillStyle = isCurrent ? T.gold : info.color;
+    ctx.font = (node.type === "boss" ? "18px" : "14px") + " serif";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillText(NODE_ICONS[node.type] || info.icon, p.cx, p.cy);
+    ctx.globalAlpha = 1.0;
+
+    // label below node (only for current, reachable, or hovered)
+    if (isCurrent || isReachable || isHovered) {
+      ctx.fillStyle = isCurrent ? T.gold : "rgba(196, 168, 114, 0.7)";
+      ctx.font = "9px serif";
+      ctx.fillText(info.label, p.cx, p.cy + r + 12);
+    }
+
+    // "YOU" marker on current node
+    if (isCurrent) {
+      ctx.fillStyle = T.goldBright;
+      ctx.font = "bold 8px serif";
+      ctx.fillText("YOU", p.cx, p.cy - r - 6);
+    }
+  }
+
+  // column labels (top)
+  ctx.fillStyle = "rgba(139, 109, 68, 0.3)";
+  ctx.font = "9px serif";
+  ctx.textAlign = "center";
+  ctx.textBaseline = "top";
+  for (var c = 0; c < chart.columns; c++) {
+    var cx = padL + ((c + 0.5) / chart.columns) * drawW;
+    if (c === 0) ctx.fillText("START", cx, 6);
+    else if (c === chart.columns - 1) ctx.fillText("EXIT", cx, 6);
+  }
+}
+
+function drawCompassRose(ctx, cx, cy, r) {
+  ctx.save();
+  ctx.strokeStyle = "rgba(212, 164, 74, 0.25)";
+  ctx.fillStyle = "rgba(212, 164, 74, 0.15)";
+  ctx.lineWidth = 1;
+  ctx.beginPath(); ctx.arc(cx, cy, r, 0, Math.PI * 2); ctx.stroke();
+  var dirs = ["N", "E", "S", "W"];
+  var angles = [-Math.PI / 2, 0, Math.PI / 2, Math.PI];
+  ctx.font = "bold 9px serif"; ctx.textAlign = "center"; ctx.textBaseline = "middle";
+  ctx.fillStyle = "rgba(212, 164, 74, 0.4)";
+  for (var d = 0; d < 4; d++) {
+    var a = angles[d];
+    ctx.fillText(dirs[d], cx + Math.cos(a) * (r + 8), cy + Math.sin(a) * (r + 8));
+    ctx.beginPath(); ctx.moveTo(cx + Math.cos(a) * (r - 3), cy + Math.sin(a) * (r - 3));
+    ctx.lineTo(cx + Math.cos(a) * r, cy + Math.sin(a) * r); ctx.stroke();
+  }
+  ctx.beginPath(); ctx.arc(cx, cy, 2, 0, Math.PI * 2); ctx.fill();
+  ctx.restore();
+}
+
+// --- show/hide API ---
+export function showVoyageChart(chart, state, callback) {
+  currentChart = chart;
+  currentState = state;
+  onSelectCallback = callback;
+  if (overlay) {
+    overlay.style.display = "flex";
+    hoveredNodeId = null;
+    tooltipEl.style.display = "none";
+    drawChart();
+  }
+}
+
+export function hideVoyageChart() {
+  if (overlay) overlay.style.display = "none";
+  if (tooltipEl) tooltipEl.style.display = "none";
+  hoveredNodeId = null;
+}
+
+export function isVoyageChartVisible() {
+  return overlay && overlay.style.display !== "none";
+}

--- a/game/js/voyageData.js
+++ b/game/js/voyageData.js
@@ -1,0 +1,275 @@
+// voyageData.js — voyage chart node types, seeded procedural generation, chart state
+// Slay-the-Spire-style branching path map for a single zone.
+
+var STORAGE_KEY = "ocean_outlaws_voyage";
+
+// --- node type definitions ---
+var NODE_TYPES = {
+  fleet_battle: { label: "Fleet Battle", icon: "\u2694", color: "#cc4444" },        // crossed swords
+  harbor_raid: { label: "Harbor Raid", icon: "\u2693", color: "#44aa88" },           // anchor
+  merchant_chase: { label: "Merchant Chase", icon: "\u26F5", color: "#ddaa44" },     // ship
+  salvage: { label: "Salvage", icon: "\u2620", color: "#8899aa" },                   // wreck (skull+bones works)
+  storm_crossing: { label: "Storm Crossing", icon: "\u2601", color: "#6688bb" },     // cloud
+  event: { label: "Event / Parley", icon: "\u{1F4DC}", color: "#bb88dd" },           // scroll
+  boss: { label: "Boss Lair", icon: "\u2620", color: "#ff4444" }                     // skull
+};
+
+export function getNodeTypes() {
+  return NODE_TYPES;
+}
+
+// --- simple seeded PRNG (separate from gameplay RNG) ---
+// We use our own lightweight PRNG so chart generation doesn't disturb the
+// gameplay RNG sequence.  mulberry32.
+function createChartRNG(seed) {
+  var state = seed | 0;
+  return function () {
+    state = (state + 0x6d2b79f5) | 0;
+    var t = Math.imul(state ^ (state >>> 15), 1 | state);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// --- generate a voyage chart for one zone ---
+// Returns { columns, nodes, edges, startNodeId, exitNodeIds }
+//   columns: number of columns (left→right progression)
+//   nodes: [{id, col, row, type, x, y}]
+//   edges: [{from, to}]
+export function generateVoyageChart(seed, zoneNumber, isBossZone) {
+  var rng = createChartRNG(seed);
+
+  // 7 columns (Slay the Spire style: ~7 rows deep)
+  var numCols = 7;
+  // 3-4 nodes per column (width), except first and last which are narrower
+  var nodesPerCol = [];
+  nodesPerCol.push(1); // single start node
+  for (var c = 1; c < numCols - 1; c++) {
+    nodesPerCol.push(2 + Math.floor(rng() * 3)); // 2-4 nodes
+  }
+  nodesPerCol.push(1); // single exit node
+
+  // build nodes
+  var nodes = [];
+  var nodeId = 0;
+  var colNodes = []; // colNodes[col] = array of node objects in that column
+  for (var col = 0; col < numCols; col++) {
+    var count = nodesPerCol[col];
+    var arr = [];
+    for (var row = 0; row < count; row++) {
+      var type = pickNodeType(rng, col, numCols, isBossZone);
+      var node = {
+        id: nodeId,
+        col: col,
+        row: row,
+        rowCount: count,
+        type: type,
+        // x/y computed later for rendering
+        x: 0,
+        y: 0
+      };
+      nodes.push(node);
+      arr.push(node);
+      nodeId++;
+    }
+    colNodes.push(arr);
+  }
+
+  // build edges — each node in col connects to 1-2 nodes in col+1
+  // guarantee every node has at least one incoming and one outgoing edge
+  var edges = [];
+  for (var col = 0; col < numCols - 1; col++) {
+    var curr = colNodes[col];
+    var next = colNodes[col + 1];
+
+    // first pass: give each current node at least one forward connection
+    for (var ci = 0; ci < curr.length; ci++) {
+      // pick the "closest" node (by row ratio) plus maybe one extra
+      var bestIdx = Math.round((ci / Math.max(1, curr.length - 1)) * (next.length - 1));
+      edges.push({ from: curr[ci].id, to: next[bestIdx].id });
+
+      // sometimes add a second edge for branching
+      if (rng() < 0.45 && next.length > 1) {
+        var alt = bestIdx + (rng() < 0.5 ? 1 : -1);
+        alt = Math.max(0, Math.min(next.length - 1, alt));
+        if (alt !== bestIdx) {
+          edges.push({ from: curr[ci].id, to: next[alt].id });
+        }
+      }
+    }
+
+    // second pass: ensure every next-col node has at least one incoming edge
+    for (var ni = 0; ni < next.length; ni++) {
+      var hasIncoming = false;
+      for (var e = 0; e < edges.length; e++) {
+        if (edges[e].to === next[ni].id) { hasIncoming = true; break; }
+      }
+      if (!hasIncoming) {
+        // connect from the nearest current-col node
+        var nearIdx = Math.round((ni / Math.max(1, next.length - 1)) * (curr.length - 1));
+        edges.push({ from: curr[nearIdx].id, to: next[ni].id });
+      }
+    }
+  }
+
+  // deduplicate edges
+  var edgeSet = {};
+  var uniqueEdges = [];
+  for (var e = 0; e < edges.length; e++) {
+    var key = edges[e].from + "-" + edges[e].to;
+    if (!edgeSet[key]) {
+      edgeSet[key] = true;
+      uniqueEdges.push(edges[e]);
+    }
+  }
+
+  // compute layout positions (0-1 range) for each node
+  for (var i = 0; i < nodes.length; i++) {
+    var n = nodes[i];
+    // x: left-to-right based on column, with padding
+    n.x = (n.col + 0.5) / numCols;
+    // y: distribute rows evenly within column, with slight jitter
+    if (n.rowCount === 1) {
+      n.y = 0.5;
+    } else {
+      var spacing = 0.7 / Math.max(1, n.rowCount - 1);
+      n.y = 0.15 + n.row * spacing;
+    }
+    // add slight jitter for organic feel
+    n.y += (rng() - 0.5) * 0.06;
+  }
+
+  var startId = colNodes[0][0].id;
+  var exitIds = [];
+  for (var ei = 0; ei < colNodes[numCols - 1].length; ei++) {
+    exitIds.push(colNodes[numCols - 1][ei].id);
+  }
+
+  return {
+    columns: numCols,
+    nodes: nodes,
+    edges: uniqueEdges,
+    startNodeId: startId,
+    exitNodeIds: exitIds,
+    seed: seed
+  };
+}
+
+function pickNodeType(rng, col, numCols, isBossZone) {
+  // first column: always fleet_battle (easy start)
+  if (col === 0) return "fleet_battle";
+  // last column: boss if boss zone, else fleet_battle
+  if (col === numCols - 1) {
+    return isBossZone ? "boss" : "fleet_battle";
+  }
+
+  // weighted pool for middle columns
+  var pool = [
+    { type: "fleet_battle", weight: 30 },
+    { type: "harbor_raid", weight: 15 },
+    { type: "merchant_chase", weight: 15 },
+    { type: "salvage", weight: 15 },
+    { type: "storm_crossing", weight: 12 },
+    { type: "event", weight: 13 }
+  ];
+
+  var total = 0;
+  for (var i = 0; i < pool.length; i++) total += pool[i].weight;
+  var roll = rng() * total;
+  var acc = 0;
+  for (var i = 0; i < pool.length; i++) {
+    acc += pool[i].weight;
+    if (roll < acc) return pool[i].type;
+  }
+  return "fleet_battle";
+}
+
+// --- voyage chart state ---
+// Tracks player position, visited nodes, revealed nodes
+export function createVoyageState(chart) {
+  var revealed = {};
+  var visited = {};
+
+  // start node is visited + revealed
+  visited[chart.startNodeId] = true;
+  revealed[chart.startNodeId] = true;
+
+  // reveal nodes adjacent to start
+  revealAdjacent(chart, chart.startNodeId, revealed);
+
+  return {
+    chartSeed: chart.seed,
+    currentNodeId: chart.startNodeId,
+    visited: visited,
+    revealed: revealed,
+    completed: false
+  };
+}
+
+function revealAdjacent(chart, nodeId, revealed) {
+  for (var i = 0; i < chart.edges.length; i++) {
+    var e = chart.edges[i];
+    if (e.from === nodeId) revealed[e.to] = true;
+    if (e.to === nodeId) revealed[e.from] = true;
+  }
+}
+
+// --- move to a node (returns true if valid move) ---
+export function moveToNode(chart, state, targetNodeId) {
+  // check that target is connected and adjacent (one column forward)
+  var canMove = false;
+  for (var i = 0; i < chart.edges.length; i++) {
+    if (chart.edges[i].from === state.currentNodeId && chart.edges[i].to === targetNodeId) {
+      canMove = true;
+      break;
+    }
+  }
+  if (!canMove) return false;
+  if (!state.revealed[targetNodeId]) return false;
+
+  state.currentNodeId = targetNodeId;
+  state.visited[targetNodeId] = true;
+  revealAdjacent(chart, targetNodeId, state.revealed);
+
+  // check if at exit
+  for (var i = 0; i < chart.exitNodeIds.length; i++) {
+    if (targetNodeId === chart.exitNodeIds[i]) {
+      state.completed = true;
+    }
+  }
+
+  return true;
+}
+
+// --- get nodes reachable from current position ---
+export function getReachableNodes(chart, state) {
+  var reachable = [];
+  for (var i = 0; i < chart.edges.length; i++) {
+    var e = chart.edges[i];
+    if (e.from === state.currentNodeId && state.revealed[e.to]) {
+      reachable.push(e.to);
+    }
+  }
+  return reachable;
+}
+
+// --- persistence ---
+export function saveVoyageState(state) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch (e) { /* ignore */ }
+}
+
+export function loadVoyageState() {
+  try {
+    var raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) return JSON.parse(raw);
+  } catch (e) { /* ignore */ }
+  return null;
+}
+
+export function clearVoyageState() {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch (e) { /* ignore */ }
+}


### PR DESCRIPTION
Closes #109

## Acceptance Criteria

- [x] Voyage chart screen shows 6-10 nodes per zone arranged in columns (left to right progression)
- [x] Node types with distinct icons: Fleet Battle (crossed swords), Harbor Raid (anchor), Merchant Chase (ship), Salvage (wreck), Storm Crossing (cloud), Event/Parley (scroll), Boss Lair (skull)
- [x] Nodes connected by paths — player can only move to connected adjacent nodes
- [x] Current position highlighted, visited nodes dimmed
- [x] Chart starts fogged — only nodes adjacent to visited ones are revealed
- [x] Tapping a revealed connected node navigates to it (triggers the encounter)
- [x] Procedural generation: each run produces a different chart layout using seeded RNG
- [x] Zone exit is always the rightmost column
- [x] Boss node always appears as the final node of zones 3 and 6
- [x] Chart has nautical/parchment visual style (consistent with HUD retheme)
- [x] Works on mobile (touch) and desktop (click)

## Changes

- **`game/js/voyageData.js`** (new, 275 lines) — Node type definitions, separate seeded PRNG (mulberry32), procedural chart generation (7-column Slay the Spire layout with 2-4 nodes per column), voyage state management (visited/revealed/fog-of-war), persistence via localStorage
- **`game/js/voyageChart.js`** (new, 457 lines) — Canvas-rendered chart overlay with parchment/nautical aesthetic, compass rose, node icons, edge drawing with visited/fogged styles, tooltip system, touch tap-to-select and mouse click support, legend bar
- **`game/js/main.js`** (modified, +23 lines) — Import voyage chart modules, create overlay on init, replace `openMap()` to show voyage chart instead of zone map, clear voyage state on new game/restart