### PR TITLE
Bug: turrets/guns spawn at world origin instead of attached to ship

### DIFF
--- a/game/js/boss.js
+++ b/game/js/boss.js
@@ -5,6 +5,7 @@ import { nextRandom } from "./rng.js";
 import { collideWithTerrain, isLand } from "./terrain.js";
 import { getOverridePath, getOverrideSize } from "./artOverrides.js";
 import { loadFbxVisual } from "./fbxVisual.js";
+import { placeTurretsFromBounds } from "./ship.js";
 
 // --- boss definitions ---
 var BOSS_DEFS = {
@@ -76,9 +77,23 @@ function applyBossOverrideAsync(mesh, bossType) {
   var path = getOverridePath(slot);
   if (!path) return;
   var fit = getOverrideSize(slot) || (bossType === "carrier" ? 18 : 16);
+  var turrets = mesh.userData.turrets || [];
+  var tentacles = mesh.userData.tentacles || [];
   loadFbxVisual(path, fit, true).then(function (visual) {
     while (mesh.children.length) mesh.remove(mesh.children[0]);
     mesh.add(visual);
+    // re-attach turrets positioned on the new model
+    if (turrets.length) {
+      placeTurretsFromBounds(mesh, turrets);
+      for (var i = 0; i < turrets.length; i++) {
+        mesh.add(turrets[i]);
+      }
+      mesh.userData.turrets = turrets;
+    }
+    // re-attach tentacles (kraken)
+    for (var i = 0; i < tentacles.length; i++) {
+      mesh.add(tentacles[i]);
+    }
   }).catch(function () {
     // keep procedural fallback on failure
   });


### PR DESCRIPTION
Closes #123

## Summary
After the Palmov FBX integration (#121), turrets were removed from the ship's scene graph when procedural geometry was replaced by the FBX visual, but never re-added as children. This caused them to stay at world origin (0,0,0) while the ship moved away.

### Changes
- **`ship.js`**: `applyShipOverrideAsync` now re-attaches turret groups and lights (lantern) to the ship mesh after FBX visual swap
- **`ship.js`**: `placeTurretsFromBounds` uses world-to-local bounding box center for accurate positioning on FBX models (exported for reuse)
- **`boss.js`**: `applyBossOverrideAsync` now re-attaches turrets and tentacles after FBX visual swap

## Acceptance Criteria
- [x] All turrets visually attached to the ship mesh and move with it
- [x] Turrets fire from ship position, not world origin
- [x] Works for all ship classes (sloop, brigantine, galleon, manowar)
- [x] Boss turrets also correctly positioned