### PR TITLE
Bug: ships sink under waves — buoyancy offset broken

### DIFF
--- a/game/js/boss.js
+++ b/game/js/boss.js
@@ -51,9 +51,9 @@ var BOSS_DEFS = {
 };
 
 // --- shared geometry ---
-var BOSS_FLOAT_OFFSET = 1.5;
-var BUOYANCY_LERP = 8;
-var TILT_LERP = 6;
+var BOSS_FLOAT_OFFSET = 2.0;
+var BUOYANCY_LERP = 12;
+var TILT_LERP = 8;
 var TILT_DAMPING = 0.2;        // bosses are big, less tilt
 
 var projGeo = null;
@@ -141,10 +141,11 @@ export function createBoss(bossType, playerX, playerZ, scene, zoneDifficulty) {
     sinking: false,
     sinkTimer: 0,
     defeated: false,
-    // smoothed buoyancy state
+    // smoothed buoyancy state (initialized on first update frame)
     _smoothY: 0.5,
     _smoothPitch: 0,
-    _smoothRoll: 0
+    _smoothRoll: 0,
+    _buoyancyInit: false
   };
 }
 
@@ -377,6 +378,14 @@ export function updateBoss(boss, ship, dt, scene, getWaveHeight, elapsed, enemyM
 
     var targetPitch = Math.atan2(waveFore - waveAft, sampleDist * 2) * TILT_DAMPING;
     var targetRoll  = Math.atan2(wavePort - waveStbd, sampleDist * 2) * TILT_DAMPING;
+
+    // snap to surface on first frame so boss never starts underwater
+    if (!boss._buoyancyInit) {
+      boss._buoyancyInit = true;
+      boss._smoothY = targetY;
+      boss._smoothPitch = targetPitch;
+      boss._smoothRoll = targetRoll;
+    }
 
     var lerpFactor = 1 - Math.exp(-BUOYANCY_LERP * dt);
     var tiltFactor = 1 - Math.exp(-TILT_LERP * dt);

--- a/game/js/enemy.js
+++ b/game/js/enemy.js
@@ -14,9 +14,9 @@ var FIRE_RANGE = 30;
 var FIRE_COOLDOWN = 1.5;       // seconds between enemy shots
 var ENEMY_PROJ_SPEED = 30;
 var ENEMY_PROJ_GRAVITY = 9.8;
-var FLOAT_OFFSET = 1.0;
-var BUOYANCY_LERP = 8;
-var TILT_LERP = 6;
+var FLOAT_OFFSET = 1.4;
+var BUOYANCY_LERP = 12;
+var TILT_LERP = 8;
 var TILT_DAMPING = 0.3;        // gentle tilt, not wild rotation
 
 // spawn tuning
@@ -291,10 +291,11 @@ function spawnEnemy(manager, playerX, playerZ, scene, waveConfig, terrain) {
     // destruction state
     sinking: false,
     sinkTimer: 0,
-    // smoothed buoyancy state
+    // smoothed buoyancy state (initialized on first update frame)
     _smoothY: 0.3,
     _smoothPitch: 0,
-    _smoothRoll: 0
+    _smoothRoll: 0,
+    _buoyancyInit: false
   };
 
   manager.enemies.push(enemy);
@@ -413,6 +414,14 @@ export function updateEnemies(manager, ship, dt, scene, getWaveHeight, elapsed, 
 
       var targetPitch = Math.atan2(waveFore - waveAft, sampleDist * 2) * TILT_DAMPING;
       var targetRoll  = Math.atan2(wavePort - waveStbd, sampleDist * 2) * TILT_DAMPING;
+
+      // snap to surface on first frame so enemy never starts underwater
+      if (!e._buoyancyInit) {
+        e._buoyancyInit = true;
+        e._smoothY = targetY;
+        e._smoothPitch = targetPitch;
+        e._smoothRoll = targetRoll;
+      }
 
       var lerpFactor = 1 - Math.exp(-BUOYANCY_LERP * dt);
       var tiltFactor = 1 - Math.exp(-TILT_LERP * dt);


### PR DESCRIPTION
Closes #124

## Changes

- **Snap buoyancy on first frame**: Added `_buoyancyInit` flag to player ship, enemy, and boss entities. On the first update frame, `_smoothY`/`_smoothPitch`/`_smoothRoll` are set directly to the wave surface position instead of lerping from zero — ships never start submerged.
- **Increased FLOAT_OFFSET**: Player ship 1.2→1.6, enemy 1.0→1.4, boss 1.5→2.0. Higher offsets keep hulls above the wave surface, especially during storms (waveAmplitude up to 2.87).
- **Faster BUOYANCY_LERP**: 8→12 across all ship types. Ships track the wave surface more tightly, reducing lag during large wave swings.
- **Faster TILT_LERP**: 6→8 across all ship types. Pitch/roll respond more quickly to wave slope changes.
- **Extracted TILT_DAMPING constant in ship.js**: Replaced inline `0.3` with named constant for consistency with enemy.js and boss.js.

## Acceptance Criteria

- [x] Ships float on the wave surface at all times
- [x] Buoyancy offset matches the new CPU flat-shaded ocean wave heights
- [x] Ships tilt/rock naturally with wave direction (gentle, not extreme)
- [x] Works during storms (larger wave amplitude)
- [x] Enemy and boss ships also float correctly