### PR TITLE
Enemy faction system: sail colors, merchant flee AI, pirate rush AI

### DIFF
--- a/game/js/main.js
+++ b/game/js/main.js
@@ -9,7 +9,7 @@ import { unlockAudio, updateEngine, setEngineClass, updateAmbience, updateMusic,
 import { playWeaponSound, playExplosion, playPlayerHit, playClick, playUpgrade, playWaveHorn, playHitConfirm, playKillConfirm } from "./soundFx.js";
 import { initNav, updateNav, handleClick, getCombatTarget, setCombatTarget, setNavBoss } from "./nav.js";
 import { createWeaponState, fireWeapon, updateWeapons, switchWeapon, getWeaponOrder, getWeaponConfig, findNearestEnemy, getActiveWeaponRange, aimAtEnemy } from "./weapon.js";
-import { createEnemyManager, updateEnemies, getPlayerHp, setOnDeathCallback, setOnHitCallback, setPlayerHp, setPlayerArmor, setPlayerMaxHp, resetEnemyManager } from "./enemy.js";
+import { createEnemyManager, updateEnemies, getPlayerHp, setOnDeathCallback, setOnHitCallback, setPlayerHp, setPlayerArmor, setPlayerMaxHp, resetEnemyManager, getFactionAnnounce, getFactionGoldMult } from "./enemy.js";
 import { initHealthBars, updateHealthBars } from "./health.js";
 import { createResources, consumeFuel, getFuelSpeedMult, resetResources } from "./resource.js";
 import { createPickupManager, spawnPickup, updatePickups, clearPickups } from "./pickup.js";
@@ -120,10 +120,11 @@ var techState = loadTechState();
 createTechScreen();
 createPortScreen();
 
-setOnDeathCallback(enemyMgr, function (x, y, z) {
+setOnDeathCallback(enemyMgr, function (x, y, z, faction) {
   spawnPickup(pickupMgr, x, y, z, scene);
   var techB = getTechBonuses(techState);
-  var gld = Math.round(GOLD_PER_KILL * (1 + techB.salvageBonus));
+  var factionMult = getFactionGoldMult(faction);
+  var gld = Math.round(GOLD_PER_KILL * factionMult * (1 + techB.salvageBonus));
   addGold(upgrades, gld);
   playExplosion();
   playKillConfirm();
@@ -766,8 +767,10 @@ function animate() {
 
     if (event) {
       if (event === "wave_start") {
-        showBanner("Fleet " + waveMgr.wave + " Approaching!", 3);
-        addKillFeedEntry("Fleet " + waveMgr.wave + " Approaching!", "#44aaff");
+        var waveFaction = waveMgr.currentConfig.faction;
+        var waveAnnounce = getFactionAnnounce(waveFaction);
+        showBanner(waveAnnounce, 3);
+        addKillFeedEntry("Wave " + waveMgr.wave + " — " + waveAnnounce, "#44aaff");
         playWaveHorn();
       } else if (event.indexOf("wave_start_boss:") === 0) {
         var bossType = event.split(":")[1];

--- a/game/js/mapData.js
+++ b/game/js/mapData.js
@@ -191,8 +191,12 @@ export function getZoneStars(state, zoneId) {
   return (state.zones[zoneId] && state.zones[zoneId].stars) || 0;
 }
 
+// --- faction rotation per wave ---
+var FACTION_ROTATION = ["pirate", "navy", "merchant", "pirate", "navy", "pirate", "merchant", "navy"];
+
 // --- build wave configs for a zone (replaces global wave configs) ---
 // Final wave marked as boss wave if zone has a boss
+// Each wave gets a faction from the rotation
 export function buildZoneWaveConfigs(zone) {
   var configs = [];
   for (var i = 1; i <= zone.waves; i++) {
@@ -201,12 +205,13 @@ export function buildZoneWaveConfigs(zone) {
       enemies: zone.enemyBase + zone.enemiesPerWave * (i - 1),
       hpMult: zone.hpScale * (1.0 + (i - 1) * 0.15),
       speedMult: zone.speedScale * (1.0 + (i - 1) * 0.08),
-      fireRateMult: 1.0 + (i - 1) * 0.1
+      fireRateMult: 1.0 + (i - 1) * 0.1,
+      faction: FACTION_ROTATION[(i - 1) % FACTION_ROTATION.length]
     };
     // mark final wave as boss wave
     if (i === zone.waves && zone.boss) {
       cfg.boss = zone.boss;
-      cfg.enemies = Math.max(1, Math.floor(cfg.enemies / 2)); // fewer regular enemies during boss
+      cfg.enemies = Math.max(1, Math.floor(cfg.enemies / 2));
     }
     configs.push(cfg);
   }

--- a/game/js/wave.js
+++ b/game/js/wave.js
@@ -15,6 +15,9 @@ var STATE_COMPLETE  = "WAVE_COMPLETE";
 var STATE_GAME_OVER = "GAME_OVER";
 var STATE_VICTORY   = "VICTORY";
 
+// --- faction rotation for default waves ---
+var FACTION_ROTATION = ["pirate", "navy", "merchant", "pirate", "navy", "pirate", "merchant", "navy"];
+
 // --- build wave config table ---
 function buildWaveConfigs() {
   var configs = [];
@@ -24,7 +27,8 @@ function buildWaveConfigs() {
       enemies: BASE_ENEMIES + ENEMIES_PER_WAVE * (i - 1),
       hpMult: 1.0 + (i - 1) * 0.15,
       speedMult: 1.0 + (i - 1) * 0.08,
-      fireRateMult: 1.0 + (i - 1) * 0.1
+      fireRateMult: 1.0 + (i - 1) * 0.1,
+      faction: FACTION_ROTATION[(i - 1) % FACTION_ROTATION.length]
     });
   }
   return configs;


### PR DESCRIPTION
Closes #113

## Changes

Three enemy factions with distinct visuals, AI behaviors, and gold rewards:

- **Pirate** (red hull): Aggressive rush AI, fast turn speed, close engagement range, swarms — 1x gold
- **Navy** (blue hull): Formation hold AI, circle-strafe at range, disciplined broadside fire, tough — 2x gold  
- **Merchant** (brown hull): Flee AI, only fires backward when cornered, high gold reward — 3x gold

Wave configs rotate through factions. Each wave spawns a single faction type with appropriate announcement.

## Acceptance Criteria

- [x] Enemy faction property: "pirate", "navy", "merchant"
- [x] Visual: sail/hull color tint per faction (red=pirate, white-blue=navy, brown=merchant) — applied to existing procedural models (will transfer to GLB when available)
- [x] Merchant AI: flees on sight, only fires backward if cornered, drops high gold on kill
- [x] Pirate AI: aggressive rush, swarms in groups of 3-5, medium gold reward
- [x] Navy AI: holds formation, fires disciplined broadsides, tough but high reward
- [x] Fleet Battle node spawns faction-appropriate enemy groups
- [x] Wave announcements show faction: "Pirate Fleet Approaching!" / "Royal Navy Patrol!"