### PR TITLE
Islands too shiny/glossy — switch to cartoon flat colors

### DIFF
--- a/game/js/boss.js
+++ b/game/js/boss.js
@@ -503,7 +503,7 @@ function updateTentacleAttacks(boss, ship, dt, scene, enemyMgr) {
       ta.delay -= dt;
       if (ta.delay <= 0) {
         ta.active = true;
-        var tentMat = new THREE.MeshLambertMaterial({ color: 0x664488, transparent: true, opacity: 0.8 });
+        var tentMat = new THREE.MeshToonMaterial({ color: 0x7755aa, transparent: true, opacity: 0.8 });
         var tentGeo = new THREE.CylinderGeometry(0.4, 0.8, 6, 8);
         ta.mesh = new THREE.Mesh(tentGeo, tentMat);
         ta.mesh.position.set(ta.x, 3, ta.z);

--- a/game/js/bossModels.js
+++ b/game/js/bossModels.js
@@ -7,11 +7,8 @@ var glassMat = null;
 
 function ensureBossMats() {
   if (metalMat) return;
-  metalMat = new THREE.MeshStandardMaterial({ color: 0x888899, roughness: 0.3, metalness: 0.8 });
-  glassMat = new THREE.MeshStandardMaterial({
-    color: 0x1a2a3a, roughness: 0.1, metalness: 0.5,
-    emissive: 0x1a2a3a, emissiveIntensity: 0
-  });
+  metalMat = new THREE.MeshToonMaterial({ color: 0x9999aa });
+  glassMat = new THREE.MeshToonMaterial({ color: 0x2a4a6a });
 }
 
 function addBossNavLights(group, x, y, z) {
@@ -75,7 +72,7 @@ function buildBattleshipMesh() {
   var hullGeo = new THREE.ExtrudeGeometry(hullShape, {
     depth: 1.1, bevelEnabled: true, bevelThickness: 0.08, bevelSize: 0.05, bevelSegments: 2
   });
-  var hullMat = new THREE.MeshStandardMaterial({ color: 0x5a3a28, roughness: 0.65, metalness: 0.15 });
+  var hullMat = new THREE.MeshToonMaterial({ color: 0x6a4430 });
   var hull = new THREE.Mesh(hullGeo, hullMat);
   hull.rotation.x = -Math.PI / 2;
   hull.position.y = -0.2;
@@ -83,7 +80,7 @@ function buildBattleshipMesh() {
 
   // waterline
   var wlGeo = new THREE.PlaneGeometry(3.0, 9.5);
-  var wlMat = new THREE.MeshStandardMaterial({ color: 0x1a0808, roughness: 0.9, metalness: 0 });
+  var wlMat = new THREE.MeshToonMaterial({ color: 0x1a0808 });
   var wl = new THREE.Mesh(wlGeo, wlMat);
   wl.rotation.x = -Math.PI / 2;
   wl.position.set(0, 0.01, 0);
@@ -91,7 +88,7 @@ function buildBattleshipMesh() {
 
   // deck
   var deckGeo = new THREE.PlaneGeometry(2.8, 8.5);
-  var deckMat = new THREE.MeshStandardMaterial({ color: 0x6a4a38, roughness: 0.5, metalness: 0.05 });
+  var deckMat = new THREE.MeshToonMaterial({ color: 0x7a5a40 });
   var deck = new THREE.Mesh(deckGeo, deckMat);
   deck.rotation.x = -Math.PI / 2;
   deck.position.y = 0.9;
@@ -99,7 +96,7 @@ function buildBattleshipMesh() {
 
   // massive bridge — two tiers
   var bridgeGeo = new THREE.BoxGeometry(1.4, 1.2, 1.6);
-  var bridgeMat = new THREE.MeshStandardMaterial({ color: 0x7a5a48, roughness: 0.45, metalness: 0.2 });
+  var bridgeMat = new THREE.MeshToonMaterial({ color: 0x8a6a50 });
   var bridge = new THREE.Mesh(bridgeGeo, bridgeMat);
   bridge.position.set(0, 1.5, -1.5);
   group.add(bridge);
@@ -110,7 +107,7 @@ function buildBattleshipMesh() {
   addBossWindows(group, 0, 1.5, -1.5, 1.4, 1.2);
 
   // smokestacks (twin)
-  var stackMat = new THREE.MeshStandardMaterial({ color: 0x333333, roughness: 0.6, metalness: 0.3 });
+  var stackMat = new THREE.MeshToonMaterial({ color: 0x444444 });
   for (var si = 0; si < 2; si++) {
     var stackGeo = new THREE.CylinderGeometry(0.18, 0.22, 0.8, 8);
     var stack = new THREE.Mesh(stackGeo, stackMat);
@@ -127,9 +124,9 @@ function buildBattleshipMesh() {
 
   // broadside turrets (4 total) — larger, more imposing
   var turretGeo = new THREE.CylinderGeometry(0.35, 0.45, 0.4, 8);
-  var turretMat = new THREE.MeshStandardMaterial({ color: 0x4a2a1a, roughness: 0.35, metalness: 0.7 });
+  var turretMat = new THREE.MeshToonMaterial({ color: 0x5a3420 });
   var barrelGeo = new THREE.CylinderGeometry(0.06, 0.07, 1.1, 6);
-  var barrelMat = new THREE.MeshStandardMaterial({ color: 0x3a2010, roughness: 0.3, metalness: 0.8 });
+  var barrelMat = new THREE.MeshToonMaterial({ color: 0x4a2818 });
 
   var turrets = [];
   var turretPositions = [
@@ -151,7 +148,7 @@ function buildBattleshipMesh() {
   }
 
   // armor plating (decorative strips along sides)
-  var plateMat = new THREE.MeshStandardMaterial({ color: 0x4a3828, roughness: 0.5, metalness: 0.4 });
+  var plateMat = new THREE.MeshToonMaterial({ color: 0x5a4830 });
   for (var side = -1; side <= 1; side += 2) {
     for (var pi = 0; pi < 4; pi++) {
       var plate = new THREE.Mesh(
@@ -190,7 +187,7 @@ function buildCarrierBossMesh() {
   var hullGeo = new THREE.ExtrudeGeometry(hullShape, {
     depth: 1.1, bevelEnabled: true, bevelThickness: 0.08, bevelSize: 0.05, bevelSegments: 2
   });
-  var hullMat = new THREE.MeshStandardMaterial({ color: 0x2a4a2a, roughness: 0.65, metalness: 0.15 });
+  var hullMat = new THREE.MeshToonMaterial({ color: 0x3a6a3a });
   var hull = new THREE.Mesh(hullGeo, hullMat);
   hull.rotation.x = -Math.PI / 2;
   hull.position.y = -0.2;
@@ -198,7 +195,7 @@ function buildCarrierBossMesh() {
 
   // waterline
   var wlGeo = new THREE.PlaneGeometry(3.8, 10.5);
-  var wlMat = new THREE.MeshStandardMaterial({ color: 0x0a1a0a, roughness: 0.9, metalness: 0 });
+  var wlMat = new THREE.MeshToonMaterial({ color: 0x0a1a0a });
   var wl = new THREE.Mesh(wlGeo, wlMat);
   wl.rotation.x = -Math.PI / 2;
   wl.position.set(0, 0.01, 0);
@@ -206,14 +203,14 @@ function buildCarrierBossMesh() {
 
   // flight deck
   var deckGeo = new THREE.PlaneGeometry(3.6, 10.0);
-  var deckMat = new THREE.MeshStandardMaterial({ color: 0x3a5a3a, roughness: 0.5, metalness: 0.05 });
+  var deckMat = new THREE.MeshToonMaterial({ color: 0x4a7a4a });
   var deck = new THREE.Mesh(deckGeo, deckMat);
   deck.rotation.x = -Math.PI / 2;
   deck.position.y = 1.0;
   group.add(deck);
 
   // runway stripes
-  var stripeMat = new THREE.MeshStandardMaterial({ color: 0xccccaa, roughness: 0.8, metalness: 0 });
+  var stripeMat = new THREE.MeshToonMaterial({ color: 0xddddbb });
   for (var s = 0; s < 3; s++) {
     var stripeGeo = new THREE.PlaneGeometry(0.08, 7.0);
     var stripe = new THREE.Mesh(stripeGeo, stripeMat);
@@ -224,7 +221,7 @@ function buildCarrierBossMesh() {
 
   // island tower (starboard side)
   var bridgeGeo = new THREE.BoxGeometry(0.9, 1.4, 1.4);
-  var bridgeMat = new THREE.MeshStandardMaterial({ color: 0x4a6a4a, roughness: 0.45, metalness: 0.2 });
+  var bridgeMat = new THREE.MeshToonMaterial({ color: 0x5a8a5a });
   var bridgeIs = new THREE.Mesh(bridgeGeo, bridgeMat);
   bridgeIs.position.set(1.4, 1.7, -1.5);
   group.add(bridgeIs);
@@ -238,7 +235,7 @@ function buildCarrierBossMesh() {
   addBossRadar(group, 1.4, 3.4, -1.5);
 
   // hangar bays
-  var hangarMat = new THREE.MeshStandardMaterial({ color: 0x2a3a2a, roughness: 0.6, metalness: 0.1 });
+  var hangarMat = new THREE.MeshToonMaterial({ color: 0x3a4a3a });
   for (var h = 0; h < 2; h++) {
     var hangar = new THREE.Mesh(new THREE.BoxGeometry(1.2, 0.6, 1.8), hangarMat);
     hangar.position.set(0, 0.8, h * 3.5 - 0.5);
@@ -247,9 +244,9 @@ function buildCarrierBossMesh() {
 
   // defensive turrets
   var turretGeo = new THREE.CylinderGeometry(0.28, 0.35, 0.3, 8);
-  var turretMat = new THREE.MeshStandardMaterial({ color: 0x2a4a2a, roughness: 0.35, metalness: 0.7 });
+  var turretMat = new THREE.MeshToonMaterial({ color: 0x3a6a3a });
   var barrelGeo = new THREE.CylinderGeometry(0.04, 0.04, 0.8, 6);
-  var barrelMat = new THREE.MeshStandardMaterial({ color: 0x1a3a1a, roughness: 0.3, metalness: 0.8 });
+  var barrelMat = new THREE.MeshToonMaterial({ color: 0x2a5a2a });
 
   var turrets = [];
   var tPos = [[0, 1.1, 3.5], [0, 1.1, -4.0]];
@@ -277,20 +274,16 @@ function buildKrakenMesh() {
   ensureBossMats();
   var group = new THREE.Group();
 
-  // body — large sphere-ish mass with PBR
+  // body — large sphere-ish mass
   var bodyGeo = new THREE.SphereGeometry(3.0, 16, 12);
-  var bodyMat = new THREE.MeshStandardMaterial({
-    color: 0x4a2868, roughness: 0.6, metalness: 0.15
-  });
+  var bodyMat = new THREE.MeshToonMaterial({ color: 0x5a3888 });
   var body = new THREE.Mesh(bodyGeo, bodyMat);
   body.scale.set(1.0, 0.5, 1.2);
   body.position.y = 0.5;
   group.add(body);
 
   // mantle ridges (decorative bumps on top)
-  var ridgeMat = new THREE.MeshStandardMaterial({
-    color: 0x3a1a50, roughness: 0.5, metalness: 0.2
-  });
+  var ridgeMat = new THREE.MeshToonMaterial({ color: 0x4a2268 });
   for (var ri = 0; ri < 5; ri++) {
     var ridgeGeo = new THREE.SphereGeometry(0.6, 6, 4);
     var ridge = new THREE.Mesh(ridgeGeo, ridgeMat);
@@ -305,9 +298,8 @@ function buildKrakenMesh() {
 
   // eyes — larger, glowing
   var eyeGeo = new THREE.SphereGeometry(0.5, 10, 8);
-  var eyeMat = new THREE.MeshStandardMaterial({
-    color: 0xffcc00, roughness: 0.2, metalness: 0.3,
-    emissive: 0xffaa00, emissiveIntensity: 0.8
+  var eyeMat = new THREE.MeshToonMaterial({
+    color: 0xffdd00, emissive: 0xffaa00, emissiveIntensity: 0.8
   });
   var eyeL = new THREE.Mesh(eyeGeo, eyeMat);
   eyeL.position.set(-1.0, 1.1, 2.2);
@@ -318,7 +310,7 @@ function buildKrakenMesh() {
 
   // pupils
   var pupilGeo = new THREE.SphereGeometry(0.2, 6, 4);
-  var pupilMat = new THREE.MeshStandardMaterial({ color: 0x110800, roughness: 0.9, metalness: 0 });
+  var pupilMat = new THREE.MeshToonMaterial({ color: 0x110800 });
   var pupilL = new THREE.Mesh(pupilGeo, pupilMat);
   pupilL.position.set(-1.0, 1.1, 2.6);
   group.add(pupilL);
@@ -328,12 +320,8 @@ function buildKrakenMesh() {
 
   // tentacles (stored for animation)
   var tentacles = [];
-  var tentacleMat = new THREE.MeshStandardMaterial({
-    color: 0x5a3078, roughness: 0.55, metalness: 0.1
-  });
-  var suckerMat = new THREE.MeshStandardMaterial({
-    color: 0x8a60aa, roughness: 0.7, metalness: 0.05
-  });
+  var tentacleMat = new THREE.MeshToonMaterial({ color: 0x6a3898 });
+  var suckerMat = new THREE.MeshToonMaterial({ color: 0x9a70cc });
   for (var i = 0; i < 8; i++) {
     var angle = (i / 8) * Math.PI * 2;
     var tentGroup = new THREE.Group();

--- a/game/js/crate.js
+++ b/game/js/crate.js
@@ -63,7 +63,7 @@ function buildCrateMesh(type) {
   var group = new THREE.Group();
 
   var color = TYPE_COLORS[type] || 0xffffff;
-  var mat = new THREE.MeshLambertMaterial({ color: color });
+  var mat = new THREE.MeshToonMaterial({ color: color });
 
   var mesh;
   if (type === "fuel") {
@@ -75,7 +75,7 @@ function buildCrateMesh(type) {
 
   // stripe to distinguish from enemy drops (white band)
   var stripeGeo = new THREE.BoxGeometry(0.72, 0.1, 0.72);
-  var stripeMat = new THREE.MeshLambertMaterial({ color: 0xffffff });
+  var stripeMat = new THREE.MeshToonMaterial({ color: 0xffffff });
   var stripe = new THREE.Mesh(stripeGeo, stripeMat);
   stripe.position.y = 0.15;
   group.add(stripe);

--- a/game/js/drone.js
+++ b/game/js/drone.js
@@ -22,7 +22,7 @@ function ensureGeo() {
   if (droneGeo) return;
   // small quadcopter-like shape
   droneGeo = new THREE.BoxGeometry(0.6, 0.15, 0.6);
-  droneMat = new THREE.MeshLambertMaterial({ color: 0x44dd66 });
+  droneMat = new THREE.MeshToonMaterial({ color: 0x44ee77 });
   droneProjGeo = new THREE.SphereGeometry(0.08, 4, 3);
   droneProjMat = new THREE.MeshBasicMaterial({ color: 0x66ffaa });
 }
@@ -37,7 +37,7 @@ function buildDroneMesh() {
 
   // rotor arms
   var armGeo = new THREE.BoxGeometry(1.0, 0.05, 0.08);
-  var armMat = new THREE.MeshLambertMaterial({ color: 0x338844 });
+  var armMat = new THREE.MeshToonMaterial({ color: 0x339955 });
   var arm1 = new THREE.Mesh(armGeo, armMat);
   arm1.rotation.y = Math.PI / 4;
   arm1.position.y = 0.05;

--- a/game/js/enemy.js
+++ b/game/js/enemy.js
@@ -9,24 +9,24 @@ import { nextRandom } from "./rng.js";
 var FACTIONS = {
   pirate: {
     label: "Pirate",
-    hullColor: 0x8a2020, deckColor: 0x6a2828, bridgeColor: 0x7a3030,
-    turretColor: 0x6a1818, barrelColor: 0x5a1010, glassColor: 0x3a1010,
+    hullColor: 0xaa2828, deckColor: 0x882020, bridgeColor: 0x993030,
+    turretColor: 0x881818, barrelColor: 0x771010, glassColor: 0x4a1818,
     speed: 18, turnSpeed: 2.2, engageDist: 12, fireRange: 25, fireCooldown: 1.2,
     hp: 2, goldMult: 1.0, groupSize: [3, 5],
     announce: "Pirate Fleet Approaching!"
   },
   navy: {
     label: "Royal Navy",
-    hullColor: 0x2a3a6a, deckColor: 0x3a4a7a, bridgeColor: 0x4a5a8a,
-    turretColor: 0x2a3a5a, barrelColor: 0x1a2a4a, glassColor: 0x1a2a4a,
+    hullColor: 0x2a4a88, deckColor: 0x3a5a99, bridgeColor: 0x4a6aaa,
+    turretColor: 0x2a4a77, barrelColor: 0x1a3a66, glassColor: 0x1a3a66,
     speed: 12, turnSpeed: 1.4, engageDist: 30, fireRange: 38, fireCooldown: 1.0,
     hp: 5, goldMult: 2.0, groupSize: [2, 4],
     announce: "Royal Navy Patrol!"
   },
   merchant: {
     label: "Merchant",
-    hullColor: 0x6a5030, deckColor: 0x7a6040, bridgeColor: 0x8a7050,
-    turretColor: 0x5a4020, barrelColor: 0x4a3018, glassColor: 0x3a2818,
+    hullColor: 0x886838, deckColor: 0x997848, bridgeColor: 0xaa8858,
+    turretColor: 0x775828, barrelColor: 0x664820, glassColor: 0x4a3820,
     speed: 10, turnSpeed: 1.6, engageDist: 50, fireRange: 20, fireCooldown: 2.5,
     hp: 3, goldMult: 3.0, groupSize: [1, 3],
     announce: "Merchant Convoy Spotted!"
@@ -97,15 +97,12 @@ function getFactionMats(faction) {
   if (factionMats[faction]) return factionMats[faction];
   var f = FACTIONS[faction] || FACTIONS.pirate;
   factionMats[faction] = {
-    hull: new THREE.MeshStandardMaterial({ color: f.hullColor, roughness: 0.65, metalness: 0.15 }),
-    deck: new THREE.MeshStandardMaterial({ color: f.deckColor, roughness: 0.5, metalness: 0.05 }),
-    bridge: new THREE.MeshStandardMaterial({ color: f.bridgeColor, roughness: 0.45, metalness: 0.2 }),
-    turret: new THREE.MeshStandardMaterial({ color: f.turretColor, roughness: 0.35, metalness: 0.7 }),
-    barrel: new THREE.MeshStandardMaterial({ color: f.barrelColor, roughness: 0.3, metalness: 0.8 }),
-    glass: new THREE.MeshStandardMaterial({
-      color: f.glassColor, roughness: 0.1, metalness: 0.5,
-      emissive: f.glassColor, emissiveIntensity: 0
-    })
+    hull: new THREE.MeshToonMaterial({ color: f.hullColor }),
+    deck: new THREE.MeshToonMaterial({ color: f.deckColor }),
+    bridge: new THREE.MeshToonMaterial({ color: f.bridgeColor }),
+    turret: new THREE.MeshToonMaterial({ color: f.turretColor }),
+    barrel: new THREE.MeshToonMaterial({ color: f.barrelColor }),
+    glass: new THREE.MeshToonMaterial({ color: f.glassColor })
   };
   return factionMats[faction];
 }
@@ -141,7 +138,7 @@ function buildEnemyMesh(faction) {
   group.add(hull);
 
   var wlGeo = new THREE.PlaneGeometry(1.1, 3.2);
-  var wlMat = new THREE.MeshStandardMaterial({ color: 0x1a0a0a, roughness: 0.9, metalness: 0 });
+  var wlMat = new THREE.MeshToonMaterial({ color: 0x1a0a0a });
   var wl = new THREE.Mesh(wlGeo, wlMat);
   wl.rotation.x = -Math.PI / 2;
   wl.position.set(0, 0.01, 0.1);

--- a/game/js/fbxVisual.js
+++ b/game/js/fbxVisual.js
@@ -34,9 +34,24 @@ function fitToSize(root, target) {
 function applyFlat(root) {
   root.traverse(function (o) {
     if (!o.isMesh || !o.material) return;
-    if (Array.isArray(o.material)) return;
-    o.material.flatShading = true;
-    o.material.needsUpdate = true;
+    var mats = Array.isArray(o.material) ? o.material : [o.material];
+    var replaced = [];
+    for (var i = 0; i < mats.length; i++) {
+      var m = mats[i];
+      var col = m.color ? m.color.clone() : new THREE.Color(0xcccccc);
+      // boost saturation for cartoon vibrancy
+      var hsl = {};
+      col.getHSL(hsl);
+      col.setHSL(hsl.h, Math.min(1, hsl.s * 1.3 + 0.05), hsl.l);
+      var toon = new THREE.MeshToonMaterial({
+        color: col,
+        side: m.side !== undefined ? m.side : THREE.FrontSide
+      });
+      if (m.map) toon.map = m.map;
+      if (m.transparent) { toon.transparent = true; toon.opacity = m.opacity; }
+      replaced.push(toon);
+    }
+    o.material = Array.isArray(o.material) ? replaced : replaced[0];
   });
 }
 

--- a/game/js/pickup.js
+++ b/game/js/pickup.js
@@ -57,7 +57,7 @@ function buildPickupMesh(type) {
   var group = new THREE.Group();
 
   var color = TYPE_COLORS[type] || 0xffffff;
-  var mat = new THREE.MeshLambertMaterial({ color: color });
+  var mat = new THREE.MeshToonMaterial({ color: color });
 
   var mesh;
   if (type === "fuel") {

--- a/game/js/port.js
+++ b/game/js/port.js
@@ -101,14 +101,14 @@ function buildPortMesh() {
 
   // pier platform
   var pierGeo = new THREE.BoxGeometry(3, 0.4, 6);
-  var pierMat = new THREE.MeshLambertMaterial({ color: 0x8b6914 });
+  var pierMat = new THREE.MeshToonMaterial({ color: 0xa07a18 });
   var pier = new THREE.Mesh(pierGeo, pierMat);
   pier.position.set(0, 1.5, 0);
   group.add(pier);
 
   // pilings (4 corner posts)
   var pilingGeo = new THREE.CylinderGeometry(0.15, 0.15, 3, 6);
-  var pilingMat = new THREE.MeshLambertMaterial({ color: 0x5a4010 });
+  var pilingMat = new THREE.MeshToonMaterial({ color: 0x6a4a14 });
   var offsets = [[-1.2, -2.5], [1.2, -2.5], [-1.2, 2.5], [1.2, 2.5]];
   for (var i = 0; i < offsets.length; i++) {
     var piling = new THREE.Mesh(pilingGeo, pilingMat);
@@ -118,14 +118,14 @@ function buildPortMesh() {
 
   // supply crate on pier
   var crateGeo = new THREE.BoxGeometry(0.8, 0.8, 0.8);
-  var crateMat = new THREE.MeshLambertMaterial({ color: 0x44aa66 });
+  var crateMat = new THREE.MeshToonMaterial({ color: 0x44cc77 });
   var crate = new THREE.Mesh(crateGeo, crateMat);
   crate.position.set(0.5, 2.1, 1.0);
   group.add(crate);
 
   // barrel on pier
   var barrelGeo = new THREE.CylinderGeometry(0.3, 0.3, 0.7, 8);
-  var barrelMat = new THREE.MeshLambertMaterial({ color: 0x2288cc });
+  var barrelMat = new THREE.MeshToonMaterial({ color: 0x2299ee });
   var barrel = new THREE.Mesh(barrelGeo, barrelMat);
   barrel.position.set(-0.6, 2.05, -0.8);
   group.add(barrel);
@@ -137,7 +137,7 @@ function buildPortMesh() {
 
   // beacon post
   var postGeo = new THREE.CylinderGeometry(0.08, 0.08, 2, 6);
-  var postMat = new THREE.MeshLambertMaterial({ color: 0x888888 });
+  var postMat = new THREE.MeshToonMaterial({ color: 0x999999 });
   var post = new THREE.Mesh(postGeo, postMat);
   post.position.set(1.2, 2.5, -2.5);
   group.add(post);

--- a/game/js/ship.js
+++ b/game/js/ship.js
@@ -43,14 +43,14 @@ function buildShipMesh() {
 
   var extrudeSettings = { depth: 0.5, bevelEnabled: false };
   var hullGeo = new THREE.ExtrudeGeometry(hullShape, extrudeSettings);
-  var hullMat = new THREE.MeshLambertMaterial({ color: 0x556677 });
+  var hullMat = new THREE.MeshToonMaterial({ color: 0x5a7088 });
   var hull = new THREE.Mesh(hullGeo, hullMat);
   hull.rotation.x = -Math.PI / 2;
   hull.position.y = -0.1;
   group.add(hull);
 
   var deckGeo = new THREE.PlaneGeometry(1.2, 3.6);
-  var deckMat = new THREE.MeshLambertMaterial({ color: 0x667788 });
+  var deckMat = new THREE.MeshToonMaterial({ color: 0x708899 });
   var deck = new THREE.Mesh(deckGeo, deckMat);
   deck.rotation.x = -Math.PI / 2;
   deck.position.y = 0.4;
@@ -58,15 +58,15 @@ function buildShipMesh() {
   group.add(deck);
 
   var bridgeGeo = new THREE.BoxGeometry(0.7, 0.6, 0.8);
-  var bridgeMat = new THREE.MeshLambertMaterial({ color: 0x778899 });
+  var bridgeMat = new THREE.MeshToonMaterial({ color: 0x8899aa });
   var bridge = new THREE.Mesh(bridgeGeo, bridgeMat);
   bridge.position.set(0, 0.7, -0.6);
   group.add(bridge);
 
   var turretGeo = new THREE.CylinderGeometry(0.2, 0.25, 0.3, 6);
-  var turretMat = new THREE.MeshLambertMaterial({ color: 0x445566 });
+  var turretMat = new THREE.MeshToonMaterial({ color: 0x4a6077 });
   var barrelGeo = new THREE.CylinderGeometry(0.04, 0.04, 0.7, 4);
-  var barrelMat = new THREE.MeshLambertMaterial({ color: 0x334455 });
+  var barrelMat = new THREE.MeshToonMaterial({ color: 0x3a5066 });
 
   var fwdTurret = new THREE.Group();
   fwdTurret.position.set(0, 0.55, 0.8);
@@ -89,7 +89,7 @@ function buildShipMesh() {
   group.userData.turrets = [fwdTurret, rearTurret];
 
   var mastGeo = new THREE.CylinderGeometry(0.02, 0.03, 1.0, 4);
-  var mastMat = new THREE.MeshLambertMaterial({ color: 0x556677 });
+  var mastMat = new THREE.MeshToonMaterial({ color: 0x5a7088 });
   var mast = new THREE.Mesh(mastGeo, mastMat);
   mast.position.set(0, 1.3, -0.6);
   group.add(mast);

--- a/game/js/shipModels.js
+++ b/game/js/shipModels.js
@@ -204,7 +204,7 @@ function buildCarrierMesh() {
   group.add(deck);
 
   // runway markings
-  var stripeMat = new THREE.MeshStandardMaterial({ color: 0xccccaa, roughness: 0.8, metalness: 0 });
+  var stripeMat = new THREE.MeshToonMaterial({ color: 0xddddbb });
   var stripeGeo = new THREE.PlaneGeometry(0.06, 3.8);
   var stripe = new THREE.Mesh(stripeGeo, stripeMat);
   stripe.rotation.x = -Math.PI / 2;
@@ -318,7 +318,7 @@ function buildSubmarineMesh() {
 
   // dive planes (horizontal fins)
   var finGeo = new THREE.BoxGeometry(0.6, 0.03, 0.15);
-  var finMat = new THREE.MeshStandardMaterial({ color: 0x3a4a5a, roughness: 0.5, metalness: 0.4 });
+  var finMat = new THREE.MeshToonMaterial({ color: 0x4a5a6a });
   var finFwd = new THREE.Mesh(finGeo, finMat);
   finFwd.position.set(0, 0.15, 1.5);
   group.add(finFwd);

--- a/game/js/shipParts.js
+++ b/game/js/shipParts.js
@@ -15,22 +15,11 @@ var anchorMat = null;
 
 export function ensureMaterials() {
   if (glassMat) return;
-  glassMat = new THREE.MeshStandardMaterial({
-    color: 0x1a2a3a, roughness: 0.1, metalness: 0.5,
-    emissive: 0x1a2a3a, emissiveIntensity: 0
-  });
-  metalMat = new THREE.MeshStandardMaterial({
-    color: 0x888899, roughness: 0.3, metalness: 0.8
-  });
-  radarMat = new THREE.MeshStandardMaterial({
-    color: 0x667777, roughness: 0.4, metalness: 0.7
-  });
-  flagMat = new THREE.MeshStandardMaterial({
-    color: 0xeeeeee, roughness: 0.9, metalness: 0.0, side: THREE.DoubleSide
-  });
-  anchorMat = new THREE.MeshStandardMaterial({
-    color: 0x444444, roughness: 0.4, metalness: 0.9
-  });
+  glassMat = new THREE.MeshToonMaterial({ color: 0x2a4a6a });
+  metalMat = new THREE.MeshToonMaterial({ color: 0x9999aa });
+  radarMat = new THREE.MeshToonMaterial({ color: 0x7799aa });
+  flagMat = new THREE.MeshToonMaterial({ color: 0xeeeeee, side: THREE.DoubleSide });
+  anchorMat = new THREE.MeshToonMaterial({ color: 0x555555 });
 }
 
 export function getMetalMat() { ensureMaterials(); return metalMat; }
@@ -38,7 +27,7 @@ export function getMetalMat() { ensureMaterials(); return metalMat; }
 export function getHullMat(color) {
   var key = color.toString(16);
   if (!hullMats[key]) {
-    hullMats[key] = new THREE.MeshStandardMaterial({ color: color, roughness: 0.7, metalness: 0.1 });
+    hullMats[key] = new THREE.MeshToonMaterial({ color: color });
   }
   return hullMats[key];
 }
@@ -46,7 +35,7 @@ export function getHullMat(color) {
 export function getDeckMat(color) {
   var key = color.toString(16);
   if (!deckMats[key]) {
-    deckMats[key] = new THREE.MeshStandardMaterial({ color: color, roughness: 0.5, metalness: 0.05 });
+    deckMats[key] = new THREE.MeshToonMaterial({ color: color });
   }
   return deckMats[key];
 }
@@ -54,7 +43,7 @@ export function getDeckMat(color) {
 export function getBridgeMat(color) {
   var key = color.toString(16);
   if (!bridgeMats[key]) {
-    bridgeMats[key] = new THREE.MeshStandardMaterial({ color: color, roughness: 0.5, metalness: 0.2 });
+    bridgeMats[key] = new THREE.MeshToonMaterial({ color: color });
   }
   return bridgeMats[key];
 }
@@ -62,7 +51,7 @@ export function getBridgeMat(color) {
 export function getTurretMat(color) {
   var key = color.toString(16);
   if (!turretMats[key]) {
-    turretMats[key] = new THREE.MeshStandardMaterial({ color: color, roughness: 0.35, metalness: 0.7 });
+    turretMats[key] = new THREE.MeshToonMaterial({ color: color });
   }
   return turretMats[key];
 }
@@ -70,7 +59,7 @@ export function getTurretMat(color) {
 export function getBarrelMat(color) {
   var key = color.toString(16);
   if (!barrelMats[key]) {
-    barrelMats[key] = new THREE.MeshStandardMaterial({ color: color, roughness: 0.3, metalness: 0.8 });
+    barrelMats[key] = new THREE.MeshToonMaterial({ color: color });
   }
   return barrelMats[key];
 }
@@ -78,7 +67,7 @@ export function getBarrelMat(color) {
 // --- waterline stripe (dark band at hull base) ---
 export function addWaterline(group, halfWidth, length, zOffset) {
   var wlGeo = new THREE.PlaneGeometry(halfWidth * 2, length);
-  var wlMat = new THREE.MeshStandardMaterial({ color: 0x1a0a0a, roughness: 0.9, metalness: 0 });
+  var wlMat = new THREE.MeshToonMaterial({ color: 0x1a0a0a });
   var wl = new THREE.Mesh(wlGeo, wlMat);
   wl.rotation.x = -Math.PI / 2;
   wl.position.set(0, 0.01, zOffset || 0);
@@ -155,12 +144,12 @@ export function addBridgeWindows(group, bx, by, bz, width, height) {
 // --- smokestack ---
 export function addSmokestack(group, x, y, z, radius, height) {
   var stackGeo = new THREE.CylinderGeometry(radius * 0.8, radius, height, 8);
-  var stackMat = new THREE.MeshStandardMaterial({ color: 0x333333, roughness: 0.6, metalness: 0.3 });
+  var stackMat = new THREE.MeshToonMaterial({ color: 0x444444 });
   var stack = new THREE.Mesh(stackGeo, stackMat);
   stack.position.set(x, y + height / 2, z);
   group.add(stack);
   var rimGeo = new THREE.TorusGeometry(radius * 0.8, 0.02, 4, 8);
-  var rimMat = new THREE.MeshStandardMaterial({ color: 0x111111, roughness: 0.8, metalness: 0.2 });
+  var rimMat = new THREE.MeshToonMaterial({ color: 0x222222 });
   var rim = new THREE.Mesh(rimGeo, rimMat);
   rim.rotation.x = Math.PI / 2;
   rim.position.set(x, y + height, z);

--- a/game/js/terrain.js
+++ b/game/js/terrain.js
@@ -328,10 +328,10 @@ function buildTerrainMesh(heightmap) {
   var positions = [];
   var colors = [];
 
-  var colorLand = new THREE.Color(0x4a7a35);
-  var colorDirt = new THREE.Color(0x8b6914);
-  var colorBeach = new THREE.Color(0xe8d5a0);
-  var colorPeak = new THREE.Color(0x5a5a5a);
+  var colorLand = new THREE.Color(0x55aa3a);
+  var colorDirt = new THREE.Color(0xaa7a18);
+  var colorBeach = new THREE.Color(0xf0dda8);
+  var colorPeak = new THREE.Color(0x6a6a6a);
 
   for (var iy = 0; iy < size - 1; iy++) {
     for (var ix = 0; ix < size - 1; ix++) {


### PR DESCRIPTION
Closes #126

## Summary
- Replace all `MeshStandardMaterial` (PBR) with `MeshToonMaterial` across ships, enemies, bosses, ports, crates, drones, and pickups
- FBX environment/island assets auto-converted from PBR to toon materials on load via `fbxVisual.js`
- Boost color saturation for vibrant cartoon aesthetic (terrain, faction colors, port structures)
- Terrain vertex colors brightened for more vibrant island surfaces

## Acceptance Criteria
- [x] Islands and environment props use flat/toon shading (no specular shine)
- [x] Colors are vibrant and saturated — cartoon aesthetic, not realistic
- [x] Consistent look between ship models and environment
- [x] Performance equal or better (toon materials are cheaper)

## Files Changed (12)
- `fbxVisual.js` — `applyFlat()` now replaces any PBR material with `MeshToonMaterial` + saturation boost
- `shipParts.js` — All shared ship materials converted to toon
- `shipModels.js` — Inline stripe/fin materials converted
- `ship.js` — Fallback ship model converted from Lambert to toon
- `enemy.js` — Faction materials converted, colors boosted
- `bossModels.js` — All boss materials (battleship, carrier, kraken) converted
- `port.js` — Port structures converted from Lambert to toon
- `crate.js`, `pickup.js`, `drone.js`, `boss.js` — Game objects converted
- `terrain.js` — Island vertex colors brightened

🤖 Generated with [Claude Code](https://claude.com/claude-code)