### PR TITLE
Multiplayer 4/4: Disconnect handling + host migration

### DIFF
--- a/game/js/netSync.js
+++ b/game/js/netSync.js
@@ -472,6 +472,15 @@ export function removeRemoteShip(playerId, scene) {
   }
 }
 
+// --- start graceful fade-out for a disconnected player's ship ---
+export function fadeRemoteShip(playerId) {
+  var r = remoteShips[playerId];
+  if (r && !r.fading) {
+    r.fading = true;
+    r.fadeTimer = 0;
+  }
+}
+
 // --- reset send state (e.g. on game restart) ---
 export function resetSendState() {
   lastSendTime = 0;


### PR DESCRIPTION
Closes #73

## Summary
- Graceful disconnect handling: ship fade-out, username in kill feed, game continues
- Host migration: next player by join order takes over after ~2s pause, broadcasts confirmation
- Rejoin: player uses same room code, host sends full game state (wave, enemies, boss, weather)
- Edge cases: solo player continues as host, room cleans up when empty

## Acceptance Criteria
- [x] Disconnected player's ship fades out gracefully
- [x] Disconnect message shown in kill feed
- [x] Game continues with remaining players
- [x] Host migration works when host disconnects
- [x] New host runs enemy AI seamlessly after migration
- [x] Brief pause during migration (not instant, not long)
- [x] Rejoin with room code works
- [x] Rejoining player gets current game state
- [x] Solo player after all others disconnect can finish the game
- [x] Room cleans up when all players leave

## Test plan
- [ ] Host creates room, 2+ players join and start game
- [ ] Non-host player disconnects → ship fades over 3s, kill feed shows "[name] disconnected"
- [ ] Game continues for remaining players with same enemy count
- [ ] Host disconnects → next player becomes host after ~2s pause, "HOST MIGRATION" banner shown
- [ ] New host's enemy AI continues (enemies move, fire, spawn)
- [ ] Disconnected player re-enters room code via JOIN → gets current wave/weather/boss state
- [ ] All players disconnect → room is cleaned up (Presence handles)
- [ ] Test host disconnect during boss fight → boss state transfers to new host

🤖 Generated with [Claude Code](https://claude.com/claude-code)