### PR TITLE
Multiplayer: sync weather state across all players

### DIFF
--- a/game/js/daynight.js
+++ b/game/js/daynight.js
@@ -193,6 +193,11 @@ export function createStars(scene) {
   return { mesh: mesh, material: material };
 }
 
+// set time of day directly (for multiplayer sync)
+export function setTimeOfDay(state, tod) {
+  state.timeOfDay = tod % 1.0;
+}
+
 // compute nightness factor (0 = day, 1 = full night)
 export function getNightness(timeOfDay) {
   if (timeOfDay < 0.2 || timeOfDay > 0.8) return 1.0;


### PR DESCRIPTION
Closes #104

## Summary
- Host determines weather state (type, intensity, time-of-day) and broadcasts it
- Periodic `weather_sync` messages sent at ~2 Hz with weather key + `timeOfDay`
- All clients apply the same weather — same fog distance, rain intensity, lighting
- Weather transitions synced — storm starts/ends at same time for all players
- Day/night cycle synchronized via `setTimeOfDay` on clients
- Rejoin snapshots include `timeOfDay` so reconnecting players get correct lighting

## Acceptance Criteria
- [x] Host determines weather state (type, intensity, time-of-day)
- [x] Broadcast weather state as periodic sync messages
- [x] All clients apply the same weather — same fog distance, rain intensity, lighting
- [x] Weather transitions should be synced (storm starts/ends at same time for all)

## Changes
- `combatSync.js`: Added `sendWeatherSync()` (host→all, ~2 Hz) and `weather_sync` message handler
- `daynight.js`: Added `setTimeOfDay()` for multiplayer time-of-day correction
- `main.js`: 
  - Reset `timeOfDay` to 0.35 on multiplayer game start for consistent initial state
  - Include `timeOfDay` in `rejoin_state` snapshot
  - Apply `timeOfDay` from rejoin state on reconnecting clients
  - Handle `weather_sync` action to correct weather + day/night drift on non-host clients
  - Host sends periodic weather sync in game loop