### PR TITLE
Bug: click-to-move (single tap waypoint) no longer works

### DIFF
--- a/game/js/input.js
+++ b/game/js/input.js
@@ -6,7 +6,8 @@ var mouse = {
   y: 0,
   clicked: false,
   clickConsumed: false,
-  held: false
+  held: false,
+  holdStart: 0
 };
 
 // keyboard action queue — consumed once per frame
@@ -32,6 +33,7 @@ function onMouseDown(e) {
     mouse.clicked = true;
     mouse.clickConsumed = false;
     mouse.held = true;
+    mouse.holdStart = performance.now();
   }
 }
 
@@ -49,6 +51,7 @@ function onTouchStart(e) {
     mouse.clicked = true;
     mouse.clickConsumed = false;
     mouse.held = true;
+    mouse.holdStart = performance.now();
   }
 }
 

--- a/game/js/main.js
+++ b/game/js/main.js
@@ -51,6 +51,7 @@ var GOLD_PER_KILL = 25;
 var prevPlayerHp = -1;
 var lastZoneResult = null; // "victory" or "game_over"
 var wasHeld = false; // tracks previous frame hold state for release detection
+var HOLD_THRESHOLD = 200; // ms — presses shorter than this count as click, not hold
 var runEnemiesSunk = 0; // enemies sunk during current run
 var runGoldLooted = 0; // gold earned during current run
 var runZonesReached = 0; // zones visited during current run
@@ -977,12 +978,16 @@ function animate() {
     }
 
     // press-and-hold: continuously update nav target while pointer is held
-    if (mouse.held) {
+    // Only activate hold mode after HOLD_THRESHOLD ms — shorter presses are clicks (waypoints)
+    var holdElapsed = mouse.held ? performance.now() - mouse.holdStart : 0;
+    if (mouse.held && holdElapsed >= HOLD_THRESHOLD) {
       handleHold(mouse.x, mouse.y);
       wasHeld = true;
-    } else if (wasHeld) {
-      // pointer just released — stop movement
+    } else if (!mouse.held && wasHeld) {
+      // pointer released after a hold — stop continuous movement
       stopHold();
+      wasHeld = false;
+    } else if (!mouse.held) {
       wasHeld = false;
     }
 


### PR DESCRIPTION
Closes #144

## Changes

Added a hold-duration threshold (200ms) to distinguish single clicks from long presses:
- **input.js**: Track `holdStart` timestamp on mousedown/touchstart
- **main.js**: Only enter continuous-follow mode (`handleHold`) after 200ms; quick releases preserve the waypoint set by `handleClick`

## Acceptance Criteria

- [x] Single click/tap sets a one-time move target (ship sails to that point and stops)
- [x] Press-and-hold still works (ship continuously follows pointer)
- [x] Both modes coexist — hold for continuous, click for waypoint
- [x] Works on mobile (touch) and desktop (mouse)