### PR TITLE
Bug: text selectable on screen + CSS/HTML game usability fixes

### DIFF
--- a/game/index.html
+++ b/game/index.html
@@ -14,8 +14,34 @@
   <base href="/ocean-outlaws/game/">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
-    html, body { width: 100%; height: 100%; overflow: hidden; background: #0a0e1a; }
-    canvas { display: block; }
+    html, body {
+      width: 100%; height: 100%; overflow: hidden; background: #0a0e1a;
+      /* Prevent text selection everywhere */
+      -webkit-user-select: none;
+      -moz-user-select: none;
+      -ms-user-select: none;
+      user-select: none;
+      /* Default cursor — no text cursor on UI */
+      cursor: default;
+      /* Prevent iOS touch callout */
+      -webkit-touch-callout: none;
+      /* Prevent tap highlight on mobile */
+      -webkit-tap-highlight-color: transparent;
+      /* Prevent pull-to-refresh & pinch-to-zoom */
+      overscroll-behavior: none;
+      touch-action: none;
+    }
+    canvas {
+      display: block;
+      /* Prevent canvas drag */
+      -webkit-user-drag: none;
+      touch-action: none;
+    }
+    img, svg {
+      -webkit-user-drag: none;
+      user-drag: none;
+      pointer-events: none;
+    }
   </style>
   <script type="importmap">
   {

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, user-scalable=no, maximum-scale=1">
   <meta name="theme-color" content="#1a1408">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
@@ -23,7 +23,19 @@
       color: #e8d5a8;
       font-family: 'Cinzel', 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif;
       overflow-x: hidden;
+      /* Prevent text selection */
+      -webkit-user-select: none;
+      -moz-user-select: none;
+      -ms-user-select: none;
+      user-select: none;
+      /* Default cursor — no text cursor on UI */
+      cursor: default;
+      /* Prevent iOS touch callout */
+      -webkit-touch-callout: none;
+      /* Prevent tap highlight on mobile */
       -webkit-tap-highlight-color: transparent;
+      /* Prevent pull-to-refresh */
+      overscroll-behavior: none;
     }
 
     /* Animated ocean background */
@@ -258,7 +270,9 @@
       letter-spacing: 0.05em;
     }
 
-    footer a { color: #8b7a5a; text-decoration: none; }
+    footer a { color: #8b7a5a; text-decoration: none; cursor: pointer; }
+
+    img, svg { -webkit-user-drag: none; user-drag: none; }
 
     /* Desktop */
     @media (min-width: 768px) {
@@ -339,6 +353,9 @@
   </footer>
 
   <script>
+    // Prevent context menu
+    window.addEventListener('contextmenu', function (e) { e.preventDefault(); });
+
     // PWA install prompt
     var deferredPrompt = null;
     var installBtn = document.getElementById('installBtn');


### PR DESCRIPTION
Closes #145

## Acceptance Criteria
- [x] No text anywhere in the game is selectable (`user-select: none` on body/root)
- [x] No text highlight/selection color visible on any UI element
- [x] No context menu on right-click (game captures all input)
- [x] No drag-and-drop on images or canvas elements
- [x] No touch callout on long-press (iOS `-webkit-touch-callout: none`)
- [x] No tap highlight on mobile (`-webkit-tap-highlight-color: transparent`)
- [x] No pinch-to-zoom on mobile (`touch-action` + viewport meta)
- [x] No pull-to-refresh on mobile
- [x] No text cursor shown when hovering UI elements (`cursor: default` or `pointer` as appropriate)
- [x] Canvas cannot be accidentally scrolled

## Changes
- **game/index.html**: Added global `user-select: none`, `cursor: default`, `-webkit-touch-callout: none`, `-webkit-tap-highlight-color: transparent`, `overscroll-behavior: none`, `touch-action: none` on `html, body`. Canvas and img/svg get drag prevention.
- **index.html** (landing page): Same treatment — `user-select: none`, `cursor: default`, touch callout/highlight prevention, `overscroll-behavior: none`, viewport `user-scalable=no, maximum-scale=1`, context menu prevention via JS, image drag prevention.
- Context menu was already prevented in `game/js/nav.js` for the game page; landing page now also prevents it.