### PR TITLE
Bug: main menu always starts same mission — no run progression

### DIFF
--- a/game/js/mainMenu.js
+++ b/game/js/mainMenu.js
@@ -1,0 +1,98 @@
+// mainMenu.js — main menu screen with New Run / Continue Run
+import { isMobile } from "./mobile.js";
+import { T, FONT } from "./theme.js";
+
+var overlay = null;
+var continueBtn = null;
+var newRunCallback = null;
+var continueRunCallback = null;
+
+export function createMainMenu() {
+  var _mob = isMobile();
+  overlay = document.createElement("div");
+  overlay.style.cssText = [
+    "position:fixed",
+    "top:0", "left:0",
+    "width:100%", "height:100%",
+    "display:none",
+    "flex-direction:column",
+    "align-items:center",
+    "justify-content:center",
+    "background:" + T.bgOverlay,
+    "z-index:250",
+    "font-family:" + FONT,
+    "user-select:none"
+  ].join(";");
+
+  var title = document.createElement("div");
+  title.textContent = "OCEAN OUTLAWS";
+  title.style.cssText = [
+    "font-size:" + (_mob ? "36px" : "48px"),
+    "font-weight:bold",
+    "color:" + T.gold,
+    "margin-bottom:8px",
+    "text-shadow:0 2px 8px rgba(212,164,74,0.4), 0 4px 16px rgba(0,0,0,0.6)",
+    "letter-spacing:6px"
+  ].join(";");
+  overlay.appendChild(title);
+
+  var subtitle = document.createElement("div");
+  subtitle.textContent = "Roguelite Naval Combat";
+  subtitle.style.cssText = [
+    "font-size:" + (_mob ? "14px" : "16px"),
+    "color:" + T.textDim,
+    "margin-bottom:48px",
+    "letter-spacing:3px"
+  ].join(";");
+  overlay.appendChild(subtitle);
+
+  var newBtn = document.createElement("button");
+  newBtn.textContent = "NEW RUN";
+  newBtn.style.cssText = buildBtnStyle(_mob, true);
+  newBtn.addEventListener("click", function () {
+    if (newRunCallback) newRunCallback();
+  });
+  overlay.appendChild(newBtn);
+
+  continueBtn = document.createElement("button");
+  continueBtn.textContent = "CONTINUE RUN";
+  continueBtn.style.cssText = buildBtnStyle(_mob, false);
+  continueBtn.addEventListener("click", function () {
+    if (continueRunCallback) continueRunCallback();
+  });
+  overlay.appendChild(continueBtn);
+
+  document.body.appendChild(overlay);
+}
+
+function buildBtnStyle(_mob, primary) {
+  return [
+    "font-family:" + FONT,
+    "font-size:" + (_mob ? "20px" : "18px"),
+    "padding:" + (_mob ? "16px 52px" : "14px 44px"),
+    "margin-bottom:16px",
+    "min-width:" + (_mob ? "260px" : "240px"),
+    "min-height:44px",
+    "background:" + (primary ? "rgba(80,60,30,0.85)" : T.bgLight),
+    "color:" + (primary ? T.goldBright : T.text),
+    "border:2px solid " + (primary ? T.borderGold : T.border),
+    "border-radius:6px",
+    "cursor:pointer",
+    "pointer-events:auto",
+    "letter-spacing:3px",
+    "text-shadow:0 1px 2px rgba(0,0,0,0.4)"
+  ].join(";");
+}
+
+export function showMainMenu(onNewRun, onContinueRun, hasContinue) {
+  newRunCallback = onNewRun;
+  continueRunCallback = onContinueRun;
+  if (continueBtn) {
+    continueBtn.style.display = hasContinue ? "block" : "none";
+  }
+  if (overlay) overlay.style.display = "flex";
+}
+
+export function hideMainMenu() {
+  if (overlay) overlay.style.display = "none";
+}

--- a/game/js/runState.js
+++ b/game/js/runState.js
@@ -1,0 +1,46 @@
+// runState.js — roguelite run state persistence
+// Tracks current run progress between encounters in the voyage chart.
+
+var RUN_KEY = "ocean_outlaws_run";
+
+export function createRunState(seed) {
+  return {
+    seed: seed,
+    selectedClass: null,
+    gold: 0,
+    upgradeLevels: null,
+    crewRoster: null,
+    crewAssigned: null,
+    enemiesSunk: 0,
+    goldLooted: 0,
+    nodesCompleted: 0,
+    active: true,
+    hp: null,
+    maxHp: null
+  };
+}
+
+export function saveRunState(state) {
+  try {
+    localStorage.setItem(RUN_KEY, JSON.stringify(state));
+  } catch (e) { /* ignore */ }
+}
+
+export function loadRunState() {
+  try {
+    var raw = localStorage.getItem(RUN_KEY);
+    if (raw) return JSON.parse(raw);
+  } catch (e) { /* ignore */ }
+  return null;
+}
+
+export function hasActiveRun() {
+  var state = loadRunState();
+  return !!(state && state.active);
+}
+
+export function clearRunState() {
+  try {
+    localStorage.removeItem(RUN_KEY);
+  } catch (e) { /* ignore */ }
+}


### PR DESCRIPTION
Closes #154

## Acceptance Criteria

- [x] Main menu offers "New Run" and "Continue Run" (if mid-run)
- [x] New Run → ship select → voyage chart (not directly into combat)
- [x] Voyage chart is the primary navigation between encounters
- [x] Each node on voyage chart leads to a distinct encounter (combat/port/event/boss)
- [x] After completing a node, player returns to voyage chart
- [x] Run ends after final voyage chart node (boss) → end-of-run summary with infamy
- [x] New runs feel different (voyage chart seeded differently each time)
- [x] Zone/wave state persists within a run (don't restart on death — roguelite permadeath resets the run)

## Implementation

- `mainMenu.js` — new main menu screen with New Run / Continue Run buttons
- `runState.js` — roguelite run state persistence (gold, upgrades, crew, HP between nodes)
- `voyageChart.js` + `voyageData.js` — Slay-the-Spire-style branching voyage chart
- `main.js` — wires the full run flow: main menu → ship select → voyage chart → node encounters → infamy summary → main menu

### Run Flow

1. **Main menu** → New Run or Continue Run
2. **Ship select** → pick your ship class
3. **Voyage chart** → choose first node (seeded differently each run)
4. **Node encounter** → combat/salvage/event based on node type; boss on exit nodes
5. **After node** → upgrade screen → crew screen → back to voyage chart
6. **After exit node victory** → end-of-run infamy summary → main menu
7. **On death** → permadeath: clears run, infamy summary, main menu