### PR TITLE
Expand 3D asset-role system with weighted/contextual variants and port docking hardening

### DIFF
--- a/docs/3d-asset-opportunities.md
+++ b/docs/3d-asset-opportunities.md
@@ -1,0 +1,254 @@
+# Ocean Outlaws 3D Asset Utilization Opportunities
+
+## Objective
+Leverage the existing 3D model inventory to increase world readability, thematic variety, and progression feedback—without requiring net-new art production.
+
+This document focuses on opportunities where gameplay systems currently use procedural placeholder geometry (or minimal visual variation) and can be upgraded using assets already present under `game/assets/models/` and cataloged in `game/data/testLabModelCatalog.json`.
+
+## Current-State Snapshot
+
+### What we already have available
+- Test Lab catalog entries: **239** total, across `ship`, `tree`, `island`, `port`, and `water` groups.
+- Active gameplay composite preset (`compositePresetsPalmov30.json`) uses **77 unique model paths**.
+- Estimated immediately available but not currently used by active gameplay composition: **162 cataloged models**.
+
+### High-value gaps in current gameplay visuals
+1. **Supply ports** are still generated from primitive meshes (`BoxGeometry`, `CylinderGeometry`, sphere lamp), even though we have piers, houses, props, and fences in the asset set.
+2. **Resource pickups/drops** are still primitive crate/barrel geometry with color tinting, despite having collectible-like props (barrels, boxes, bags, fish, bottles, baskets, food).
+3. **Map composition runtime** currently loads a single composite file (`compositePresetsPalmov30.json`), leaving large themed sets and alternate compositions underused.
+
+## Opportunity Matrix (Comprehensive)
+
+## 1) Ports, Harbors, and Shoreline Economy Spaces
+
+### 1.1 Replace procedural port mesh with modular GLB harbor kits
+**Current behavior:** `buildPortMesh()` in `port.js` builds a minimal pier + crate + barrel + lamp from primitives.
+
+**Assets to leverage now:**
+- Main anchors: `environment/wooden-piers/*`, `environment/wooden-platforms/*`, `environment/destroyed-wooden-pier.glb`
+- Harbor dressing: `environment/barrels/*`, `environment/boxes/*`, `environment/bags/*`, `environment/boards/*`, `environment/lamppost.glb`, `environment/bench.glb`, `environment/chairs/*`, `environment/tables/*`
+- Harbor structures: `houses/trading/*`, `houses/pirate/*`, `houses/lighthouse.glb`, `houses/house.glb`
+- Boundary/readability: `environment/fences/stone/*`, `environment/fences/untreated/*`, `environment/wooden-posts/*`
+
+**Gameplay benefit:**
+- Ports become recognizable POIs at distance.
+- Better affordance for repair/restock interactions.
+- Easier future addition of dock-specific mechanics (shop NPCs, queueing, quests).
+
+**Implementation notes:**
+- Define 3-5 reusable port composition templates (small cove dock, merchant quay, pirate shack dock, lighthouse jetty, damaged dock).
+- Swap template by biome/zone difficulty or faction influence.
+
+### 1.2 Faction-themed ports
+**Assets to leverage now:**
+- Pirate themes: `houses/pirate/*`, `vehicles/pirate-ships/*`
+- Merchant/trade themes: `houses/trading/*`, `food-tents/*`, `bag-grain*`, `basket.glb`, `box*`
+- Neutral/civil themes: `house.glb`, `lighthouse.glb`, benches/tables/chairs
+
+**Gameplay benefit:**
+- Visual storytelling of control/safety at each port.
+- Allows map progression feedback through environment state changes.
+
+### 1.3 Port upgrade visual progression
+**Assets to leverage now:**
+- Tier progression using more complete pier + props sets (`wooden-pier` -> `wooden-pier-5` + lamppost + fenced market details).
+
+**Gameplay benefit:**
+- Port level/relationship can be read without UI.
+
+---
+
+## 2) Drops, Collectibles, and Salvage Readability
+
+### 2.1 Replace primitive pickup meshes with type-specific prop models
+**Current behavior:** `pickup.js` builds drops from primitive box/cylinder geometry.
+
+**Assets to leverage now by pickup type:**
+- Ammo: `environment/boxes/*`, `environment/barrels/barrel-stand.glb`
+- Fuel: `environment/barrels/*`, `environment/bottles/*`
+- Parts: `environment/boards/*`, `environment/wooden-posts/*`, `environment/wooden-platforms/*`
+- Gold/loot: `environment/basket.glb`, `environment/mug.glb`, `environment/bags/*`
+- Food/heal style pickups (future): `environment/food/*`, `environment/drying-fish.glb`, `environment/fish.glb`
+
+**Gameplay benefit:**
+- No need to infer pickup type only from color.
+- Stronger “salvage from wreckage” fantasy.
+
+### 2.2 Add rarity/quality variants via existing prop families
+**Assets to leverage now:**
+- Use numbered variants (e.g., `barrel`, `barrel-2`, `barrel-3`; `box`, `box-2`, `box-3`) for common/uncommon/rare visuals.
+
+**Gameplay benefit:**
+- Better reward anticipation before collection.
+
+### 2.3 Wreck-drop bundles
+**Assets to leverage now:**
+- `vehicles/destroyed/*` fragments + floating props (`boards`, `barrels`, `bags`, `bottles`) as temporary salvage fields.
+
+**Gameplay benefit:**
+- Post-combat scenes feel consequential.
+- Opportunity for risk/reward mini-loops (linger for loot vs continue combat).
+
+---
+
+## 3) Island Biome and Encounter Set Dressing
+
+### 3.1 Use additional island/location packs in runtime rotation
+**Current behavior:** Runtime composition path defaults to `compositePresetsPalmov30.json`.
+
+**Assets to leverage now:**
+- Location anchors in `lands/*`, `islands/*`, `waters/water-location-*`
+- Supplemental terrain detail in `mountains/*`, `stones/*`, `trees/*`, `plants/*`
+
+**Gameplay benefit:**
+- More zone distinctiveness and replay variety.
+- Better tie between named map zones and in-world silhouettes.
+
+### 3.2 Encounter-specific visual language
+**Assets to leverage now:**
+- Sea monster zones: `environment/tentacles/*`, `land-sea-monster-attack.glb`, `water-location-sea-monster-attack.glb`
+- Secret/ruin zones: `land-secret-island.glb`, `houses/secret/*`, `stones/ancient/*`
+- Trade zones: `land-trade-port.glb`, `houses/trading/*`, market props
+- Lighthouse/nav zones: `island-lighthouse-pier.glb`, `houses/lighthouse.glb`, piers/lampposts
+
+**Gameplay benefit:**
+- Faster player comprehension of threat/opportunity by silhouette.
+
+### 3.3 Coastal traffic and static ambient vessels
+**Assets to leverage now:**
+- `vehicles/sailboats/*`, `vehicles/boat.glb`, `ships-palmov/boats/*`, `ships-palmov/small/*`
+
+**Gameplay benefit:**
+- World feels populated, not just combat-spawned.
+
+---
+
+## 4) Enemy, Mission, and Boss Scene Enhancement
+
+### 4.1 Expand enemy ship silhouette diversity without balance changes
+**Assets to leverage now:**
+- `ships-palmov/small|medium|large/*`, `ships-palmov/viking/*`, `vehicles/pirate-ships/*`
+
+**Gameplay benefit:**
+- More visual variety at same stat tiers.
+- Easier faction recognition.
+
+### 4.2 Boss arena staging assets
+**Assets to leverage now:**
+- Kraken/monster arenas: `environment/tentacles/*`, `waterfall.glb`, dramatic rock sets (`mountain-arch*`, `ancient-stone*`)
+- Human boss arenas: fortress-like fence/pier/house clusters.
+
+**Gameplay benefit:**
+- Boss fights feel authored rather than regular-wave scaling.
+
+### 4.3 Convoy/escort mission dressing (future mode)
+**Assets to leverage now:**
+- Merchant convoy from `vehicles/sailboats/*` + cargo props (`bags`, `boxes`, `food`).
+
+**Gameplay benefit:**
+- Enables non-combat objective formats using existing art.
+
+---
+
+## 5) UI/Meta Loops that Can Use Existing Models
+
+### 5.1 Upgrade screens and card reward previews
+**Assets to leverage now:**
+- `ship` catalog entries as rotating 3D previews.
+- Prop assets for reward cards (crate, barrel, fish, etc.).
+
+**Gameplay benefit:**
+- Better polish and player understanding in meta UI.
+
+### 5.2 Port screen diorama backgrounds
+**Assets to leverage now:**
+- `houses/*`, `wooden-piers/*`, market props + faction ship parked in background.
+
+**Gameplay benefit:**
+- Port interactions feel physically located in-world.
+
+### 5.3 Minimap/legend icon derivation from model families
+**Assets to leverage now:**
+- Use consistent iconography tied to model categories (pirate-house icon, lighthouse icon, tentacle icon).
+
+**Gameplay benefit:**
+- Stronger map readability and onboarding.
+
+---
+
+## 6) Technical Integration Opportunities
+
+### 6.1 Asset role registry (lightweight)
+Create a small JSON mapping from model paths to gameplay roles:
+- `port_modules`, `pickup_ammo`, `pickup_fuel`, `pickup_parts`, `pickup_gold`, `encounter_sea_monster`, etc.
+
+This enables deterministic selection and future balancing without hardcoding asset paths in multiple systems.
+
+### 6.2 Weighted variation pools by zone and faction
+Define weighted pools of models for each system:
+- Port template pool by faction.
+- Pickup model pool by resource type and rarity.
+- Ambient vessel pool by zone danger level.
+
+### 6.3 Budget-aware LOD/quality gates
+Reuse existing quality settings to control:
+- Prop density at ports.
+- Drop bundle complexity.
+- Ambient traffic count.
+
+### 6.4 Collision policy per asset role
+- Keep colliders for major navigational blockers (islands, buildings, large piers).
+- Disable/simplify collider on small props and floating pickups.
+
+---
+
+## Prioritized Roadmap
+
+### Phase 1 (High impact, low risk)
+1. **Port visual overhaul:** replace primitive `buildPortMesh()` with modular GLB compositions.
+2. **Pickup mesh overhaul:** replace primitive crate/barrel with role-specific prop models.
+3. **Add 2-3 themed port variants** (merchant, pirate, neutral).
+
+### Phase 2 (Medium effort, high replay value)
+1. Rotate/add additional composition sets for zone-specific visuals.
+2. Add ambient vessel spawning using small/boat model pools.
+3. Add wreck-drop salvage bundles from destroyed ship + prop fragments.
+
+### Phase 3 (Polish + depth)
+1. Boss arena prop kits per boss type.
+2. Port upgrade progression visuals by reputation or game stage.
+3. UI 3D previews in port and reward contexts.
+
+---
+
+## Suggested Success Metrics
+- **Visual variety:** unique model paths spawned per 10-minute run.
+- **System coverage:** % of gameplay systems using GLB assets instead of primitives.
+- **Player readability:** reduced time-to-identify pickup/resource type in playtests.
+- **Engagement proxy:** average time spent at port and around post-combat salvage zones.
+
+## Immediate Candidate Asset Pools (Quick Start)
+
+### Port module starter set
+- `assets/models/environment/wooden-piers/wooden-pier.glb`
+- `assets/models/environment/wooden-platforms/wooden-platform.glb`
+- `assets/models/environment/lamppost.glb`
+- `assets/models/houses/trading/trading-house.glb`
+- `assets/models/environment/boxes/box.glb`
+- `assets/models/environment/barrels/barrel.glb`
+
+### Pickup starter set
+- Ammo: `assets/models/environment/boxes/box-2.glb`
+- Fuel: `assets/models/environment/barrels/barrel-2.glb`
+- Parts: `assets/models/environment/boards/board.glb`
+- Gold: `assets/models/environment/basket.glb`
+
+### Encounter flavor set
+- Sea monster: `assets/models/environment/tentacles/tentacles.glb`
+- Trade route: `assets/models/vehicles/sailboats/sailboat.glb`
+- Ruins: `assets/models/stones/ancient/ancient-stone-12.glb`
+
+---
+
+## Conclusion
+Ocean Outlaws already has a deep, production-ready 3D asset library; the biggest wins now come from **wiring this inventory into active gameplay systems** (ports, pickups, encounter staging), not from creating new art. Converting just ports and pickups from primitives to existing GLBs would materially improve perceived production value and support future feature depth.

--- a/game/data/assetRoleRegistry.json
+++ b/game/data/assetRoleRegistry.json
@@ -1,6 +1,7 @@
 {
   "version": 1,
   "roles": {
+    "port.factions": ["neutral", "merchant", "pirate"],
     "port.themes": [
       [
         { "path": "assets/models/environment/wooden-piers/wooden-pier.glb", "fit": 8, "x": 0, "y": 0, "z": 0, "ry": 0 },
@@ -23,6 +24,76 @@
         { "path": "assets/models/environment/barrels/barrel-2.glb", "fit": 1.0, "x": 0.6, "y": 1.8, "z": -0.7, "ry": 0 },
         { "path": "assets/models/environment/bottles/bottle-2.glb", "fit": 0.7, "x": 0.2, "y": 2.0, "z": 0.4, "ry": 0 }
       ]
+    ],
+    "port.themes.neutral": [
+      [
+        { "path": "assets/models/environment/wooden-piers/wooden-pier.glb", "fit": 8, "x": 0, "y": 0, "z": 0, "ry": 0 },
+        { "path": "assets/models/environment/wooden-posts/wooden-post-2.glb", "fit": 2.5, "x": -1.2, "y": 0, "z": -2.3, "ry": 0 },
+        { "path": "assets/models/environment/wooden-posts/wooden-post-3.glb", "fit": 2.5, "x": 1.2, "y": 0, "z": -2.3, "ry": 0 },
+        { "path": "assets/models/environment/boxes/box.glb", "fit": 1.1, "x": 0.6, "y": 1.8, "z": 0.9, "ry": 0.4712389 },
+        { "path": "assets/models/environment/barrels/barrel.glb", "fit": 1.0, "x": -0.6, "y": 1.8, "z": -0.7, "ry": 0 }
+      ],
+      [
+        { "path": "assets/models/environment/wooden-piers/wooden-pier-4.glb", "fit": 8.5, "x": 0, "y": 0, "z": 0, "ry": 0 },
+        { "path": "assets/models/environment/lamppost.glb", "fit": 3.0, "x": 1.1, "y": 1.4, "z": -2.0, "ry": 0 },
+        { "path": "assets/models/environment/bags/bag-grain.glb", "fit": 1.1, "x": -0.5, "y": 1.8, "z": 0.7, "ry": 0 },
+        { "path": "assets/models/environment/boxes/box-3.glb", "fit": 1.1, "x": 0.7, "y": 1.8, "z": 1.0, "ry": 0.6283185 },
+        { "path": "assets/models/environment/barrels/barrel-3.glb", "fit": 1.1, "x": -0.8, "y": 1.8, "z": -0.7, "ry": 0 }
+      ],
+      [
+        { "path": "assets/models/environment/wooden-platforms/wooden-platform-2.glb", "fit": 8.2, "x": 0, "y": 0, "z": 0, "ry": 0 },
+        { "path": "assets/models/environment/wooden-piers/wooden-pier-2.glb", "fit": 8, "x": 0, "y": 0, "z": 0.2, "ry": 0 },
+        { "path": "assets/models/environment/boards/board-2.glb", "fit": 1.1, "x": -0.6, "y": 1.8, "z": 0.6, "ry": 0.6283185 },
+        { "path": "assets/models/environment/barrels/barrel-2.glb", "fit": 1.0, "x": 0.6, "y": 1.8, "z": -0.7, "ry": 0 },
+        { "path": "assets/models/environment/bottles/bottle-2.glb", "fit": 0.7, "x": 0.2, "y": 2.0, "z": 0.4, "ry": 0 }
+      ]
+    ],
+    "port.themes.merchant": [
+      [
+        { "path": "assets/models/environment/wooden-piers/wooden-pier-4.glb", "fit": 8.4, "x": 0, "y": 0, "z": 0, "ry": 0 },
+        { "path": "assets/models/houses/trading/trading-house.glb", "fit": 5.4, "x": 0.2, "y": 1.8, "z": -2.4, "ry": 0 },
+        { "path": "assets/models/environment/food-tents/food-tent-2.glb", "fit": 2.8, "x": -1.1, "y": 1.8, "z": 1.0, "ry": 0 },
+        { "path": "assets/models/environment/bags/bag-grain.glb", "fit": 1.0, "x": 0.7, "y": 1.8, "z": 1.1, "ry": 0.17 },
+        { "path": "assets/models/environment/boxes/box-3.glb", "fit": 1.0, "x": -0.6, "y": 1.8, "z": 0.8, "ry": 0.5 }
+      ],
+      [
+        { "path": "assets/models/environment/wooden-platforms/wooden-platform.glb", "fit": 8.4, "x": 0, "y": 0, "z": 0, "ry": 0 },
+        { "path": "assets/models/houses/trading/trading-house-2.glb", "fit": 5.6, "x": -0.3, "y": 1.8, "z": -2.5, "ry": 0 },
+        { "path": "assets/models/environment/tables/table-2.glb", "fit": 1.6, "x": 0.95, "y": 1.8, "z": 0.55, "ry": 0.22 },
+        { "path": "assets/models/environment/chairs/chair.glb", "fit": 1.1, "x": 0.35, "y": 1.8, "z": 0.95, "ry": -0.4 },
+        { "path": "assets/models/environment/barrels/barrel-stand.glb", "fit": 1.4, "x": -0.8, "y": 1.8, "z": 0.6, "ry": 0.2 }
+      ]
+    ],
+    "port.themes.pirate": [
+      [
+        { "path": "assets/models/environment/destroyed-wooden-pier.glb", "fit": 8.3, "x": 0, "y": 0, "z": 0, "ry": 0 },
+        { "path": "assets/models/houses/pirate/pirate-house.glb", "fit": 5.8, "x": -0.1, "y": 1.8, "z": -2.3, "ry": 0 },
+        { "path": "assets/models/environment/barrels/barrel-3.glb", "fit": 1.0, "x": 0.9, "y": 1.8, "z": 0.85, "ry": 0 },
+        { "path": "assets/models/environment/fences/untreated/untreated-fence.glb", "fit": 2.3, "x": 0.2, "y": 1.8, "z": 1.3, "ry": 0.08 },
+        { "path": "assets/models/environment/bags/bag-grain-2.glb", "fit": 1.0, "x": -0.7, "y": 1.8, "z": 0.8, "ry": -0.35 }
+      ],
+      [
+        { "path": "assets/models/environment/wooden-piers/wooden-pier-5.glb", "fit": 8.6, "x": 0, "y": 0, "z": 0, "ry": 0 },
+        { "path": "assets/models/houses/pirate/pirate-house-2.glb", "fit": 5.6, "x": 0, "y": 1.8, "z": -2.5, "ry": 0 },
+        { "path": "assets/models/environment/fences/stone/stone-fence-small.glb", "fit": 2.2, "x": 1.0, "y": 1.8, "z": 1.1, "ry": 0.24 },
+        { "path": "assets/models/environment/barrels/barrel.glb", "fit": 1.0, "x": -0.6, "y": 1.8, "z": 0.9, "ry": 0 },
+        { "path": "assets/models/environment/boxes/box-2.glb", "fit": 1.0, "x": 0.6, "y": 1.8, "z": 0.7, "ry": 0.35 }
+      ]
+    ],
+    "ambient.merchant": [
+      { "path": "assets/models/vehicles/sailboats/sailboat.glb", "fit": 6.2 },
+      { "path": "assets/models/vehicles/sailboats/sailboat-2.glb", "fit": 6.2 },
+      { "path": "assets/models/ships-palmov/boats/chinese-boat.glb", "fit": 6.0 }
+    ],
+    "ambient.navy": [
+      { "path": "assets/models/ships-palmov/boats/boat-1.glb", "fit": 6.0 },
+      { "path": "assets/models/ships-palmov/boats/boat-3.glb", "fit": 6.0 },
+      { "path": "assets/models/ships-palmov/small/ship-small-5.glb", "fit": 6.5 }
+    ],
+    "ambient.pirate": [
+      { "path": "assets/models/ships-palmov/small/pirate-ship-small.glb", "fit": 6.6 },
+      { "path": "assets/models/vehicles/pirate-ships/pirate-ship.glb", "fit": 6.8 },
+      { "path": "assets/models/vehicles/pirate-ships/pirate-ship-2.glb", "fit": 6.8 }
     ],
     "pickup.ammo": [
       { "path": "assets/models/environment/boxes/box.glb", "fit": 1.0 },

--- a/game/data/assetRoleRegistry.json
+++ b/game/data/assetRoleRegistry.json
@@ -1,0 +1,48 @@
+{
+  "version": 1,
+  "roles": {
+    "port.themes": [
+      [
+        { "path": "assets/models/environment/wooden-piers/wooden-pier.glb", "fit": 8, "x": 0, "y": 0, "z": 0, "ry": 0 },
+        { "path": "assets/models/environment/wooden-posts/wooden-post-2.glb", "fit": 2.5, "x": -1.2, "y": 0, "z": -2.3, "ry": 0 },
+        { "path": "assets/models/environment/wooden-posts/wooden-post-3.glb", "fit": 2.5, "x": 1.2, "y": 0, "z": -2.3, "ry": 0 },
+        { "path": "assets/models/environment/boxes/box.glb", "fit": 1.1, "x": 0.6, "y": 1.8, "z": 0.9, "ry": 0.4712389 },
+        { "path": "assets/models/environment/barrels/barrel.glb", "fit": 1.0, "x": -0.6, "y": 1.8, "z": -0.7, "ry": 0 }
+      ],
+      [
+        { "path": "assets/models/environment/wooden-piers/wooden-pier-4.glb", "fit": 8.5, "x": 0, "y": 0, "z": 0, "ry": 0 },
+        { "path": "assets/models/environment/lamppost.glb", "fit": 3.0, "x": 1.1, "y": 1.4, "z": -2.0, "ry": 0 },
+        { "path": "assets/models/environment/bags/bag-grain.glb", "fit": 1.1, "x": -0.5, "y": 1.8, "z": 0.7, "ry": 0 },
+        { "path": "assets/models/environment/boxes/box-3.glb", "fit": 1.1, "x": 0.7, "y": 1.8, "z": 1.0, "ry": 0.6283185 },
+        { "path": "assets/models/environment/barrels/barrel-3.glb", "fit": 1.1, "x": -0.8, "y": 1.8, "z": -0.7, "ry": 0 }
+      ],
+      [
+        { "path": "assets/models/environment/wooden-platforms/wooden-platform-2.glb", "fit": 8.2, "x": 0, "y": 0, "z": 0, "ry": 0 },
+        { "path": "assets/models/environment/wooden-piers/wooden-pier-2.glb", "fit": 8, "x": 0, "y": 0, "z": 0.2, "ry": 0 },
+        { "path": "assets/models/environment/boards/board-2.glb", "fit": 1.1, "x": -0.6, "y": 1.8, "z": 0.6, "ry": 0.6283185 },
+        { "path": "assets/models/environment/barrels/barrel-2.glb", "fit": 1.0, "x": 0.6, "y": 1.8, "z": -0.7, "ry": 0 },
+        { "path": "assets/models/environment/bottles/bottle-2.glb", "fit": 0.7, "x": 0.2, "y": 2.0, "z": 0.4, "ry": 0 }
+      ]
+    ],
+    "pickup.ammo": [
+      { "path": "assets/models/environment/boxes/box.glb", "fit": 1.0 },
+      { "path": "assets/models/environment/boxes/box-2.glb", "fit": 1.0 },
+      { "path": "assets/models/environment/boxes/box-3.glb", "fit": 1.0 }
+    ],
+    "pickup.fuel": [
+      { "path": "assets/models/environment/barrels/barrel.glb", "fit": 1.0 },
+      { "path": "assets/models/environment/barrels/barrel-2.glb", "fit": 1.0 },
+      { "path": "assets/models/environment/bottles/bottle-2.glb", "fit": 0.95 }
+    ],
+    "pickup.parts": [
+      { "path": "assets/models/environment/boards/board.glb", "fit": 1.0 },
+      { "path": "assets/models/environment/boards/board-2.glb", "fit": 1.0 },
+      { "path": "assets/models/environment/wooden-posts/wooden-post.glb", "fit": 1.0 }
+    ],
+    "pickup.gold": [
+      { "path": "assets/models/environment/basket.glb", "fit": 1.0 },
+      { "path": "assets/models/environment/bags/bag-grain.glb", "fit": 1.0 },
+      { "path": "assets/models/environment/mug.glb", "fit": 1.0 }
+    ]
+  }
+}

--- a/game/data/assetRoleRegistry.json
+++ b/game/data/assetRoleRegistry.json
@@ -92,6 +92,42 @@
         ]
       }
     ],
+    "port.themes.merchant.condition.calm": [
+      {
+        "weight": 1.6,
+        "modules": [
+          { "path": "assets/models/environment/wooden-piers/wooden-pier-4.glb", "fit": 8.5, "x": 0, "y": 0, "z": 0, "ry": 0 },
+          { "path": "assets/models/houses/trading/trading-house.glb", "fit": 5.6, "x": 0.2, "y": 1.8, "z": -2.5, "ry": 0 },
+          { "path": "assets/models/environment/food-tents/food-tent-2.glb", "fit": 2.9, "x": -1.0, "y": 1.8, "z": 1.1, "ry": 0 },
+          { "path": "assets/models/environment/bags/bag-grain.glb", "fit": 1.0, "x": 0.8, "y": 1.8, "z": 1.0, "ry": 0.2 },
+          { "path": "assets/models/environment/tables/table-2.glb", "fit": 1.5, "x": -0.55, "y": 1.8, "z": 0.75, "ry": 0.28 }
+        ]
+      }
+    ],
+    "port.themes.pirate.condition.stormy": [
+      {
+        "weight": 1.7,
+        "modules": [
+          { "path": "assets/models/environment/destroyed-wooden-pier.glb", "fit": 8.5, "x": 0, "y": 0, "z": 0, "ry": 0 },
+          { "path": "assets/models/houses/pirate/pirate-house-2.glb", "fit": 5.8, "x": 0, "y": 1.8, "z": -2.5, "ry": 0 },
+          { "path": "assets/models/environment/fences/stone/stone-fence-small.glb", "fit": 2.3, "x": 1.0, "y": 1.8, "z": 1.15, "ry": 0.3 },
+          { "path": "assets/models/environment/barrels/barrel-3.glb", "fit": 1.0, "x": -0.7, "y": 1.8, "z": 0.9, "ry": 0 },
+          { "path": "assets/models/environment/boxes/box-2.glb", "fit": 1.0, "x": 0.65, "y": 1.8, "z": 0.75, "ry": 0.38 }
+        ]
+      }
+    ],
+    "port.themes.pirate.zone.stormwall": [
+      {
+        "weight": 1.9,
+        "modules": [
+          { "path": "assets/models/environment/destroyed-wooden-pier.glb", "fit": 8.6, "x": 0, "y": 0, "z": 0, "ry": 0 },
+          { "path": "assets/models/houses/pirate/pirate-house-2.glb", "fit": 5.9, "x": 0, "y": 1.8, "z": -2.6, "ry": 0 },
+          { "path": "assets/models/environment/fences/stone/stone-fence-small.glb", "fit": 2.4, "x": 1.05, "y": 1.8, "z": 1.1, "ry": 0.33 },
+          { "path": "assets/models/environment/barrels/barrel-3.glb", "fit": 1.0, "x": -0.85, "y": 1.8, "z": 0.85, "ry": 0.15 },
+          { "path": "assets/models/environment/bags/bag-grain-2.glb", "fit": 1.0, "x": 0.5, "y": 1.8, "z": 0.7, "ry": -0.25 }
+        ]
+      }
+    ],
     "ambient.merchant": [
       { "path": "assets/models/vehicles/sailboats/sailboat.glb", "fit": 6.2, "weight": 1.4 },
       { "path": "assets/models/vehicles/sailboats/sailboat-2.glb", "fit": 6.2, "weight": 1.1 },

--- a/game/data/assetRoleRegistry.json
+++ b/game/data/assetRoleRegistry.json
@@ -107,6 +107,21 @@
       { "path": "assets/models/vehicles/pirate-ships/pirate-ship.glb", "fit": 6.8, "weight": 1.0 },
       { "path": "assets/models/vehicles/pirate-ships/pirate-ship-2.glb", "fit": 6.8, "weight": 0.9 }
     ],
+    "enemy.merchant": [
+      { "path": "assets/models/vehicles/sailboats/sailboat.glb", "fit": 6.5, "weight": 1.3 },
+      { "path": "assets/models/vehicles/sailboats/sailboat-2.glb", "fit": 6.5, "weight": 1.0 },
+      { "path": "assets/models/ships-palmov/boats/chinese-boat.glb", "fit": 6.3, "weight": 0.8 }
+    ],
+    "enemy.navy": [
+      { "path": "assets/models/ships-palmov/small/ship-small-5.glb", "fit": 6.8, "weight": 1.3 },
+      { "path": "assets/models/ships-palmov/boats/boat-3.glb", "fit": 6.3, "weight": 1.0 },
+      { "path": "assets/models/ships-palmov/boats/boat-1.glb", "fit": 6.3, "weight": 0.9 }
+    ],
+    "enemy.pirate": [
+      { "path": "assets/models/vehicles/pirate-ships/pirate-ship.glb", "fit": 7.0, "weight": 1.3 },
+      { "path": "assets/models/vehicles/pirate-ships/pirate-ship-2.glb", "fit": 7.0, "weight": 1.0 },
+      { "path": "assets/models/ships-palmov/small/pirate-ship-small.glb", "fit": 6.8, "weight": 0.8 }
+    ],
     "pickup.ammo": [
       { "path": "assets/models/environment/boxes/box.glb", "fit": 1.0 },
       { "path": "assets/models/environment/boxes/box-2.glb", "fit": 1.0 },

--- a/game/data/assetRoleRegistry.json
+++ b/game/data/assetRoleRegistry.json
@@ -97,6 +97,16 @@
       { "path": "assets/models/vehicles/sailboats/sailboat-2.glb", "fit": 6.2, "weight": 1.1 },
       { "path": "assets/models/ships-palmov/boats/chinese-boat.glb", "fit": 6.0, "weight": 0.7 }
     ],
+    "ambient.merchant.condition.calm": [
+      { "path": "assets/models/vehicles/sailboats/sailboat.glb", "fit": 6.2, "weight": 1.7 },
+      { "path": "assets/models/vehicles/sailboats/sailboat-2.glb", "fit": 6.2, "weight": 1.2 },
+      { "path": "assets/models/ships-palmov/boats/chinese-boat.glb", "fit": 6.0, "weight": 0.5 }
+    ],
+    "ambient.merchant.condition.stormy": [
+      { "path": "assets/models/ships-palmov/boats/chinese-boat.glb", "fit": 6.0, "weight": 1.4 },
+      { "path": "assets/models/vehicles/sailboats/sailboat-2.glb", "fit": 6.2, "weight": 0.9 },
+      { "path": "assets/models/vehicles/sailboats/sailboat.glb", "fit": 6.2, "weight": 0.7 }
+    ],
     "ambient.navy": [
       { "path": "assets/models/ships-palmov/boats/boat-1.glb", "fit": 6.0, "weight": 1.2 },
       { "path": "assets/models/ships-palmov/boats/boat-3.glb", "fit": 6.0, "weight": 1.0 },
@@ -117,10 +127,25 @@
       { "path": "assets/models/ships-palmov/boats/boat-3.glb", "fit": 6.3, "weight": 1.0 },
       { "path": "assets/models/ships-palmov/boats/boat-1.glb", "fit": 6.3, "weight": 0.9 }
     ],
+    "enemy.navy.condition.stormy": [
+      { "path": "assets/models/ships-palmov/small/ship-small-5.glb", "fit": 6.9, "weight": 1.6 },
+      { "path": "assets/models/ships-palmov/boats/boat-3.glb", "fit": 6.3, "weight": 0.9 },
+      { "path": "assets/models/ships-palmov/boats/boat-1.glb", "fit": 6.3, "weight": 0.6 }
+    ],
     "enemy.pirate": [
       { "path": "assets/models/vehicles/pirate-ships/pirate-ship.glb", "fit": 7.0, "weight": 1.3 },
       { "path": "assets/models/vehicles/pirate-ships/pirate-ship-2.glb", "fit": 7.0, "weight": 1.0 },
       { "path": "assets/models/ships-palmov/small/pirate-ship-small.glb", "fit": 6.8, "weight": 0.8 }
+    ],
+    "enemy.pirate.condition.stormy": [
+      { "path": "assets/models/vehicles/pirate-ships/pirate-ship.glb", "fit": 7.1, "weight": 1.5 },
+      { "path": "assets/models/vehicles/pirate-ships/pirate-ship-2.glb", "fit": 7.1, "weight": 1.2 },
+      { "path": "assets/models/ships-palmov/small/pirate-ship-small.glb", "fit": 6.8, "weight": 0.5 }
+    ],
+    "enemy.pirate.zone.stormwall": [
+      { "path": "assets/models/vehicles/pirate-ships/pirate-ship-2.glb", "fit": 7.2, "weight": 1.8 },
+      { "path": "assets/models/vehicles/pirate-ships/pirate-ship.glb", "fit": 7.0, "weight": 1.1 },
+      { "path": "assets/models/ships-palmov/small/pirate-ship-small.glb", "fit": 6.8, "weight": 0.4 }
     ],
     "pickup.ammo": [
       { "path": "assets/models/environment/boxes/box.glb", "fit": 1.0 },

--- a/game/data/assetRoleRegistry.json
+++ b/game/data/assetRoleRegistry.json
@@ -49,51 +49,63 @@
       ]
     ],
     "port.themes.merchant": [
-      [
-        { "path": "assets/models/environment/wooden-piers/wooden-pier-4.glb", "fit": 8.4, "x": 0, "y": 0, "z": 0, "ry": 0 },
-        { "path": "assets/models/houses/trading/trading-house.glb", "fit": 5.4, "x": 0.2, "y": 1.8, "z": -2.4, "ry": 0 },
-        { "path": "assets/models/environment/food-tents/food-tent-2.glb", "fit": 2.8, "x": -1.1, "y": 1.8, "z": 1.0, "ry": 0 },
-        { "path": "assets/models/environment/bags/bag-grain.glb", "fit": 1.0, "x": 0.7, "y": 1.8, "z": 1.1, "ry": 0.17 },
-        { "path": "assets/models/environment/boxes/box-3.glb", "fit": 1.0, "x": -0.6, "y": 1.8, "z": 0.8, "ry": 0.5 }
-      ],
-      [
-        { "path": "assets/models/environment/wooden-platforms/wooden-platform.glb", "fit": 8.4, "x": 0, "y": 0, "z": 0, "ry": 0 },
-        { "path": "assets/models/houses/trading/trading-house-2.glb", "fit": 5.6, "x": -0.3, "y": 1.8, "z": -2.5, "ry": 0 },
-        { "path": "assets/models/environment/tables/table-2.glb", "fit": 1.6, "x": 0.95, "y": 1.8, "z": 0.55, "ry": 0.22 },
-        { "path": "assets/models/environment/chairs/chair.glb", "fit": 1.1, "x": 0.35, "y": 1.8, "z": 0.95, "ry": -0.4 },
-        { "path": "assets/models/environment/barrels/barrel-stand.glb", "fit": 1.4, "x": -0.8, "y": 1.8, "z": 0.6, "ry": 0.2 }
-      ]
+      {
+        "weight": 1.2,
+        "modules": [
+          { "path": "assets/models/environment/wooden-piers/wooden-pier-4.glb", "fit": 8.4, "x": 0, "y": 0, "z": 0, "ry": 0 },
+          { "path": "assets/models/houses/trading/trading-house.glb", "fit": 5.4, "x": 0.2, "y": 1.8, "z": -2.4, "ry": 0 },
+          { "path": "assets/models/environment/food-tents/food-tent-2.glb", "fit": 2.8, "x": -1.1, "y": 1.8, "z": 1.0, "ry": 0 },
+          { "path": "assets/models/environment/bags/bag-grain.glb", "fit": 1.0, "x": 0.7, "y": 1.8, "z": 1.1, "ry": 0.17 },
+          { "path": "assets/models/environment/boxes/box-3.glb", "fit": 1.0, "x": -0.6, "y": 1.8, "z": 0.8, "ry": 0.5 }
+        ]
+      },
+      {
+        "weight": 1.0,
+        "modules": [
+          { "path": "assets/models/environment/wooden-platforms/wooden-platform.glb", "fit": 8.4, "x": 0, "y": 0, "z": 0, "ry": 0 },
+          { "path": "assets/models/houses/trading/trading-house-2.glb", "fit": 5.6, "x": -0.3, "y": 1.8, "z": -2.5, "ry": 0 },
+          { "path": "assets/models/environment/tables/table-2.glb", "fit": 1.6, "x": 0.95, "y": 1.8, "z": 0.55, "ry": 0.22 },
+          { "path": "assets/models/environment/chairs/chair.glb", "fit": 1.1, "x": 0.35, "y": 1.8, "z": 0.95, "ry": -0.4 },
+          { "path": "assets/models/environment/barrels/barrel-stand.glb", "fit": 1.4, "x": -0.8, "y": 1.8, "z": 0.6, "ry": 0.2 }
+        ]
+      }
     ],
     "port.themes.pirate": [
-      [
-        { "path": "assets/models/environment/destroyed-wooden-pier.glb", "fit": 8.3, "x": 0, "y": 0, "z": 0, "ry": 0 },
-        { "path": "assets/models/houses/pirate/pirate-house.glb", "fit": 5.8, "x": -0.1, "y": 1.8, "z": -2.3, "ry": 0 },
-        { "path": "assets/models/environment/barrels/barrel-3.glb", "fit": 1.0, "x": 0.9, "y": 1.8, "z": 0.85, "ry": 0 },
-        { "path": "assets/models/environment/fences/untreated/untreated-fence.glb", "fit": 2.3, "x": 0.2, "y": 1.8, "z": 1.3, "ry": 0.08 },
-        { "path": "assets/models/environment/bags/bag-grain-2.glb", "fit": 1.0, "x": -0.7, "y": 1.8, "z": 0.8, "ry": -0.35 }
-      ],
-      [
-        { "path": "assets/models/environment/wooden-piers/wooden-pier-5.glb", "fit": 8.6, "x": 0, "y": 0, "z": 0, "ry": 0 },
-        { "path": "assets/models/houses/pirate/pirate-house-2.glb", "fit": 5.6, "x": 0, "y": 1.8, "z": -2.5, "ry": 0 },
-        { "path": "assets/models/environment/fences/stone/stone-fence-small.glb", "fit": 2.2, "x": 1.0, "y": 1.8, "z": 1.1, "ry": 0.24 },
-        { "path": "assets/models/environment/barrels/barrel.glb", "fit": 1.0, "x": -0.6, "y": 1.8, "z": 0.9, "ry": 0 },
-        { "path": "assets/models/environment/boxes/box-2.glb", "fit": 1.0, "x": 0.6, "y": 1.8, "z": 0.7, "ry": 0.35 }
-      ]
+      {
+        "weight": 1.15,
+        "modules": [
+          { "path": "assets/models/environment/destroyed-wooden-pier.glb", "fit": 8.3, "x": 0, "y": 0, "z": 0, "ry": 0 },
+          { "path": "assets/models/houses/pirate/pirate-house.glb", "fit": 5.8, "x": -0.1, "y": 1.8, "z": -2.3, "ry": 0 },
+          { "path": "assets/models/environment/barrels/barrel-3.glb", "fit": 1.0, "x": 0.9, "y": 1.8, "z": 0.85, "ry": 0 },
+          { "path": "assets/models/environment/fences/untreated/untreated-fence.glb", "fit": 2.3, "x": 0.2, "y": 1.8, "z": 1.3, "ry": 0.08 },
+          { "path": "assets/models/environment/bags/bag-grain-2.glb", "fit": 1.0, "x": -0.7, "y": 1.8, "z": 0.8, "ry": -0.35 }
+        ]
+      },
+      {
+        "weight": 1.0,
+        "modules": [
+          { "path": "assets/models/environment/wooden-piers/wooden-pier-5.glb", "fit": 8.6, "x": 0, "y": 0, "z": 0, "ry": 0 },
+          { "path": "assets/models/houses/pirate/pirate-house-2.glb", "fit": 5.6, "x": 0, "y": 1.8, "z": -2.5, "ry": 0 },
+          { "path": "assets/models/environment/fences/stone/stone-fence-small.glb", "fit": 2.2, "x": 1.0, "y": 1.8, "z": 1.1, "ry": 0.24 },
+          { "path": "assets/models/environment/barrels/barrel.glb", "fit": 1.0, "x": -0.6, "y": 1.8, "z": 0.9, "ry": 0 },
+          { "path": "assets/models/environment/boxes/box-2.glb", "fit": 1.0, "x": 0.6, "y": 1.8, "z": 0.7, "ry": 0.35 }
+        ]
+      }
     ],
     "ambient.merchant": [
-      { "path": "assets/models/vehicles/sailboats/sailboat.glb", "fit": 6.2 },
-      { "path": "assets/models/vehicles/sailboats/sailboat-2.glb", "fit": 6.2 },
-      { "path": "assets/models/ships-palmov/boats/chinese-boat.glb", "fit": 6.0 }
+      { "path": "assets/models/vehicles/sailboats/sailboat.glb", "fit": 6.2, "weight": 1.4 },
+      { "path": "assets/models/vehicles/sailboats/sailboat-2.glb", "fit": 6.2, "weight": 1.1 },
+      { "path": "assets/models/ships-palmov/boats/chinese-boat.glb", "fit": 6.0, "weight": 0.7 }
     ],
     "ambient.navy": [
-      { "path": "assets/models/ships-palmov/boats/boat-1.glb", "fit": 6.0 },
-      { "path": "assets/models/ships-palmov/boats/boat-3.glb", "fit": 6.0 },
-      { "path": "assets/models/ships-palmov/small/ship-small-5.glb", "fit": 6.5 }
+      { "path": "assets/models/ships-palmov/boats/boat-1.glb", "fit": 6.0, "weight": 1.2 },
+      { "path": "assets/models/ships-palmov/boats/boat-3.glb", "fit": 6.0, "weight": 1.0 },
+      { "path": "assets/models/ships-palmov/small/ship-small-5.glb", "fit": 6.5, "weight": 0.8 }
     ],
     "ambient.pirate": [
-      { "path": "assets/models/ships-palmov/small/pirate-ship-small.glb", "fit": 6.6 },
-      { "path": "assets/models/vehicles/pirate-ships/pirate-ship.glb", "fit": 6.8 },
-      { "path": "assets/models/vehicles/pirate-ships/pirate-ship-2.glb", "fit": 6.8 }
+      { "path": "assets/models/ships-palmov/small/pirate-ship-small.glb", "fit": 6.6, "weight": 1.2 },
+      { "path": "assets/models/vehicles/pirate-ships/pirate-ship.glb", "fit": 6.8, "weight": 1.0 },
+      { "path": "assets/models/vehicles/pirate-ships/pirate-ship-2.glb", "fit": 6.8, "weight": 0.9 }
     ],
     "pickup.ammo": [
       { "path": "assets/models/environment/boxes/box.glb", "fit": 1.0 },

--- a/game/index.html
+++ b/game/index.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, user-scalable=no, maximum-scale=1">
+  <meta name="viewport"
+    content="width=device-width, initial-scale=1.0, viewport-fit=cover, user-scalable=no, maximum-scale=1">
   <meta name="theme-color" content="#0a0e1a">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
@@ -11,11 +13,20 @@
   <link rel="manifest" href="manifest.json">
   <link rel="icon" href="icons/icon-192.png" type="image/png">
   <link rel="apple-touch-icon" href="icons/icon-192.png">
-  <base href="/ocean-outlaws/game/">
+  <base href="/game/">
   <style>
-    * { margin: 0; padding: 0; box-sizing: border-box; }
-    html, body {
-      width: 100%; height: 100%; overflow: hidden; background: #0a0e1a;
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    html,
+    body {
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+      background: #0a0e1a;
       /* Prevent text selection everywhere */
       -webkit-user-select: none;
       -moz-user-select: none;
@@ -31,13 +42,16 @@
       overscroll-behavior: none;
       touch-action: none;
     }
+
     canvas {
       display: block;
       /* Prevent canvas drag */
       -webkit-user-drag: none;
       touch-action: none;
     }
-    img, svg {
+
+    img,
+    svg {
       -webkit-user-drag: none;
       user-drag: none;
       pointer-events: none;
@@ -53,7 +67,9 @@
   }
   </script>
 </head>
+
 <body>
   <script type="module" src="js/main.js"></script>
 </body>
+
 </html>

--- a/game/js/assetRoles.js
+++ b/game/js/assetRoles.js
@@ -1,0 +1,36 @@
+// assetRoles.js — shared runtime registry for model role mappings
+
+var ASSET_ROLE_REGISTRY_PATH = "data/assetRoleRegistry.json";
+var _assetRoles = null;
+var _assetRolesPromise = null;
+
+function loadAssetRoles() {
+  if (_assetRolesPromise) return _assetRolesPromise;
+  _assetRolesPromise = fetch(ASSET_ROLE_REGISTRY_PATH)
+    .then(function (res) {
+      if (!res.ok) throw new Error("asset role registry fetch failed");
+      return res.json();
+    })
+    .then(function (data) {
+      _assetRoles = data && data.roles ? data.roles : null;
+      return _assetRoles;
+    })
+    .catch(function () {
+      _assetRoles = null;
+      return null;
+    });
+  return _assetRolesPromise;
+}
+
+// Eager load so early spawns can use role overrides
+loadAssetRoles();
+
+export function ensureAssetRoles() {
+  return loadAssetRoles();
+}
+
+export function getRoleVariants(roleKey) {
+  if (!_assetRoles || !roleKey) return null;
+  var v = _assetRoles[roleKey];
+  return Array.isArray(v) ? v : null;
+}

--- a/game/js/assetRoles.js
+++ b/game/js/assetRoles.js
@@ -34,3 +34,52 @@ export function getRoleVariants(roleKey) {
   var v = _assetRoles[roleKey];
   return Array.isArray(v) ? v : null;
 }
+
+function getWeight(entry) {
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) return 1;
+  var w = Number(entry.weight);
+  if (!isFinite(w) || w <= 0) return 1;
+  return w;
+}
+
+function unwrapEntry(entry) {
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) return entry;
+  if (entry.value !== undefined) return entry.value;
+  if (entry.variant !== undefined) return entry.variant;
+  if (Array.isArray(entry.modules)) return entry.modules;
+  return entry;
+}
+
+function pickFromPool(pool, rngFn) {
+  if (!pool || pool.length === 0) return null;
+  var random = typeof rngFn === "function" ? rngFn : Math.random;
+
+  var totalWeight = 0;
+  var hasCustomWeight = false;
+  for (var i = 0; i < pool.length; i++) {
+    var w = getWeight(pool[i]);
+    totalWeight += w;
+    if (w !== 1) hasCustomWeight = true;
+  }
+  if (totalWeight <= 0) return null;
+
+  if (!hasCustomWeight) {
+    var idx = Math.floor(random() * pool.length);
+    if (idx < 0 || idx >= pool.length) idx = 0;
+    return unwrapEntry(pool[idx]);
+  }
+
+  var roll = random() * totalWeight;
+  for (var j = 0; j < pool.length; j++) {
+    roll -= getWeight(pool[j]);
+    if (roll <= 0) return unwrapEntry(pool[j]);
+  }
+  return unwrapEntry(pool[pool.length - 1]);
+}
+
+export function pickRoleVariant(roleKey, fallbackPool, rngFn) {
+  var rolePool = getRoleVariants(roleKey);
+  var pool = rolePool && rolePool.length ? rolePool : fallbackPool;
+  if (!Array.isArray(pool)) return null;
+  return pickFromPool(pool, rngFn);
+}

--- a/game/js/boss.js
+++ b/game/js/boss.js
@@ -90,7 +90,7 @@ function applyBossOverrideAsync(mesh, bossType, boss) {
   var fit = getOverrideSize(slot) || (bossType === "carrier" ? 18 : 16);
   var firePoints = mesh.userData.turrets || [];
   var tentacles = mesh.userData.tentacles || [];
-  loadGlbVisual(path, fit, true).then(function (visual) {
+  loadGlbVisual(path, fit, true, { noDecimate: true }).then(function (visual) {
     while (mesh.children.length) mesh.remove(mesh.children[0]);
     mesh.add(visual);
     // re-attach fire points so they move with the boss

--- a/game/js/boss.js
+++ b/game/js/boss.js
@@ -82,7 +82,7 @@ function bossSlotForType(type) {
   return null;
 }
 
-function applyBossOverrideAsync(mesh, bossType) {
+function applyBossOverrideAsync(mesh, bossType, boss) {
   var slot = bossSlotForType(bossType);
   if (!slot) return;
   var path = getOverridePath(slot);
@@ -102,6 +102,7 @@ function applyBossOverrideAsync(mesh, bossType) {
     for (var i = 0; i < tentacles.length; i++) {
       mesh.add(tentacles[i]);
     }
+    updateBossHitbox(boss, visual);
   }).catch(function () {
     console.error("Failed to load boss model: " + path);
     while (mesh.children.length) mesh.remove(mesh.children[0]);
@@ -116,7 +117,21 @@ function applyBossOverrideAsync(mesh, bossType) {
     for (var j = 0; j < tentacles.length; j++) {
       mesh.add(tentacles[j]);
     }
+    updateBossHitbox(boss, mesh);
   });
+}
+
+
+function updateBossHitbox(boss, sourceObj) {
+  if (!boss || !sourceObj) return;
+  sourceObj.updateMatrixWorld(true);
+  var box = new THREE.Box3().setFromObject(sourceObj);
+  if (!isFinite(box.min.x) || !isFinite(box.max.x)) return;
+  var size = new THREE.Vector3();
+  box.getSize(size);
+  boss.hitHalfL = Math.max(2.4, size.z * 0.5 * 0.85);
+  boss.hitHalfW = Math.max(1.6, size.x * 0.5 * 0.8);
+  boss.hitRadius = Math.max(boss.hitRadius || 4.0, Math.sqrt(boss.hitHalfL * boss.hitHalfL + boss.hitHalfW * boss.hitHalfW));
 }
 
 // --- get boss definition ---
@@ -131,7 +146,6 @@ export function createBoss(bossType, playerX, playerZ, scene, zoneDifficulty) {
   if (!def) return null;
 
   var mesh = buildBossMesh(bossType);
-  applyBossOverrideAsync(mesh, bossType);
   var spawnDist = 80;
   var angle = nextRandom() * Math.PI * 2;
   var x = playerX + Math.sin(angle) * spawnDist;
@@ -142,7 +156,7 @@ export function createBoss(bossType, playerX, playerZ, scene, zoneDifficulty) {
   var hpScale = 1 + (zoneDifficulty - 1) * 0.2;
   var damageMult = 1 + (zoneDifficulty - 1) * 0.15;
 
-  return {
+  var boss = {
     type: bossType,
     def: def,
     mesh: mesh,
@@ -171,6 +185,10 @@ export function createBoss(bossType, playerX, playerZ, scene, zoneDifficulty) {
     _buoyancyInit: false,
     _stuckDetector: createStuckDetector()
   };
+
+  updateBossHitbox(boss, mesh);
+  applyBossOverrideAsync(mesh, bossType, boss);
+  return boss;
 }
 
 // --- get current phase index ---

--- a/game/js/enemy.js
+++ b/game/js/enemy.js
@@ -4,7 +4,7 @@ import { isLand, collideWithTerrain, terrainBlocksLine, getTerrainAvoidance } fr
 import { slideCollision, createStuckDetector, updateStuck, isStuck, nudgeToOpenWater } from "./collision.js";
 import { getOverridePath, getOverrideSize } from "./artOverrides.js";
 import { loadGlbVisual } from "./glbVisual.js";
-import { ensureAssetRoles, getRoleVariants } from "./assetRoles.js";
+import { ensureAssetRoles, pickRoleVariant } from "./assetRoles.js";
 import { nextRandom } from "./rng.js";
 
 // --- faction definitions ---
@@ -147,12 +147,7 @@ function getEnemyOverrideSpec(enemy) {
 
 function pickAmbientModelVariant(faction) {
   var key = faction || "merchant";
-  var rolePool = getRoleVariants("ambient." + key);
-  var pool = rolePool && rolePool.length ? rolePool : AMBIENT_MODEL_POOLS[key];
-  if (!pool || pool.length === 0) return null;
-  var idx = Math.floor(nextRandom() * pool.length);
-  if (idx < 0 || idx >= pool.length) idx = 0;
-  return pool[idx];
+  return pickRoleVariant("ambient." + key, AMBIENT_MODEL_POOLS[key], nextRandom);
 }
 
 function applyEnemyOverrideAsync(mesh, enemy) {

--- a/game/js/enemy.js
+++ b/game/js/enemy.js
@@ -47,6 +47,24 @@ var AMBIENT_MODEL_POOLS = {
   ]
 };
 
+var ENEMY_MODEL_POOLS = {
+  merchant: [
+    { path: "assets/models/vehicles/sailboats/sailboat.glb", fit: 6.5 },
+    { path: "assets/models/vehicles/sailboats/sailboat-2.glb", fit: 6.5 },
+    { path: "assets/models/ships-palmov/boats/chinese-boat.glb", fit: 6.3 }
+  ],
+  navy: [
+    { path: "assets/models/ships-palmov/small/ship-small-5.glb", fit: 6.8 },
+    { path: "assets/models/ships-palmov/boats/boat-3.glb", fit: 6.3 },
+    { path: "assets/models/ships-palmov/boats/boat-1.glb", fit: 6.3 }
+  ],
+  pirate: [
+    { path: "assets/models/vehicles/pirate-ships/pirate-ship.glb", fit: 7.0 },
+    { path: "assets/models/vehicles/pirate-ships/pirate-ship-2.glb", fit: 7.0 },
+    { path: "assets/models/ships-palmov/small/pirate-ship-small.glb", fit: 6.8 }
+  ]
+};
+
 export function getFactions() { return FACTIONS; }
 export function getFactionAnnounce(faction) {
   var f = FACTIONS[faction];
@@ -148,6 +166,11 @@ function getEnemyOverrideSpec(enemy) {
 function pickAmbientModelVariant(faction) {
   var key = faction || "merchant";
   return pickRoleVariant("ambient." + key, AMBIENT_MODEL_POOLS[key], nextRandom);
+}
+
+function pickCombatModelVariant(faction) {
+  var key = faction || "pirate";
+  return pickRoleVariant("enemy." + key, ENEMY_MODEL_POOLS[key], nextRandom);
 }
 
 function applyEnemyOverrideAsync(mesh, enemy) {
@@ -328,7 +351,8 @@ function spawnEnemy(manager, playerX, playerZ, scene, waveConfig, terrain) {
     _smoothPitch: 0,
     _smoothRoll: 0,
     _buoyancyInit: false,
-    _stuckDetector: createStuckDetector()
+    _stuckDetector: createStuckDetector(),
+    visualOverride: pickCombatModelVariant(faction)
   };
 
   updateEnemyHitbox(enemy, mesh);

--- a/game/js/glbVisual.js
+++ b/game/js/glbVisual.js
@@ -104,12 +104,13 @@ function loadTemplate(path) {
   return cache[path];
 }
 
-export async function loadGlbVisual(path, fitSize, flatShaded) {
+export async function loadGlbVisual(path, fitSize, flatShaded, options) {
   var tpl = await loadTemplate(path);
   var visual = tpl.clone(true);
   fitToSize(visual, fitSize || 10);
   if (flatShaded !== false) applyFlat(visual);
+  var opts = options || {};
   var qCfg = getQualityConfig();
-  if (qCfg.maxTriangles > 0) enforceTriBudget(visual, qCfg.maxTriangles);
+  if (!opts.noDecimate && qCfg.maxTriangles > 0) enforceTriBudget(visual, qCfg.maxTriangles);
   return visual;
 }

--- a/game/js/main.js
+++ b/game/js/main.js
@@ -745,8 +745,9 @@ function startMultiplayerCombat() {
   seedRNG(seed);
   activeTerrain = createTerrain(seed, 2);
   scene.add(activeTerrain.mesh);
+  var mpPortRoleContext = { zoneId: "multiplayer", condition: "calm", difficulty: 2 };
   clearPorts(portMgr, scene);
-  initPorts(portMgr, activeTerrain, scene);
+  initPorts(portMgr, activeTerrain, scene, mpPortRoleContext);
   clearCrates(crateMgr, scene);
   clearMerchants(merchantMgr, scene);
   if (ship && ship.mesh) scene.remove(ship.mesh);
@@ -961,10 +962,18 @@ function startNodeCombat(node, runSeed) {
   var terrainSeed = runSeed + node.id * 1000 + 7;
   seedRNG(terrainSeed);
   var terrainDiff = 1 + Math.floor(node.col * 5 / Math.max(1, activeChart.columns - 1));
+  var weatherPreset = "calm";
+  if (node.type === "storm_crossing") weatherPreset = "storm";
+  else if (node.col >= 5) weatherPreset = "rough";
+  var nodePortRoleContext = {
+    zoneId: "run_node_" + node.id,
+    condition: weatherPreset === "storm" ? "stormy" : weatherPreset,
+    difficulty: Math.min(terrainDiff, 6)
+  };
   activeTerrain = createTerrain(terrainSeed, Math.min(terrainDiff, 6));
   scene.add(activeTerrain.mesh);
   clearPorts(portMgr, scene);
-  initPorts(portMgr, activeTerrain, scene);
+  initPorts(portMgr, activeTerrain, scene, nodePortRoleContext);
   clearCrates(crateMgr, scene);
   clearMerchants(merchantMgr, scene);
   if (ship && ship.mesh) scene.remove(ship.mesh);
@@ -984,9 +993,6 @@ function startNodeCombat(node, runSeed) {
   abilityState = createAbilityState(selectedClass);
   initNav(cam.camera, ship, scene, enemyMgr, activeTerrain);
   resetDrones(droneMgr, scene);
-  var weatherPreset = "calm";
-  if (node.type === "storm_crossing") weatherPreset = "storm";
-  else if (node.col >= 5) weatherPreset = "rough";
   setWeather(weather, weatherPreset);
   setEngineClass(selectedClass);
   gameFrozen = false;
@@ -1088,8 +1094,13 @@ function startZoneCombat(classKey, zoneId) {
   seedRNG(terrainSeed);
   activeTerrain = createTerrain(terrainSeed, zone.difficulty);
   scene.add(activeTerrain.mesh);
+  var zonePortRoleContext = {
+    zoneId: zoneId,
+    condition: zone.condition || "calm",
+    difficulty: zone.difficulty
+  };
   clearPorts(portMgr, scene);
-  initPorts(portMgr, activeTerrain, scene);
+  initPorts(portMgr, activeTerrain, scene, zonePortRoleContext);
   clearCrates(crateMgr, scene);
   clearMerchants(merchantMgr, scene);
   if (ship && ship.mesh) scene.remove(ship.mesh);

--- a/game/js/main.js
+++ b/game/js/main.js
@@ -1405,12 +1405,18 @@ function animate() {
       }
     }
 
-    updateEnemies(enemyMgr, ship, dt, scene, weatherWaveHeight, elapsed, waveMgr, getWaveConfig(waveMgr), activeTerrain);
+    var activeZone = activeZoneId ? getZone(activeZoneId) : null;
+    var roleContext = activeZone ? {
+      zoneId: activeZoneId,
+      condition: activeZone.condition,
+      difficulty: activeZone.difficulty
+    } : null;
+    updateEnemies(enemyMgr, ship, dt, scene, weatherWaveHeight, elapsed, waveMgr, getWaveConfig(waveMgr), activeTerrain, roleContext);
     updatePickups(pickupMgr, ship, resources, dt, elapsed, weatherWaveHeight, scene, upgrades);
     updateCrewPickups(crewPickupMgr, ship, dt, elapsed, weatherWaveHeight, scene);
     updatePorts(portMgr, ship, resources, enemyMgr, dt, upgrades, selectedClass, activeTerrain);
     updateCrates(crateMgr, ship, resources, activeTerrain, dt, elapsed, weatherWaveHeight, scene, upgrades);
-    updateMerchants(merchantMgr, ship, dt, scene, activeTerrain, elapsed, weatherWaveHeight, enemyMgr, activeZoneId ? getZone(activeZoneId) : null);
+    updateMerchants(merchantMgr, ship, dt, scene, activeTerrain, elapsed, weatherWaveHeight, enemyMgr, activeZone, activeZoneId);
     if (mults.autoRepair) {
       var arHp = getPlayerHp(enemyMgr);
       if (arHp.hp < arHp.maxHp) setPlayerHp(enemyMgr, Math.min(arHp.maxHp, arHp.hp + dt));

--- a/game/js/main.js
+++ b/game/js/main.js
@@ -1408,7 +1408,7 @@ function animate() {
     updateEnemies(enemyMgr, ship, dt, scene, weatherWaveHeight, elapsed, waveMgr, getWaveConfig(waveMgr), activeTerrain);
     updatePickups(pickupMgr, ship, resources, dt, elapsed, weatherWaveHeight, scene, upgrades);
     updateCrewPickups(crewPickupMgr, ship, dt, elapsed, weatherWaveHeight, scene);
-    updatePorts(portMgr, ship, resources, enemyMgr, dt, upgrades, selectedClass);
+    updatePorts(portMgr, ship, resources, enemyMgr, dt, upgrades, selectedClass, activeTerrain);
     updateCrates(crateMgr, ship, resources, activeTerrain, dt, elapsed, weatherWaveHeight, scene, upgrades);
     updateMerchants(merchantMgr, ship, dt, scene, activeTerrain, elapsed, weatherWaveHeight, enemyMgr, activeZoneId ? getZone(activeZoneId) : null);
     if (mults.autoRepair) {
@@ -1620,7 +1620,10 @@ function animate() {
     if (portMgr.ports) {
       for (var mpi = 0; mpi < portMgr.ports.length; mpi++) {
         var mp = portMgr.ports[mpi];
-        portPositions.push({ x: mp.posX, z: mp.posZ });
+        portPositions.push({
+          x: mp.dockX !== undefined ? mp.dockX : mp.posX,
+          z: mp.dockZ !== undefined ? mp.dockZ : mp.posZ
+        });
       }
     }
     var pickupList = pickupMgr.pickups || [];

--- a/game/js/merchant.js
+++ b/game/js/merchant.js
@@ -70,7 +70,7 @@ export function getMerchantCount(mgr) {
 }
 
 // --- spawn a merchant group (solo or convoy) ---
-function spawnMerchantGroup(mgr, scene, terrain, enemyMgr) {
+function spawnMerchantGroup(mgr, scene, terrain, enemyMgr, roleContext) {
   if (mgr.merchants.length >= MAX_MERCHANTS) return;
 
   // pick trade route: start on one edge, destination on opposite edge
@@ -108,7 +108,8 @@ function spawnMerchantGroup(mgr, scene, terrain, enemyMgr) {
       "merchant",
       merchantSpeed,
       scene,
-      { startX: route.startX, startZ: route.startZ, endX: route.endX, endZ: route.endZ }
+      { startX: route.startX, startZ: route.startZ, endX: route.endX, endZ: route.endZ },
+      roleContext
     );
     if (enemy) {
       enemy.fleeSpeed = fleeSpeed;
@@ -131,7 +132,8 @@ function spawnMerchantGroup(mgr, scene, terrain, enemyMgr) {
       ESCORT_FACTION,
       escortSpeed,
       scene,
-      { startX: route.startX, startZ: route.startZ, endX: route.endX, endZ: route.endZ }
+      { startX: route.startX, startZ: route.startZ, endX: route.endX, endZ: route.endZ },
+      roleContext
     );
     if (escort) {
       escort.fleeSpeed = escortSpeed;
@@ -155,14 +157,19 @@ export function clearMerchants(mgr, scene) {
 }
 
 // --- update: tick spawn timer, track lifetime, despawn off-map ---
-export function updateMerchants(mgr, ship, dt, scene, terrain, elapsed, getWaveHeight, enemyMgr, zone) {
+export function updateMerchants(mgr, ship, dt, scene, terrain, elapsed, getWaveHeight, enemyMgr, zone, zoneId) {
   // scale spawn interval by zone difficulty
   var difficulty = (zone && zone.difficulty) ? zone.difficulty : 1;
   var interval = Math.max(SPAWN_INTERVAL_MIN, SPAWN_INTERVAL_BASE - difficulty * 2);
+  var roleContext = zone ? {
+    zoneId: zoneId || zone.id || null,
+    condition: zone.condition || null,
+    difficulty: zone.difficulty || null
+  } : null;
 
   mgr.spawnTimer -= dt;
   if (mgr.spawnTimer <= 0) {
-    spawnMerchantGroup(mgr, scene, terrain, enemyMgr);
+    spawnMerchantGroup(mgr, scene, terrain, enemyMgr, roleContext);
     mgr.spawnTimer = interval;
   }
 

--- a/game/js/pickup.js
+++ b/game/js/pickup.js
@@ -4,7 +4,7 @@ import { addAmmo, addFuel, addParts } from "./resource.js";
 import { addGold } from "./upgrade.js";
 import { nextRandom } from "./rng.js";
 import { loadGlbVisual } from "./glbVisual.js";
-import { ensureAssetRoles, getRoleVariants } from "./assetRoles.js";
+import { ensureAssetRoles, pickRoleVariant } from "./assetRoles.js";
 
 // --- tuning ---
 var PICKUP_FLOAT_OFFSET = 0.8;
@@ -77,12 +77,7 @@ var GLOW_COLORS = {
 };
 
 function pickPickupModel(type) {
-  var rolePool = getRoleVariants("pickup." + type);
-  var pool = rolePool && rolePool.length ? rolePool : PICKUP_MODEL_POOLS[type];
-  if (!pool || pool.length === 0) return null;
-  var idx = Math.floor(nextRandom() * pool.length);
-  if (idx < 0 || idx >= pool.length) idx = 0;
-  return pool[idx];
+  return pickRoleVariant("pickup." + type, PICKUP_MODEL_POOLS[type], nextRandom);
 }
 
 // --- build pickup mesh ---

--- a/game/js/pickup.js
+++ b/game/js/pickup.js
@@ -3,6 +3,8 @@ import * as THREE from "three";
 import { addAmmo, addFuel, addParts } from "./resource.js";
 import { addGold } from "./upgrade.js";
 import { nextRandom } from "./rng.js";
+import { loadGlbVisual } from "./glbVisual.js";
+import { ensureAssetRoles, getRoleVariants } from "./assetRoles.js";
 
 // --- tuning ---
 var PICKUP_FLOAT_OFFSET = 0.8;
@@ -36,6 +38,29 @@ function ensureGeo() {
   barrelGeo = new THREE.CylinderGeometry(0.25, 0.3, 0.7, 8);
 }
 
+var PICKUP_MODEL_POOLS = {
+  ammo: [
+    { path: "assets/models/environment/boxes/box.glb", fit: 1.0 },
+    { path: "assets/models/environment/boxes/box-2.glb", fit: 1.0 },
+    { path: "assets/models/environment/boxes/box-3.glb", fit: 1.0 }
+  ],
+  fuel: [
+    { path: "assets/models/environment/barrels/barrel.glb", fit: 1.0 },
+    { path: "assets/models/environment/barrels/barrel-2.glb", fit: 1.0 },
+    { path: "assets/models/environment/bottles/bottle-2.glb", fit: 0.95 }
+  ],
+  parts: [
+    { path: "assets/models/environment/boards/board.glb", fit: 1.0 },
+    { path: "assets/models/environment/boards/board-2.glb", fit: 1.0 },
+    { path: "assets/models/environment/wooden-posts/wooden-post.glb", fit: 1.0 }
+  ],
+  gold: [
+    { path: "assets/models/environment/basket.glb", fit: 1.0 },
+    { path: "assets/models/environment/bags/bag-grain.glb", fit: 1.0 },
+    { path: "assets/models/environment/mug.glb", fit: 1.0 }
+  ]
+};
+
 // --- color by type ---
 var TYPE_COLORS = {
   ammo: 0xffaa22,
@@ -51,6 +76,15 @@ var GLOW_COLORS = {
   gold: 0xffee88
 };
 
+function pickPickupModel(type) {
+  var rolePool = getRoleVariants("pickup." + type);
+  var pool = rolePool && rolePool.length ? rolePool : PICKUP_MODEL_POOLS[type];
+  if (!pool || pool.length === 0) return null;
+  var idx = Math.floor(nextRandom() * pool.length);
+  if (idx < 0 || idx >= pool.length) idx = 0;
+  return pool[idx];
+}
+
 // --- build pickup mesh ---
 function buildPickupMesh(type) {
   ensureGeo();
@@ -65,6 +99,7 @@ function buildPickupMesh(type) {
   } else {
     mesh = new THREE.Mesh(crateGeo, mat);
   }
+  mesh.userData.pickupFallback = true;
   group.add(mesh);
 
   // glow point light
@@ -77,8 +112,28 @@ function buildPickupMesh(type) {
   return group;
 }
 
+function hydratePickupMesh(pickup) {
+  var model = pickPickupModel(pickup.type);
+  if (!model) return;
+  loadGlbVisual(model.path, model.fit, true)
+    .then(function (obj) {
+      if (pickup.collected || !pickup.mesh || !pickup.mesh.parent) return;
+      pickup.mesh.traverse(function (child) {
+        if (child.isMesh && child.userData && child.userData.pickupFallback) {
+          child.visible = false;
+        }
+      });
+      obj.position.y = 0.1;
+      pickup.mesh.add(obj);
+    })
+    .catch(function () {
+      // keep fallback mesh
+    });
+}
+
 // --- pickup manager ---
 export function createPickupManager() {
+  ensureAssetRoles();
   return {
     pickups: [],
     onCollectCallback: null  // called with (index) for multiplayer sync
@@ -107,14 +162,17 @@ export function spawnPickup(manager, x, y, z, scene) {
   mesh.position.set(x, y + PICKUP_FLOAT_OFFSET, z);
   scene.add(mesh);
 
-  manager.pickups.push({
+  var pickup = {
     mesh: mesh,
     type: type,
     posX: x,
     posZ: z,
     age: 0,
     collected: false
-  });
+  };
+  manager.pickups.push(pickup);
+
+  hydratePickupMesh(pickup);
 }
 
 // --- clear all pickups (called on wave transition) ---

--- a/game/js/port.js
+++ b/game/js/port.js
@@ -2,18 +2,23 @@
 import * as THREE from "three";
 import { addAmmo, addFuel } from "./resource.js";
 import { getRepairCost } from "./upgrade.js";
-import { sampleHeightmap, isHeightmapLand } from "./terrain.js";
+import { sampleHeightmap, isHeightmapLand, isLand } from "./terrain.js";
 import { nextRandom } from "./rng.js";
 import { loadGlbVisual } from "./glbVisual.js";
 import { ensureAssetRoles, getRoleVariants } from "./assetRoles.js";
 
 // --- tuning ---
 var PORT_COUNT = 3;              // ports per map
-var PORT_COLLECT_RADIUS = 8;     // proximity to trigger resupply
+var PORT_COLLECT_RADIUS = 10;    // proximity to trigger resupply
 var PORT_COOLDOWN = 45;          // seconds before port can be used again
 var PORT_AMMO_RESTOCK = 30;
 var PORT_FUEL_RESTOCK = 40;
 var PORT_HP_RESTOCK = 15;        // flat HP restored
+var PORT_WATER_NUDGE = 4;        // move port root slightly toward open water
+var PORT_DOCK_OFFSET = 8;        // interaction anchor placed on water side of port
+var PORT_DOCK_MAX_OFFSET = 22;   // allow farther dock fallback on complex coasts
+var PORT_DOCK_CLEAR_RADIUS = 2.2;
+var PORT_DOCK_REFRESH = 0.75;    // refresh dock anchor against visual colliders
 
 // coastline search: find cells near sea level
 var COAST_SEARCH_ATTEMPTS = 200;
@@ -22,6 +27,7 @@ var COAST_HEIGHT_MAX = 0.15;     // just above sea level (beach)
 var MAP_HALF = 200;              // half of MAP_SIZE (400)
 var MIN_PORT_SPACING = 60;       // minimum distance between ports
 var MIN_CENTER_DIST = 40;        // keep ports away from spawn
+var PORT_THEME_ORDER = ["neutral", "merchant", "pirate"];
 
 var PORT_THEME_VARIANTS = [
   [
@@ -46,6 +52,42 @@ var PORT_THEME_VARIANTS = [
     { path: "assets/models/environment/bottles/bottle-2.glb", fit: 0.7, x: 0.2, y: 2.0, z: 0.4, ry: 0 }
   ]
 ];
+
+var PORT_THEME_VARIANTS_BY_FACTION = {
+  neutral: PORT_THEME_VARIANTS,
+  merchant: [
+    [
+      { path: "assets/models/environment/wooden-piers/wooden-pier-4.glb", fit: 8.4, x: 0, y: 0, z: 0, ry: 0 },
+      { path: "assets/models/houses/trading/trading-house.glb", fit: 5.4, x: 0.2, y: 1.8, z: -2.4, ry: 0 },
+      { path: "assets/models/environment/food-tents/food-tent-2.glb", fit: 2.8, x: -1.1, y: 1.8, z: 1.0, ry: 0 },
+      { path: "assets/models/environment/bags/bag-grain.glb", fit: 1.0, x: 0.7, y: 1.8, z: 1.1, ry: 0.17 },
+      { path: "assets/models/environment/boxes/box-3.glb", fit: 1.0, x: -0.6, y: 1.8, z: 0.8, ry: 0.5 }
+    ],
+    [
+      { path: "assets/models/environment/wooden-platforms/wooden-platform.glb", fit: 8.4, x: 0, y: 0, z: 0, ry: 0 },
+      { path: "assets/models/houses/trading/trading-house-2.glb", fit: 5.6, x: -0.3, y: 1.8, z: -2.5, ry: 0 },
+      { path: "assets/models/environment/tables/table-2.glb", fit: 1.6, x: 0.95, y: 1.8, z: 0.55, ry: 0.22 },
+      { path: "assets/models/environment/chairs/chair.glb", fit: 1.1, x: 0.35, y: 1.8, z: 0.95, ry: -0.4 },
+      { path: "assets/models/environment/barrels/barrel-stand.glb", fit: 1.4, x: -0.8, y: 1.8, z: 0.6, ry: 0.2 }
+    ]
+  ],
+  pirate: [
+    [
+      { path: "assets/models/environment/destroyed-wooden-pier.glb", fit: 8.3, x: 0, y: 0, z: 0, ry: 0 },
+      { path: "assets/models/houses/pirate/pirate-house.glb", fit: 5.8, x: -0.1, y: 1.8, z: -2.3, ry: 0 },
+      { path: "assets/models/environment/barrels/barrel-3.glb", fit: 1.0, x: 0.9, y: 1.8, z: 0.85, ry: 0 },
+      { path: "assets/models/environment/fences/untreated/untreated-fence.glb", fit: 2.3, x: 0.2, y: 1.8, z: 1.3, ry: 0.08 },
+      { path: "assets/models/environment/bags/bag-grain-2.glb", fit: 1.0, x: -0.7, y: 1.8, z: 0.8, ry: -0.35 }
+    ],
+    [
+      { path: "assets/models/environment/wooden-piers/wooden-pier-5.glb", fit: 8.6, x: 0, y: 0, z: 0, ry: 0 },
+      { path: "assets/models/houses/pirate/pirate-house-2.glb", fit: 5.6, x: 0, y: 1.8, z: -2.5, ry: 0 },
+      { path: "assets/models/environment/fences/stone/stone-fence-small.glb", fit: 2.2, x: 1.0, y: 1.8, z: 1.1, ry: 0.24 },
+      { path: "assets/models/environment/barrels/barrel.glb", fit: 1.0, x: -0.6, y: 1.8, z: 0.9, ry: 0 },
+      { path: "assets/models/environment/boxes/box-2.glb", fit: 1.0, x: 0.6, y: 1.8, z: 0.7, ry: 0.35 }
+    ]
+  ]
+};
 
 // --- find coastline positions ---
 function findCoastlinePositions(terrain) {
@@ -112,17 +154,78 @@ function findCoastlinePositions(terrain) {
         bestWaterAngle = angle;
       }
     }
-    // nudge 3 units toward the deepest water neighbor
-    x += Math.cos(bestWaterAngle) * 3;
-    z += Math.sin(bestWaterAngle) * 3;
+    // nudge toward deepest water neighbor to reduce shoreline collision frustration
+    x += Math.cos(bestWaterAngle) * PORT_WATER_NUDGE;
+    z += Math.sin(bestWaterAngle) * PORT_WATER_NUDGE;
 
-    positions.push({ x: x, z: z });
+    var dock = findDockCandidate(
+      x, z, bestWaterAngle,
+      Math.max(1, PORT_DOCK_OFFSET * 0.4),
+      PORT_DOCK_MAX_OFFSET,
+      1.5,
+      function (dx, dz) {
+        return hasWaterClearance(terrain, dx, dz, isHeightmapLand);
+      }
+    );
+    var foundDock = !!dock;
+    if (!foundDock) continue;
+
+    positions.push({ x: x, z: z, waterAngle: bestWaterAngle, dockX: dock.x, dockZ: dock.z });
   }
   return positions;
 }
 
+function normalizeThemeKey(value) {
+  if (typeof value !== "string") return null;
+  var key = value.trim().toLowerCase();
+  return key || null;
+}
+
+function getPortThemeKeys() {
+  var roleKeys = getRoleVariants("port.factions");
+  if (!roleKeys || !roleKeys.length) return PORT_THEME_ORDER;
+
+  var keys = [];
+  for (var i = 0; i < roleKeys.length; i++) {
+    var key = normalizeThemeKey(roleKeys[i]);
+    if (!key) continue;
+    if (keys.indexOf(key) >= 0) continue;
+    keys.push(key);
+  }
+  return keys.length ? keys : PORT_THEME_ORDER;
+}
+
+function getFallbackThemes(themeKey) {
+  var themed = themeKey ? PORT_THEME_VARIANTS_BY_FACTION[themeKey] : null;
+  return themed && themed.length ? themed : PORT_THEME_VARIANTS;
+}
+
+function hasWaterClearance(terrain, x, z, landTest) {
+  if (landTest(terrain, x, z)) return false;
+  for (var a = 0; a < 8; a++) {
+    var angle = a * Math.PI / 4;
+    var cx = x + Math.cos(angle) * PORT_DOCK_CLEAR_RADIUS;
+    var cz = z + Math.sin(angle) * PORT_DOCK_CLEAR_RADIUS;
+    if (landTest(terrain, cx, cz)) return false;
+  }
+  return true;
+}
+
+function findDockCandidate(baseX, baseZ, baseAngle, minDist, maxDist, step, isWaterTest) {
+  var angleOffsets = [0, 0.35, -0.35, 0.7, -0.7, 1.05, -1.05];
+  for (var dist = minDist; dist <= maxDist; dist += step) {
+    for (var i = 0; i < angleOffsets.length; i++) {
+      var angle = baseAngle + angleOffsets[i];
+      var x = baseX + Math.cos(angle) * dist;
+      var z = baseZ + Math.sin(angle) * dist;
+      if (isWaterTest(x, z)) return { x: x, z: z };
+    }
+  }
+  return null;
+}
+
 // --- build dock mesh ---
-function buildPortMesh() {
+function buildPortMesh(themeKey) {
   var group = new THREE.Group();
 
   // pier platform
@@ -182,30 +285,38 @@ function buildPortMesh() {
   group.userData.light = light;
   group.userData.lamp = lamp;
   group.userData.lampMat = lampMat;
+  group.userData.themeKey = themeKey || "neutral";
 
   // async GLB dock dressing; keep primitive base as resilient fallback
-  hydratePortVisual(group);
+  hydratePortVisual(group, themeKey);
 
   return group;
 }
 
-function pickPortTheme() {
+function pickPortTheme(themeKey) {
+  var normalizedKey = normalizeThemeKey(themeKey);
+  var themedRole = normalizedKey ? getRoleVariants("port.themes." + normalizedKey) : null;
   var roleThemes = getRoleVariants("port.themes");
-  var themes = roleThemes && roleThemes.length ? roleThemes : PORT_THEME_VARIANTS;
+  var themes = themedRole && themedRole.length
+    ? themedRole
+    : roleThemes && roleThemes.length
+      ? roleThemes
+      : getFallbackThemes(normalizedKey);
   var idx = Math.floor(nextRandom() * themes.length);
   if (idx < 0 || idx >= themes.length) idx = 0;
   return themes[idx];
 }
 
-function hydratePortVisual(group) {
-  var modules = pickPortTheme();
+function hydratePortVisual(group, themeKey) {
+  var modules = pickPortTheme(themeKey);
   var visualRoot = new THREE.Group();
   group.add(visualRoot);
 
   var fallbackHidden = false;
   for (var i = 0; i < modules.length; i++) {
     (function (mod) {
-      loadGlbVisual(mod.path, mod.fit, true)
+      // Keep full mesh topology for port kits; budget decimation can punch visible holes.
+      loadGlbVisual(mod.path, mod.fit, true, { noDecimate: true })
         .then(function (obj) {
           if (!fallbackHidden) {
             fallbackHidden = true;
@@ -239,9 +350,12 @@ export function createPortManager() {
 export function initPorts(manager, terrain, scene) {
   clearPorts(manager, scene);
   var positions = findCoastlinePositions(terrain);
+  var themeKeys = getPortThemeKeys();
+  var themeOffset = themeKeys.length ? Math.floor(nextRandom() * themeKeys.length) : 0;
 
   for (var i = 0; i < positions.length; i++) {
-    var mesh = buildPortMesh();
+    var themeKey = themeKeys.length ? themeKeys[(themeOffset + i) % themeKeys.length] : null;
+    var mesh = buildPortMesh(themeKey);
     mesh.position.set(positions[i].x, 0, positions[i].z);
     scene.add(mesh);
 
@@ -249,12 +363,46 @@ export function initPorts(manager, terrain, scene) {
       mesh: mesh,
       posX: positions[i].x,
       posZ: positions[i].z,
+      dockX: positions[i].dockX,
+      dockZ: positions[i].dockZ,
+      dockRefreshTimer: 0,
+      waterAngle: positions[i].waterAngle,
+      themeKey: themeKey || "neutral",
       cooldown: 0,       // 0 = available
       available: true
     });
   }
 
   manager.initialized = true;
+}
+
+function getPortTarget(port) {
+  if (!port) return { x: 0, z: 0 };
+  return {
+    x: port.dockX !== undefined ? port.dockX : port.posX,
+    z: port.dockZ !== undefined ? port.dockZ : port.posZ
+  };
+}
+
+function refreshPortDockTarget(port, terrain) {
+  if (!port || !terrain) return;
+  var current = getPortTarget(port);
+  if (hasWaterClearance(terrain, current.x, current.z, isLand)) return;
+
+  var dock = findDockCandidate(
+    port.posX,
+    port.posZ,
+    port.waterAngle || 0,
+    Math.max(1, PORT_DOCK_OFFSET * 0.35),
+    PORT_DOCK_MAX_OFFSET,
+    1.25,
+    function (x, z) {
+      return hasWaterClearance(terrain, x, z, isLand);
+    }
+  );
+  if (!dock) return;
+  port.dockX = dock.x;
+  port.dockZ = dock.z;
 }
 
 // --- clear all ports ---
@@ -267,9 +415,15 @@ export function clearPorts(manager, scene) {
 }
 
 // --- update ports: check proximity, tick cooldowns, update visuals ---
-export function updatePorts(manager, ship, resources, enemyMgr, dt, upgrades, classKey) {
+export function updatePorts(manager, ship, resources, enemyMgr, dt, upgrades, classKey, terrain) {
   for (var i = 0; i < manager.ports.length; i++) {
     var port = manager.ports[i];
+
+    port.dockRefreshTimer = (port.dockRefreshTimer || 0) - dt;
+    if (port.dockRefreshTimer <= 0) {
+      refreshPortDockTarget(port, terrain);
+      port.dockRefreshTimer = PORT_DOCK_REFRESH;
+    }
 
     // tick cooldown
     if (port.cooldown > 0) {
@@ -282,8 +436,9 @@ export function updatePorts(manager, ship, resources, enemyMgr, dt, upgrades, cl
 
     // check proximity for resupply
     if (port.available) {
-      var dx = ship.posX - port.posX;
-      var dz = ship.posZ - port.posZ;
+      var target = getPortTarget(port);
+      var dx = ship.posX - target.x;
+      var dz = ship.posZ - target.z;
       var distSq = dx * dx + dz * dz;
 
       if (distSq < PORT_COLLECT_RADIUS * PORT_COLLECT_RADIUS) {
@@ -332,8 +487,9 @@ export function getPortsInfo(manager, ship) {
   var nearestDist = Infinity;
   for (var i = 0; i < manager.ports.length; i++) {
     var port = manager.ports[i];
-    var dx = ship.posX - port.posX;
-    var dz = ship.posZ - port.posZ;
+    var target = getPortTarget(port);
+    var dx = ship.posX - target.x;
+    var dz = ship.posZ - target.z;
     var dist = Math.sqrt(dx * dx + dz * dz);
     if (dist < nearestDist) {
       nearestDist = dist;

--- a/game/js/port.js
+++ b/game/js/port.js
@@ -5,7 +5,7 @@ import { getRepairCost } from "./upgrade.js";
 import { sampleHeightmap, isHeightmapLand, isLand } from "./terrain.js";
 import { nextRandom } from "./rng.js";
 import { loadGlbVisual } from "./glbVisual.js";
-import { ensureAssetRoles, getRoleVariants } from "./assetRoles.js";
+import { ensureAssetRoles, getRoleVariants, pickRoleVariant } from "./assetRoles.js";
 
 // --- tuning ---
 var PORT_COUNT = 3;              // ports per map
@@ -295,20 +295,20 @@ function buildPortMesh(themeKey) {
 
 function pickPortTheme(themeKey) {
   var normalizedKey = normalizeThemeKey(themeKey);
-  var themedRole = normalizedKey ? getRoleVariants("port.themes." + normalizedKey) : null;
-  var roleThemes = getRoleVariants("port.themes");
-  var themes = themedRole && themedRole.length
-    ? themedRole
-    : roleThemes && roleThemes.length
-      ? roleThemes
-      : getFallbackThemes(normalizedKey);
-  var idx = Math.floor(nextRandom() * themes.length);
-  if (idx < 0 || idx >= themes.length) idx = 0;
-  return themes[idx];
+  var themedKey = normalizedKey ? "port.themes." + normalizedKey : null;
+  var modules = themedKey ? pickRoleVariant(themedKey, null, nextRandom) : null;
+  if (!modules) modules = pickRoleVariant("port.themes", null, nextRandom);
+  if (modules) return modules;
+
+  var fallback = getFallbackThemes(normalizedKey);
+  var idx = Math.floor(nextRandom() * fallback.length);
+  if (idx < 0 || idx >= fallback.length) idx = 0;
+  return fallback[idx];
 }
 
 function hydratePortVisual(group, themeKey) {
   var modules = pickPortTheme(themeKey);
+  if (!Array.isArray(modules) || modules.length === 0) return;
   var visualRoot = new THREE.Group();
   group.add(visualRoot);
 

--- a/game/js/port.js
+++ b/game/js/port.js
@@ -4,6 +4,8 @@ import { addAmmo, addFuel } from "./resource.js";
 import { getRepairCost } from "./upgrade.js";
 import { sampleHeightmap, isHeightmapLand } from "./terrain.js";
 import { nextRandom } from "./rng.js";
+import { loadGlbVisual } from "./glbVisual.js";
+import { ensureAssetRoles, getRoleVariants } from "./assetRoles.js";
 
 // --- tuning ---
 var PORT_COUNT = 3;              // ports per map
@@ -20,6 +22,30 @@ var COAST_HEIGHT_MAX = 0.15;     // just above sea level (beach)
 var MAP_HALF = 200;              // half of MAP_SIZE (400)
 var MIN_PORT_SPACING = 60;       // minimum distance between ports
 var MIN_CENTER_DIST = 40;        // keep ports away from spawn
+
+var PORT_THEME_VARIANTS = [
+  [
+    { path: "assets/models/environment/wooden-piers/wooden-pier.glb", fit: 8, x: 0, y: 0, z: 0, ry: 0 },
+    { path: "assets/models/environment/wooden-posts/wooden-post-2.glb", fit: 2.5, x: -1.2, y: 0, z: -2.3, ry: 0 },
+    { path: "assets/models/environment/wooden-posts/wooden-post-3.glb", fit: 2.5, x: 1.2, y: 0, z: -2.3, ry: 0 },
+    { path: "assets/models/environment/boxes/box.glb", fit: 1.1, x: 0.6, y: 1.8, z: 0.9, ry: Math.PI * 0.15 },
+    { path: "assets/models/environment/barrels/barrel.glb", fit: 1.0, x: -0.6, y: 1.8, z: -0.7, ry: 0 }
+  ],
+  [
+    { path: "assets/models/environment/wooden-piers/wooden-pier-4.glb", fit: 8.5, x: 0, y: 0, z: 0, ry: 0 },
+    { path: "assets/models/environment/lamppost.glb", fit: 3.0, x: 1.1, y: 1.4, z: -2.0, ry: 0 },
+    { path: "assets/models/environment/bags/bag-grain.glb", fit: 1.1, x: -0.5, y: 1.8, z: 0.7, ry: 0 },
+    { path: "assets/models/environment/boxes/box-3.glb", fit: 1.1, x: 0.7, y: 1.8, z: 1.0, ry: Math.PI * 0.2 },
+    { path: "assets/models/environment/barrels/barrel-3.glb", fit: 1.1, x: -0.8, y: 1.8, z: -0.7, ry: 0 }
+  ],
+  [
+    { path: "assets/models/environment/wooden-platforms/wooden-platform-2.glb", fit: 8.2, x: 0, y: 0, z: 0, ry: 0 },
+    { path: "assets/models/environment/wooden-piers/wooden-pier-2.glb", fit: 8, x: 0, y: 0, z: 0.2, ry: 0 },
+    { path: "assets/models/environment/boards/board-2.glb", fit: 1.1, x: -0.6, y: 1.8, z: 0.6, ry: Math.PI * 0.2 },
+    { path: "assets/models/environment/barrels/barrel-2.glb", fit: 1.0, x: 0.6, y: 1.8, z: -0.7, ry: 0 },
+    { path: "assets/models/environment/bottles/bottle-2.glb", fit: 0.7, x: 0.2, y: 2.0, z: 0.4, ry: 0 }
+  ]
+];
 
 // --- find coastline positions ---
 function findCoastlinePositions(terrain) {
@@ -104,6 +130,7 @@ function buildPortMesh() {
   var pierMat = new THREE.MeshToonMaterial({ color: 0xa07a18 });
   var pier = new THREE.Mesh(pierGeo, pierMat);
   pier.position.set(0, 1.5, 0);
+  pier.userData.portFallback = true;
   group.add(pier);
 
   // pilings (4 corner posts)
@@ -113,6 +140,7 @@ function buildPortMesh() {
   for (var i = 0; i < offsets.length; i++) {
     var piling = new THREE.Mesh(pilingGeo, pilingMat);
     piling.position.set(offsets[i][0], 0.2, offsets[i][1]);
+    piling.userData.portFallback = true;
     group.add(piling);
   }
 
@@ -121,6 +149,7 @@ function buildPortMesh() {
   var crateMat = new THREE.MeshToonMaterial({ color: 0x44cc77 });
   var crate = new THREE.Mesh(crateGeo, crateMat);
   crate.position.set(0.5, 2.1, 1.0);
+  crate.userData.portFallback = true;
   group.add(crate);
 
   // barrel on pier
@@ -128,6 +157,7 @@ function buildPortMesh() {
   var barrelMat = new THREE.MeshToonMaterial({ color: 0x2299ee });
   var barrel = new THREE.Mesh(barrelGeo, barrelMat);
   barrel.position.set(-0.6, 2.05, -0.8);
+  barrel.userData.portFallback = true;
   group.add(barrel);
 
   // glow light (green when available, grey when on cooldown)
@@ -153,11 +183,52 @@ function buildPortMesh() {
   group.userData.lamp = lamp;
   group.userData.lampMat = lampMat;
 
+  // async GLB dock dressing; keep primitive base as resilient fallback
+  hydratePortVisual(group);
+
   return group;
+}
+
+function pickPortTheme() {
+  var roleThemes = getRoleVariants("port.themes");
+  var themes = roleThemes && roleThemes.length ? roleThemes : PORT_THEME_VARIANTS;
+  var idx = Math.floor(nextRandom() * themes.length);
+  if (idx < 0 || idx >= themes.length) idx = 0;
+  return themes[idx];
+}
+
+function hydratePortVisual(group) {
+  var modules = pickPortTheme();
+  var visualRoot = new THREE.Group();
+  group.add(visualRoot);
+
+  var fallbackHidden = false;
+  for (var i = 0; i < modules.length; i++) {
+    (function (mod) {
+      loadGlbVisual(mod.path, mod.fit, true)
+        .then(function (obj) {
+          if (!fallbackHidden) {
+            fallbackHidden = true;
+            group.traverse(function (child) {
+              if (child.isMesh && child.userData && child.userData.portFallback) {
+                child.visible = false;
+              }
+            });
+          }
+          obj.position.set(mod.x || 0, mod.y || 0, mod.z || 0);
+          obj.rotation.y = mod.ry || 0;
+          visualRoot.add(obj);
+        })
+        .catch(function () {
+          // keep primitive fallback visuals if GLB fails
+        });
+    })(modules[i]);
+  }
 }
 
 // --- port manager ---
 export function createPortManager() {
+  ensureAssetRoles();
   return {
     ports: [],
     initialized: false

--- a/game/js/ship.js
+++ b/game/js/ship.js
@@ -48,7 +48,7 @@ export function applyShipOverrideAsync(mesh, classKey) {
   if (!path) return null;
   var fitSize = getOverrideSize(classKey) || 8;
   var firePoints = mesh.userData.turrets || [];
-  return loadGlbVisual(path, fitSize, true).then(function (visual) {
+  return loadGlbVisual(path, fitSize, true, { noDecimate: true }).then(function (visual) {
     // snapshot children to preserve (fire points and lights like lantern)
     var keep = [];
     for (var i = 0; i < mesh.children.length; i++) {

--- a/game/js/shipSelect.js
+++ b/game/js/shipSelect.js
@@ -80,7 +80,7 @@ function createPreviewEntry(classKey, canvas) {
     var path = getOverridePath(classKey);
     var size = getOverrideSize(classKey) || 6;
     if (!path) return;
-    loadGlbVisual(path, size, true).then(function (visual) {
+    loadGlbVisual(path, size, true, { noDecimate: true }).then(function (visual) {
       entry.model = visual;
       scene.add(visual);
     }).catch(function () {});


### PR DESCRIPTION
## Summary
This PR continues the 3D models rollout by moving model selection to a richer data-driven role system and fixing related gameplay regressions.

### What’s included
- Added weighted role selection support in `assetRoles` (`pickRoleVariant`).
- Added contextual role fallback chain support in gameplay usage:
  - `zone` -> `condition` -> `difficulty` -> base role.
- Extended role-driven model selection coverage to:
  - Ports/themes
  - Ambient ships
  - Wave enemies
  - Pickups
- Hardened port usability:
  - Water-safe dock anchor selection + periodic revalidation
  - Dock-based minimap markers and interaction checks
  - Increased port interaction radius
- Fixed mesh fidelity regressions by disabling destructive decimation where needed:
  - Player ship, enemy ship, boss ship, ship-select preview, port kits
- Added runtime diagnostics for balancing:
  - `window.get_role_pick_stats()`
  - `window.reset_role_pick_stats()`

## Why
- Makes 3D model variety tunable from JSON without code edits.
- Reduces regressions from terrain/collider timing and model simplification.
- Enables faster balancing of visual variety by role/zone/weather.

## Key commits
- `3a25f38` Expand 3D role-driven ship visuals and harden port docking
- `d6ae04a` Add weighted asset-role selection for ports, ambient ships, and pickups
- `a8f49b6` Drive wave enemy ship models from faction role pools
- `ff2085b` Support zone- and condition-aware enemy role variants
- `f53063f` Enable contextual role keys for port theme selection
- `2a11850` Add contextual pickup role variants and shared role context
- `d4b4035` Make port faction themes weight-driven via role registry
- `140382e` Add runtime diagnostics for asset-role variant picks

## Validation
- `node --check` on touched modules (`assetRoles`, `port`, `enemy`, `pickup`, `main`, `merchant`, etc.)
- `python -m json.tool game/data/assetRoleRegistry.json`
- Playwright smoke runs (`iter20`–`iter30`), no `errors-*.json` generated

## Follow-ups (not blocker for this PR)
- Add asset-role schema/path validator script.
- Add deterministic role-sampling harness for balancing.
- Add deterministic multi-seed port reachability regression harness.

---

**PR Checklist**
- [x] `output/` is not included in the PR
- [x] `progress.md` is not included in the PR
- [ ] Reviewer smoke-tested: new run -> ship select -> combat -> voyage -> combat
- [ ] Reviewer verified dock interaction feels correct near shoreline
- [ ] Reviewer spot-checked `window.get_role_pick_stats()` output during playtest