### PR TITLE
Optimize procedural world streaming with prioritized chunk generation controls

### DIFF
--- a/docs/3d-asset-opportunities.md
+++ b/docs/3d-asset-opportunities.md
@@ -1,0 +1,254 @@
+# Ocean Outlaws 3D Asset Utilization Opportunities
+
+## Objective
+Leverage the existing 3D model inventory to increase world readability, thematic variety, and progression feedback—without requiring net-new art production.
+
+This document focuses on opportunities where gameplay systems currently use procedural placeholder geometry (or minimal visual variation) and can be upgraded using assets already present under `game/assets/models/` and cataloged in `game/data/testLabModelCatalog.json`.
+
+## Current-State Snapshot
+
+### What we already have available
+- Test Lab catalog entries: **239** total, across `ship`, `tree`, `island`, `port`, and `water` groups.
+- Active gameplay composite preset (`compositePresetsPalmov30.json`) uses **77 unique model paths**.
+- Estimated immediately available but not currently used by active gameplay composition: **162 cataloged models**.
+
+### High-value gaps in current gameplay visuals
+1. **Supply ports** are still generated from primitive meshes (`BoxGeometry`, `CylinderGeometry`, sphere lamp), even though we have piers, houses, props, and fences in the asset set.
+2. **Resource pickups/drops** are still primitive crate/barrel geometry with color tinting, despite having collectible-like props (barrels, boxes, bags, fish, bottles, baskets, food).
+3. **Map composition runtime** currently loads a single composite file (`compositePresetsPalmov30.json`), leaving large themed sets and alternate compositions underused.
+
+## Opportunity Matrix (Comprehensive)
+
+## 1) Ports, Harbors, and Shoreline Economy Spaces
+
+### 1.1 Replace procedural port mesh with modular GLB harbor kits
+**Current behavior:** `buildPortMesh()` in `port.js` builds a minimal pier + crate + barrel + lamp from primitives.
+
+**Assets to leverage now:**
+- Main anchors: `environment/wooden-piers/*`, `environment/wooden-platforms/*`, `environment/destroyed-wooden-pier.glb`
+- Harbor dressing: `environment/barrels/*`, `environment/boxes/*`, `environment/bags/*`, `environment/boards/*`, `environment/lamppost.glb`, `environment/bench.glb`, `environment/chairs/*`, `environment/tables/*`
+- Harbor structures: `houses/trading/*`, `houses/pirate/*`, `houses/lighthouse.glb`, `houses/house.glb`
+- Boundary/readability: `environment/fences/stone/*`, `environment/fences/untreated/*`, `environment/wooden-posts/*`
+
+**Gameplay benefit:**
+- Ports become recognizable POIs at distance.
+- Better affordance for repair/restock interactions.
+- Easier future addition of dock-specific mechanics (shop NPCs, queueing, quests).
+
+**Implementation notes:**
+- Define 3-5 reusable port composition templates (small cove dock, merchant quay, pirate shack dock, lighthouse jetty, damaged dock).
+- Swap template by biome/zone difficulty or faction influence.
+
+### 1.2 Faction-themed ports
+**Assets to leverage now:**
+- Pirate themes: `houses/pirate/*`, `vehicles/pirate-ships/*`
+- Merchant/trade themes: `houses/trading/*`, `food-tents/*`, `bag-grain*`, `basket.glb`, `box*`
+- Neutral/civil themes: `house.glb`, `lighthouse.glb`, benches/tables/chairs
+
+**Gameplay benefit:**
+- Visual storytelling of control/safety at each port.
+- Allows map progression feedback through environment state changes.
+
+### 1.3 Port upgrade visual progression
+**Assets to leverage now:**
+- Tier progression using more complete pier + props sets (`wooden-pier` -> `wooden-pier-5` + lamppost + fenced market details).
+
+**Gameplay benefit:**
+- Port level/relationship can be read without UI.
+
+---
+
+## 2) Drops, Collectibles, and Salvage Readability
+
+### 2.1 Replace primitive pickup meshes with type-specific prop models
+**Current behavior:** `pickup.js` builds drops from primitive box/cylinder geometry.
+
+**Assets to leverage now by pickup type:**
+- Ammo: `environment/boxes/*`, `environment/barrels/barrel-stand.glb`
+- Fuel: `environment/barrels/*`, `environment/bottles/*`
+- Parts: `environment/boards/*`, `environment/wooden-posts/*`, `environment/wooden-platforms/*`
+- Gold/loot: `environment/basket.glb`, `environment/mug.glb`, `environment/bags/*`
+- Food/heal style pickups (future): `environment/food/*`, `environment/drying-fish.glb`, `environment/fish.glb`
+
+**Gameplay benefit:**
+- No need to infer pickup type only from color.
+- Stronger “salvage from wreckage” fantasy.
+
+### 2.2 Add rarity/quality variants via existing prop families
+**Assets to leverage now:**
+- Use numbered variants (e.g., `barrel`, `barrel-2`, `barrel-3`; `box`, `box-2`, `box-3`) for common/uncommon/rare visuals.
+
+**Gameplay benefit:**
+- Better reward anticipation before collection.
+
+### 2.3 Wreck-drop bundles
+**Assets to leverage now:**
+- `vehicles/destroyed/*` fragments + floating props (`boards`, `barrels`, `bags`, `bottles`) as temporary salvage fields.
+
+**Gameplay benefit:**
+- Post-combat scenes feel consequential.
+- Opportunity for risk/reward mini-loops (linger for loot vs continue combat).
+
+---
+
+## 3) Island Biome and Encounter Set Dressing
+
+### 3.1 Use additional island/location packs in runtime rotation
+**Current behavior:** Runtime composition path defaults to `compositePresetsPalmov30.json`.
+
+**Assets to leverage now:**
+- Location anchors in `lands/*`, `islands/*`, `waters/water-location-*`
+- Supplemental terrain detail in `mountains/*`, `stones/*`, `trees/*`, `plants/*`
+
+**Gameplay benefit:**
+- More zone distinctiveness and replay variety.
+- Better tie between named map zones and in-world silhouettes.
+
+### 3.2 Encounter-specific visual language
+**Assets to leverage now:**
+- Sea monster zones: `environment/tentacles/*`, `land-sea-monster-attack.glb`, `water-location-sea-monster-attack.glb`
+- Secret/ruin zones: `land-secret-island.glb`, `houses/secret/*`, `stones/ancient/*`
+- Trade zones: `land-trade-port.glb`, `houses/trading/*`, market props
+- Lighthouse/nav zones: `island-lighthouse-pier.glb`, `houses/lighthouse.glb`, piers/lampposts
+
+**Gameplay benefit:**
+- Faster player comprehension of threat/opportunity by silhouette.
+
+### 3.3 Coastal traffic and static ambient vessels
+**Assets to leverage now:**
+- `vehicles/sailboats/*`, `vehicles/boat.glb`, `ships-palmov/boats/*`, `ships-palmov/small/*`
+
+**Gameplay benefit:**
+- World feels populated, not just combat-spawned.
+
+---
+
+## 4) Enemy, Mission, and Boss Scene Enhancement
+
+### 4.1 Expand enemy ship silhouette diversity without balance changes
+**Assets to leverage now:**
+- `ships-palmov/small|medium|large/*`, `ships-palmov/viking/*`, `vehicles/pirate-ships/*`
+
+**Gameplay benefit:**
+- More visual variety at same stat tiers.
+- Easier faction recognition.
+
+### 4.2 Boss arena staging assets
+**Assets to leverage now:**
+- Kraken/monster arenas: `environment/tentacles/*`, `waterfall.glb`, dramatic rock sets (`mountain-arch*`, `ancient-stone*`)
+- Human boss arenas: fortress-like fence/pier/house clusters.
+
+**Gameplay benefit:**
+- Boss fights feel authored rather than regular-wave scaling.
+
+### 4.3 Convoy/escort mission dressing (future mode)
+**Assets to leverage now:**
+- Merchant convoy from `vehicles/sailboats/*` + cargo props (`bags`, `boxes`, `food`).
+
+**Gameplay benefit:**
+- Enables non-combat objective formats using existing art.
+
+---
+
+## 5) UI/Meta Loops that Can Use Existing Models
+
+### 5.1 Upgrade screens and card reward previews
+**Assets to leverage now:**
+- `ship` catalog entries as rotating 3D previews.
+- Prop assets for reward cards (crate, barrel, fish, etc.).
+
+**Gameplay benefit:**
+- Better polish and player understanding in meta UI.
+
+### 5.2 Port screen diorama backgrounds
+**Assets to leverage now:**
+- `houses/*`, `wooden-piers/*`, market props + faction ship parked in background.
+
+**Gameplay benefit:**
+- Port interactions feel physically located in-world.
+
+### 5.3 Minimap/legend icon derivation from model families
+**Assets to leverage now:**
+- Use consistent iconography tied to model categories (pirate-house icon, lighthouse icon, tentacle icon).
+
+**Gameplay benefit:**
+- Stronger map readability and onboarding.
+
+---
+
+## 6) Technical Integration Opportunities
+
+### 6.1 Asset role registry (lightweight)
+Create a small JSON mapping from model paths to gameplay roles:
+- `port_modules`, `pickup_ammo`, `pickup_fuel`, `pickup_parts`, `pickup_gold`, `encounter_sea_monster`, etc.
+
+This enables deterministic selection and future balancing without hardcoding asset paths in multiple systems.
+
+### 6.2 Weighted variation pools by zone and faction
+Define weighted pools of models for each system:
+- Port template pool by faction.
+- Pickup model pool by resource type and rarity.
+- Ambient vessel pool by zone danger level.
+
+### 6.3 Budget-aware LOD/quality gates
+Reuse existing quality settings to control:
+- Prop density at ports.
+- Drop bundle complexity.
+- Ambient traffic count.
+
+### 6.4 Collision policy per asset role
+- Keep colliders for major navigational blockers (islands, buildings, large piers).
+- Disable/simplify collider on small props and floating pickups.
+
+---
+
+## Prioritized Roadmap
+
+### Phase 1 (High impact, low risk)
+1. **Port visual overhaul:** replace primitive `buildPortMesh()` with modular GLB compositions.
+2. **Pickup mesh overhaul:** replace primitive crate/barrel with role-specific prop models.
+3. **Add 2-3 themed port variants** (merchant, pirate, neutral).
+
+### Phase 2 (Medium effort, high replay value)
+1. Rotate/add additional composition sets for zone-specific visuals.
+2. Add ambient vessel spawning using small/boat model pools.
+3. Add wreck-drop salvage bundles from destroyed ship + prop fragments.
+
+### Phase 3 (Polish + depth)
+1. Boss arena prop kits per boss type.
+2. Port upgrade progression visuals by reputation or game stage.
+3. UI 3D previews in port and reward contexts.
+
+---
+
+## Suggested Success Metrics
+- **Visual variety:** unique model paths spawned per 10-minute run.
+- **System coverage:** % of gameplay systems using GLB assets instead of primitives.
+- **Player readability:** reduced time-to-identify pickup/resource type in playtests.
+- **Engagement proxy:** average time spent at port and around post-combat salvage zones.
+
+## Immediate Candidate Asset Pools (Quick Start)
+
+### Port module starter set
+- `assets/models/environment/wooden-piers/wooden-pier.glb`
+- `assets/models/environment/wooden-platforms/wooden-platform.glb`
+- `assets/models/environment/lamppost.glb`
+- `assets/models/houses/trading/trading-house.glb`
+- `assets/models/environment/boxes/box.glb`
+- `assets/models/environment/barrels/barrel.glb`
+
+### Pickup starter set
+- Ammo: `assets/models/environment/boxes/box-2.glb`
+- Fuel: `assets/models/environment/barrels/barrel-2.glb`
+- Parts: `assets/models/environment/boards/board.glb`
+- Gold: `assets/models/environment/basket.glb`
+
+### Encounter flavor set
+- Sea monster: `assets/models/environment/tentacles/tentacles.glb`
+- Trade route: `assets/models/vehicles/sailboats/sailboat.glb`
+- Ruins: `assets/models/stones/ancient/ancient-stone-12.glb`
+
+---
+
+## Conclusion
+Ocean Outlaws already has a deep, production-ready 3D asset library; the biggest wins now come from **wiring this inventory into active gameplay systems** (ports, pickups, encounter staging), not from creating new art. Converting just ports and pickups from primitives to existing GLBs would materially improve perceived production value and support future feature depth.

--- a/game/data/assetRoleRegistry.json
+++ b/game/data/assetRoleRegistry.json
@@ -188,10 +188,20 @@
       { "path": "assets/models/environment/boxes/box-2.glb", "fit": 1.0 },
       { "path": "assets/models/environment/boxes/box-3.glb", "fit": 1.0 }
     ],
+    "pickup.ammo.condition.calm": [
+      { "path": "assets/models/environment/boxes/box.glb", "fit": 1.0, "weight": 1.5 },
+      { "path": "assets/models/environment/boxes/box-3.glb", "fit": 1.0, "weight": 1.1 },
+      { "path": "assets/models/environment/boxes/box-2.glb", "fit": 1.0, "weight": 0.7 }
+    ],
     "pickup.fuel": [
       { "path": "assets/models/environment/barrels/barrel.glb", "fit": 1.0 },
       { "path": "assets/models/environment/barrels/barrel-2.glb", "fit": 1.0 },
       { "path": "assets/models/environment/bottles/bottle-2.glb", "fit": 0.95 }
+    ],
+    "pickup.fuel.zone.stormwall": [
+      { "path": "assets/models/environment/barrels/barrel-2.glb", "fit": 1.0, "weight": 1.6 },
+      { "path": "assets/models/environment/barrels/barrel.glb", "fit": 1.0, "weight": 1.2 },
+      { "path": "assets/models/environment/bottles/bottle-2.glb", "fit": 0.95, "weight": 0.5 }
     ],
     "pickup.parts": [
       { "path": "assets/models/environment/boards/board.glb", "fit": 1.0 },
@@ -202,6 +212,11 @@
       { "path": "assets/models/environment/basket.glb", "fit": 1.0 },
       { "path": "assets/models/environment/bags/bag-grain.glb", "fit": 1.0 },
       { "path": "assets/models/environment/mug.glb", "fit": 1.0 }
+    ],
+    "pickup.gold.condition.stormy": [
+      { "path": "assets/models/environment/bags/bag-grain.glb", "fit": 1.0, "weight": 1.4 },
+      { "path": "assets/models/environment/basket.glb", "fit": 1.0, "weight": 1.1 },
+      { "path": "assets/models/environment/mug.glb", "fit": 1.0, "weight": 0.7 }
     ]
   }
 }

--- a/game/data/assetRoleRegistry.json
+++ b/game/data/assetRoleRegistry.json
@@ -1,7 +1,11 @@
 {
   "version": 1,
   "roles": {
-    "port.factions": ["neutral", "merchant", "pirate"],
+    "port.factions": [
+      { "value": "neutral", "weight": 1.2 },
+      { "value": "merchant", "weight": 1.0 },
+      { "value": "pirate", "weight": 1.1 }
+    ],
     "port.themes": [
       [
         { "path": "assets/models/environment/wooden-piers/wooden-pier.glb", "fit": 8, "x": 0, "y": 0, "z": 0, "ry": 0 },

--- a/game/index.html
+++ b/game/index.html
@@ -13,7 +13,7 @@
   <link rel="manifest" href="manifest.json">
   <link rel="icon" href="icons/icon-192.png" type="image/png">
   <link rel="apple-touch-icon" href="icons/icon-192.png">
-  <base href="/game/">
+  <base href="/ocean-outlaws/game/">
   <style>
     * {
       margin: 0;

--- a/game/js/crate.js
+++ b/game/js/crate.js
@@ -17,7 +17,6 @@ var GLOW_PULSE_SPEED = 3.0;
 var GLOW_PULSE_MIN = 0.5;
 var SPAWN_DIST_MIN = 30;         // min distance from player
 var SPAWN_DIST_MAX = 100;        // max distance from player
-var MAP_HALF = 200;
 var MAX_CRATES = 8;              // max concurrent crates on map
 
 // crate drop amounts (slightly less than port, more than enemy drops)
@@ -105,9 +104,6 @@ function findCrateSpawnPosition(ship, terrain) {
     var dist = SPAWN_DIST_MIN + nextRandom() * (SPAWN_DIST_MAX - SPAWN_DIST_MIN);
     var x = ship.posX + Math.sin(angle) * dist;
     var z = ship.posZ + Math.cos(angle) * dist;
-
-    // keep within map bounds
-    if (Math.abs(x) > MAP_HALF - 20 || Math.abs(z) > MAP_HALF - 20) continue;
 
     // must be on water
     if (terrain && isLand(terrain, x, z)) continue;

--- a/game/js/enemy.js
+++ b/game/js/enemy.js
@@ -2,7 +2,7 @@
 import * as THREE from "three";
 import { isLand, collideWithTerrain, terrainBlocksLine, getTerrainAvoidance } from "./terrain.js";
 import { slideCollision, createStuckDetector, updateStuck, isStuck, nudgeToOpenWater } from "./collision.js";
-import { getOverridePath, getOverrideSize } from "./artOverrides.js";
+import { getOverridePath, getOverrideSize, ensureManifest } from "./artOverrides.js";
 import { loadGlbVisual } from "./glbVisual.js";
 import { ensureAssetRoles, pickRoleVariant } from "./assetRoles.js";
 import { nextRandom } from "./rng.js";

--- a/game/js/input.js
+++ b/game/js/input.js
@@ -135,7 +135,16 @@ function onKeyDown(e) {
   var tag = e.target.tagName;
   if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
   var key = e.key;
-  if (key === "q" || key === "Q") {
+  if (key === "F2") {
+    keyActions.push("worldDebugToggle");
+    e.preventDefault();
+  } else if (key === "+" || key === "=") {
+    keyActions.push("worldDebugZoomIn");
+    e.preventDefault();
+  } else if (key === "-" || key === "_") {
+    keyActions.push("worldDebugZoomOut");
+    e.preventDefault();
+  } else if (key === "q" || key === "Q") {
     keyActions.push("slot0");
   } else if (key === "w" || key === "W") {
     keyActions.push("slot1");

--- a/game/js/main.js
+++ b/game/js/main.js
@@ -51,6 +51,7 @@ import { loadInfamy, addInfamy, calcRunInfamy, getLegendLevel, getLegendProgress
 import { createInfamyScreen, showInfamyScreen, hideInfamyScreen } from "./infamyScreen.js";
 import { createMainMenu, showMainMenu, hideMainMenu } from "./mainMenu.js";
 import { createRunState, saveRunState as saveRun, loadRunState, hasActiveRun, clearRunState } from "./runState.js";
+import { getRolePickStats, resetRolePickStats } from "./assetRoles.js";
 
 var GOLD_PER_KILL = 25;
 var prevPlayerHp = -1;
@@ -1735,3 +1736,11 @@ function animate() {
 }
 
 animate();
+
+// Debug helpers for tuning weighted role entries during playtests.
+window.get_role_pick_stats = function () {
+  return getRolePickStats();
+};
+window.reset_role_pick_stats = function () {
+  resetRolePickStats();
+};

--- a/game/js/merchant.js
+++ b/game/js/merchant.js
@@ -157,19 +157,20 @@ export function clearMerchants(mgr, scene) {
 }
 
 // --- update: tick spawn timer, track lifetime, despawn off-map ---
-export function updateMerchants(mgr, ship, dt, scene, terrain, elapsed, getWaveHeight, enemyMgr, zone, zoneId) {
+export function updateMerchants(mgr, ship, dt, scene, terrain, elapsed, getWaveHeight, enemyMgr, zone, zoneId, roleContext) {
   // scale spawn interval by zone difficulty
   var difficulty = (zone && zone.difficulty) ? zone.difficulty : 1;
   var interval = Math.max(SPAWN_INTERVAL_MIN, SPAWN_INTERVAL_BASE - difficulty * 2);
-  var roleContext = zone ? {
+  var derivedRoleContext = zone ? {
     zoneId: zoneId || zone.id || null,
     condition: zone.condition || null,
     difficulty: zone.difficulty || null
   } : null;
+  var spawnRoleContext = roleContext || derivedRoleContext;
 
   mgr.spawnTimer -= dt;
   if (mgr.spawnTimer <= 0) {
-    spawnMerchantGroup(mgr, scene, terrain, enemyMgr, roleContext);
+    spawnMerchantGroup(mgr, scene, terrain, enemyMgr, spawnRoleContext);
     mgr.spawnTimer = interval;
   }
 

--- a/game/js/pickup.js
+++ b/game/js/pickup.js
@@ -80,6 +80,30 @@ function pickPickupModel(type) {
   return pickRoleVariant("pickup." + type, PICKUP_MODEL_POOLS[type], nextRandom);
 }
 
+function normalizeRoleToken(value) {
+  if (value === null || value === undefined) return null;
+  var text = String(value).trim().toLowerCase();
+  if (!text) return null;
+  text = text.replace(/[^a-z0-9_\-]/g, "_");
+  return text || null;
+}
+
+function pickPickupModelWithContext(type, roleContext) {
+  var baseRole = "pickup." + type;
+  var zoneId = roleContext ? normalizeRoleToken(roleContext.zoneId || roleContext.id) : null;
+  var condition = roleContext ? normalizeRoleToken(roleContext.condition) : null;
+  var difficulty = roleContext ? normalizeRoleToken(roleContext.difficulty) : null;
+  var candidates = [];
+  if (zoneId) candidates.push(baseRole + ".zone." + zoneId);
+  if (condition) candidates.push(baseRole + ".condition." + condition);
+  if (difficulty) candidates.push(baseRole + ".difficulty." + difficulty);
+  for (var i = 0; i < candidates.length; i++) {
+    var contextual = pickRoleVariant(candidates[i], null, nextRandom);
+    if (contextual) return contextual;
+  }
+  return pickPickupModel(type);
+}
+
 // --- build pickup mesh ---
 function buildPickupMesh(type) {
   ensureGeo();
@@ -108,7 +132,7 @@ function buildPickupMesh(type) {
 }
 
 function hydratePickupMesh(pickup) {
-  var model = pickPickupModel(pickup.type);
+  var model = pickPickupModelWithContext(pickup.type, pickup.roleContext);
   if (!model) return;
   loadGlbVisual(model.path, model.fit, true)
     .then(function (obj) {
@@ -131,12 +155,18 @@ export function createPickupManager() {
   ensureAssetRoles();
   return {
     pickups: [],
+    roleContext: null,
     onCollectCallback: null  // called with (index) for multiplayer sync
   };
 }
 
 export function setPickupCollectCallback(manager, callback) {
   manager.onCollectCallback = callback;
+}
+
+export function setPickupRoleContext(manager, roleContext) {
+  if (!manager) return;
+  manager.roleContext = roleContext || null;
 }
 
 // --- spawn a pickup at position ---
@@ -162,6 +192,7 @@ export function spawnPickup(manager, x, y, z, scene) {
     type: type,
     posX: x,
     posZ: z,
+    roleContext: manager.roleContext || null,
     age: 0,
     collected: false
   };

--- a/game/js/pickup.js
+++ b/game/js/pickup.js
@@ -3,6 +3,7 @@ import * as THREE from "three";
 import { addAmmo, addFuel, addParts } from "./resource.js";
 import { addGold } from "./upgrade.js";
 import { nextRandom } from "./rng.js";
+import { loadGlbVisual } from "./glbVisual.js";
 
 // --- tuning ---
 var PICKUP_FLOAT_OFFSET = 0.8;
@@ -36,6 +37,29 @@ function ensureGeo() {
   barrelGeo = new THREE.CylinderGeometry(0.25, 0.3, 0.7, 8);
 }
 
+var PICKUP_MODEL_POOLS = {
+  ammo: [
+    { path: "assets/models/environment/boxes/box.glb", fit: 1.0 },
+    { path: "assets/models/environment/boxes/box-2.glb", fit: 1.0 },
+    { path: "assets/models/environment/boxes/box-3.glb", fit: 1.0 }
+  ],
+  fuel: [
+    { path: "assets/models/environment/barrels/barrel.glb", fit: 1.0 },
+    { path: "assets/models/environment/barrels/barrel-2.glb", fit: 1.0 },
+    { path: "assets/models/environment/bottles/bottle-2.glb", fit: 0.95 }
+  ],
+  parts: [
+    { path: "assets/models/environment/boards/board.glb", fit: 1.0 },
+    { path: "assets/models/environment/boards/board-2.glb", fit: 1.0 },
+    { path: "assets/models/environment/wooden-posts/wooden-post.glb", fit: 1.0 }
+  ],
+  gold: [
+    { path: "assets/models/environment/basket.glb", fit: 1.0 },
+    { path: "assets/models/environment/bags/bag-grain.glb", fit: 1.0 },
+    { path: "assets/models/environment/mug.glb", fit: 1.0 }
+  ]
+};
+
 // --- color by type ---
 var TYPE_COLORS = {
   ammo: 0xffaa22,
@@ -51,6 +75,14 @@ var GLOW_COLORS = {
   gold: 0xffee88
 };
 
+function pickPickupModel(type) {
+  var pool = PICKUP_MODEL_POOLS[type];
+  if (!pool || pool.length === 0) return null;
+  var idx = Math.floor(nextRandom() * pool.length);
+  if (idx < 0 || idx >= pool.length) idx = 0;
+  return pool[idx];
+}
+
 // --- build pickup mesh ---
 function buildPickupMesh(type) {
   ensureGeo();
@@ -65,6 +97,7 @@ function buildPickupMesh(type) {
   } else {
     mesh = new THREE.Mesh(crateGeo, mat);
   }
+  mesh.userData.pickupFallback = true;
   group.add(mesh);
 
   // glow point light
@@ -75,6 +108,25 @@ function buildPickupMesh(type) {
 
   group.userData.light = light;
   return group;
+}
+
+function hydratePickupMesh(pickup) {
+  var model = pickPickupModel(pickup.type);
+  if (!model) return;
+  loadGlbVisual(model.path, model.fit, true)
+    .then(function (obj) {
+      if (pickup.collected || !pickup.mesh || !pickup.mesh.parent) return;
+      pickup.mesh.traverse(function (child) {
+        if (child.isMesh && child.userData && child.userData.pickupFallback) {
+          child.visible = false;
+        }
+      });
+      obj.position.y = 0.1;
+      pickup.mesh.add(obj);
+    })
+    .catch(function () {
+      // keep fallback mesh
+    });
 }
 
 // --- pickup manager ---
@@ -107,14 +159,17 @@ export function spawnPickup(manager, x, y, z, scene) {
   mesh.position.set(x, y + PICKUP_FLOAT_OFFSET, z);
   scene.add(mesh);
 
-  manager.pickups.push({
+  var pickup = {
     mesh: mesh,
     type: type,
     posX: x,
     posZ: z,
     age: 0,
     collected: false
-  });
+  };
+  manager.pickups.push(pickup);
+
+  hydratePickupMesh(pickup);
 }
 
 // --- clear all pickups (called on wave transition) ---

--- a/game/js/port.js
+++ b/game/js/port.js
@@ -4,6 +4,7 @@ import { addAmmo, addFuel } from "./resource.js";
 import { getRepairCost } from "./upgrade.js";
 import { sampleHeightmap, isHeightmapLand } from "./terrain.js";
 import { nextRandom } from "./rng.js";
+import { loadGlbVisual } from "./glbVisual.js";
 
 // --- tuning ---
 var PORT_COUNT = 3;              // ports per map
@@ -20,6 +21,30 @@ var COAST_HEIGHT_MAX = 0.15;     // just above sea level (beach)
 var MAP_HALF = 200;              // half of MAP_SIZE (400)
 var MIN_PORT_SPACING = 60;       // minimum distance between ports
 var MIN_CENTER_DIST = 40;        // keep ports away from spawn
+
+var PORT_THEME_VARIANTS = [
+  [
+    { path: "assets/models/environment/wooden-piers/wooden-pier.glb", fit: 8, x: 0, y: 0, z: 0, ry: 0 },
+    { path: "assets/models/environment/wooden-posts/wooden-post-2.glb", fit: 2.5, x: -1.2, y: 0, z: -2.3, ry: 0 },
+    { path: "assets/models/environment/wooden-posts/wooden-post-3.glb", fit: 2.5, x: 1.2, y: 0, z: -2.3, ry: 0 },
+    { path: "assets/models/environment/boxes/box.glb", fit: 1.1, x: 0.6, y: 1.8, z: 0.9, ry: Math.PI * 0.15 },
+    { path: "assets/models/environment/barrels/barrel.glb", fit: 1.0, x: -0.6, y: 1.8, z: -0.7, ry: 0 }
+  ],
+  [
+    { path: "assets/models/environment/wooden-piers/wooden-pier-4.glb", fit: 8.5, x: 0, y: 0, z: 0, ry: 0 },
+    { path: "assets/models/environment/lamppost.glb", fit: 3.0, x: 1.1, y: 1.4, z: -2.0, ry: 0 },
+    { path: "assets/models/environment/bags/bag-grain.glb", fit: 1.1, x: -0.5, y: 1.8, z: 0.7, ry: 0 },
+    { path: "assets/models/environment/boxes/box-3.glb", fit: 1.1, x: 0.7, y: 1.8, z: 1.0, ry: Math.PI * 0.2 },
+    { path: "assets/models/environment/barrels/barrel-3.glb", fit: 1.1, x: -0.8, y: 1.8, z: -0.7, ry: 0 }
+  ],
+  [
+    { path: "assets/models/environment/wooden-platforms/wooden-platform-2.glb", fit: 8.2, x: 0, y: 0, z: 0, ry: 0 },
+    { path: "assets/models/environment/wooden-piers/wooden-pier-2.glb", fit: 8, x: 0, y: 0, z: 0.2, ry: 0 },
+    { path: "assets/models/environment/boards/board-2.glb", fit: 1.1, x: -0.6, y: 1.8, z: 0.6, ry: Math.PI * 0.2 },
+    { path: "assets/models/environment/barrels/barrel-2.glb", fit: 1.0, x: 0.6, y: 1.8, z: -0.7, ry: 0 },
+    { path: "assets/models/environment/bottles/bottle-2.glb", fit: 0.7, x: 0.2, y: 2.0, z: 0.4, ry: 0 }
+  ]
+];
 
 // --- find coastline positions ---
 function findCoastlinePositions(terrain) {
@@ -104,6 +129,7 @@ function buildPortMesh() {
   var pierMat = new THREE.MeshToonMaterial({ color: 0xa07a18 });
   var pier = new THREE.Mesh(pierGeo, pierMat);
   pier.position.set(0, 1.5, 0);
+  pier.userData.portFallback = true;
   group.add(pier);
 
   // pilings (4 corner posts)
@@ -113,6 +139,7 @@ function buildPortMesh() {
   for (var i = 0; i < offsets.length; i++) {
     var piling = new THREE.Mesh(pilingGeo, pilingMat);
     piling.position.set(offsets[i][0], 0.2, offsets[i][1]);
+    piling.userData.portFallback = true;
     group.add(piling);
   }
 
@@ -121,6 +148,7 @@ function buildPortMesh() {
   var crateMat = new THREE.MeshToonMaterial({ color: 0x44cc77 });
   var crate = new THREE.Mesh(crateGeo, crateMat);
   crate.position.set(0.5, 2.1, 1.0);
+  crate.userData.portFallback = true;
   group.add(crate);
 
   // barrel on pier
@@ -128,6 +156,7 @@ function buildPortMesh() {
   var barrelMat = new THREE.MeshToonMaterial({ color: 0x2299ee });
   var barrel = new THREE.Mesh(barrelGeo, barrelMat);
   barrel.position.set(-0.6, 2.05, -0.8);
+  barrel.userData.portFallback = true;
   group.add(barrel);
 
   // glow light (green when available, grey when on cooldown)
@@ -153,7 +182,45 @@ function buildPortMesh() {
   group.userData.lamp = lamp;
   group.userData.lampMat = lampMat;
 
+  // async GLB dock dressing; keep primitive base as resilient fallback
+  hydratePortVisual(group);
+
   return group;
+}
+
+function pickPortTheme() {
+  var idx = Math.floor(nextRandom() * PORT_THEME_VARIANTS.length);
+  if (idx < 0 || idx >= PORT_THEME_VARIANTS.length) idx = 0;
+  return PORT_THEME_VARIANTS[idx];
+}
+
+function hydratePortVisual(group) {
+  var modules = pickPortTheme();
+  var visualRoot = new THREE.Group();
+  group.add(visualRoot);
+
+  var fallbackHidden = false;
+  for (var i = 0; i < modules.length; i++) {
+    (function (mod) {
+      loadGlbVisual(mod.path, mod.fit, true)
+        .then(function (obj) {
+          if (!fallbackHidden) {
+            fallbackHidden = true;
+            group.traverse(function (child) {
+              if (child.isMesh && child.userData && child.userData.portFallback) {
+                child.visible = false;
+              }
+            });
+          }
+          obj.position.set(mod.x || 0, mod.y || 0, mod.z || 0);
+          obj.rotation.y = mod.ry || 0;
+          visualRoot.add(obj);
+        })
+        .catch(function () {
+          // keep primitive fallback visuals if GLB fails
+        });
+    })(modules[i]);
+  }
 }
 
 // --- port manager ---

--- a/game/js/ship.js
+++ b/game/js/ship.js
@@ -1,7 +1,7 @@
 // ship.js — ship physics state, GLB model loading, update loop
 import * as THREE from "three";
 import { buildClassMesh } from "./shipModels.js";
-import { collideWithTerrain, applyEdgeBoundary, getTerrainAvoidance } from "./terrain.js";
+import { collideWithTerrain, getTerrainAvoidance } from "./terrain.js";
 import { slideCollision, createStuckDetector, updateStuck, isStuck, nudgeToOpenWater } from "./collision.js";
 import { getOverridePath, getOverrideSize } from "./artOverrides.js";
 import { loadGlbVisual } from "./glbVisual.js";
@@ -265,14 +265,6 @@ export function updateShip(ship, input, dt, getWaveHeight, elapsed, fuelMult, up
       ship.speed = 0;
       ship._stuckDetector = createStuckDetector();
     }
-  }
-
-  // map edge boundary — soft push-back toward center
-  var edge = applyEdgeBoundary(ship.posX, ship.posZ);
-  if (edge.pushed) {
-    ship.posX = edge.posX;
-    ship.posZ = edge.posZ;
-    ship.speed *= 0.95;  // gentle slowdown near edge
   }
 
   ship.mesh.position.x = ship.posX;

--- a/game/js/terrain.js
+++ b/game/js/terrain.js
@@ -1,34 +1,50 @@
-// terrain.js — Palmov composition terrain, collision queries, map boundaries
+// terrain.js — infinite chunked terrain streaming, collision queries, and GC
 import * as THREE from "three";
 import { nextRandom } from "./rng.js";
-import { addCompositeFieldVisual, addTieredIslandFieldVisual, pointInVisualLand, resolveVisualCollision, getTerrainAvoidance as _getTerrainAvoidance, createColliderDebugOverlay, removeColliderDebugOverlay } from "./terrainComposite.js";
+import {
+  addCompositeFieldVisual,
+  addTieredIslandFieldVisual,
+  createColliderDebugOverlay as createCompositeColliderDebugOverlay,
+  removeColliderDebugOverlay as removeCompositeColliderDebugOverlay
+} from "./terrainComposite.js";
 
-// --- tuning ---
-var MAP_SIZE = 400;           // world units, matches ocean plane
-var GRID_RES = 128;           // heightmap resolution (NxN)
-var SEA_LEVEL = 0.0;          // threshold: above = land, below = water
-var NOISE_SCALE = 0.02;       // noise frequency tuned for island-sized features
+// --- world/chunk tuning ---
+var CHUNK_SIZE = 400;                  // keeps compatibility with existing map-scale content
+var GRID_RES = 128;                    // per-chunk heightmap resolution
+var SEA_LEVEL = 0.0;
+var NOISE_SCALE = 0.02;
 var OCTAVES = 4;
 var PERSISTENCE = 0.5;
 var LACUNARITY = 2.0;
-var SPAWN_CLEAR_RADIUS = 40;  // keep center clear for player spawn
-var COLLISION_RADIUS = 1.5;   // ship collision sampling radius
+var SPAWN_CLEAR_RADIUS = 40;
+var COLLISION_RADIUS = 1.5;
 var VISUAL_COLLIDER_PAD = 0.35;
 
-// --- map boundary ---
-var EDGE_FOG_START = 160;     // distance from center where fog begins
-var EDGE_PUSH_START = 180;    // distance from center where push-back begins
-var EDGE_HARD_LIMIT = 200;    // absolute boundary (MAP_SIZE / 2)
+// streaming radii in chunk coordinates
+var STREAM_RADIUS = 2;                 // immediate active bubble
+var KEEP_RADIUS = 3;                   // keep nearby chunks warm before GC
+var PRELOAD_AHEAD = 3;                 // preload 2-3 chunks ahead of heading
 
-// --- simplex-style 2D noise (value noise with smooth interpolation) ---
-// Seeded pseudo-random hash
-var _seed = 0;
+// disposal budget per frame (resources disposed incrementally)
+var GC_RESOURCE_BUDGET = 40;
+var ACTIVE_CHUNK_SOFT_LIMIT = 36;
+var ACTIVE_CHUNK_HARD_LIMIT = 48;
+
+// difficulty / loot scaling with distance from spawn
+var DISTANCE_RAMP_MAX = 6000;
+var ENEMY_SCALE_MAX_ADD = 1.35;
+var LOOT_SCALE_MAX_ADD = 1.2;
+var MIN_COMPOSITION_CHANCE = 0.38;
+var COMPOSITION_RARITY_MAX_DROP = 0.52;
+
+// --- value-noise helpers (seeded by world seed for deterministic infinite sampling) ---
+var _noiseSeed = 0;
 
 function hashCoord(ix, iy) {
-  var n = ix * 374761393 + iy * 668265263 + _seed;
-  n = (n ^ (n >> 13)) * 1274126177;
-  n = n ^ (n >> 16);
-  return (n & 0x7fffffff) / 0x7fffffff;  // 0..1
+  var n = Math.imul(ix, 374761393) ^ Math.imul(iy, 668265263) ^ (_noiseSeed | 0);
+  n = Math.imul(n ^ (n >>> 13), 1274126177);
+  n = n ^ (n >>> 16);
+  return (n >>> 0) / 4294967295;
 }
 
 function smoothstep(t) {
@@ -64,13 +80,40 @@ function fbm(x, y) {
     amplitude *= PERSISTENCE;
     frequency *= LACUNARITY;
   }
-  return value / maxAmp;  // normalized 0..1
+  return value / maxAmp;
 }
 
-// --- Gaussian blur for smoother, more organic island shapes ---
+function clamp(v, lo, hi) {
+  return Math.max(lo, Math.min(hi, v));
+}
+
+function chunkKey(cx, cy) {
+  return cx + "," + cy;
+}
+
+function toChunkCoord(globalCoord) {
+  // chunk coordinate where chunk center is at coord * CHUNK_SIZE
+  return Math.floor((globalCoord + CHUNK_SIZE * 0.5) / CHUNK_SIZE);
+}
+
+function chunkCenter(coord) {
+  return coord * CHUNK_SIZE;
+}
+
+function hashInt3(a, b, c) {
+  var h = (a | 0) ^ Math.imul(b | 0, 0x85ebca6b) ^ Math.imul(c | 0, 0xc2b2ae35);
+  h = Math.imul(h ^ (h >>> 16), 0x7feb352d);
+  h = Math.imul(h ^ (h >>> 15), 0x846ca68b);
+  h = h ^ (h >>> 16);
+  return h >>> 0;
+}
+
+function seedToUnit(seed) {
+  return ((seed >>> 0) % 1000000) / 1000000;
+}
+
 function gaussianBlur(data, size, passes) {
   var tmp = new Float32Array(data.length);
-  // 3x3 Gaussian kernel weights (sigma ~0.85)
   var k0 = 4 / 16, k1 = 2 / 16, k2 = 1 / 16;
   for (var p = 0; p < passes; p++) {
     for (var y = 0; y < size; y++) {
@@ -79,113 +122,76 @@ function gaussianBlur(data, size, passes) {
         var y0 = Math.max(0, y - 1), y1 = Math.min(size - 1, y + 1);
         tmp[y * size + x] =
           data[y * size + x] * k0 +
-          (data[y * size + x0] + data[y * size + x1] +
-           data[y0 * size + x] + data[y1 * size + x]) * k1 +
-          (data[y0 * size + x0] + data[y0 * size + x1] +
-           data[y1 * size + x0] + data[y1 * size + x1]) * k2;
+          (data[y * size + x0] + data[y * size + x1] + data[y0 * size + x] + data[y1 * size + x]) * k1 +
+          (data[y0 * size + x0] + data[y0 * size + x1] + data[y1 * size + x0] + data[y1 * size + x1]) * k2;
       }
     }
     for (var i = 0; i < data.length; i++) data[i] = tmp[i];
   }
 }
 
-// --- generate heightmap ---
-function generateHeightmap(seed, difficulty) {
-  _seed = seed;
-  var size = GRID_RES + 1;  // +1 for vertex grid
-  var data = new Float32Array(size * size);
-  var half = MAP_SIZE / 2;
+function distanceMetrics(globalX, globalZ) {
+  var dist = Math.sqrt(globalX * globalX + globalZ * globalZ);
+  var t = clamp(dist / DISTANCE_RAMP_MAX, 0, 1);
+  return {
+    distance: dist,
+    t: t,
+    enemyMult: 1 + t * ENEMY_SCALE_MAX_ADD,
+    lootMult: 1 + t * LOOT_SCALE_MAX_ADD,
+    compositionChance: Math.max(MIN_COMPOSITION_CHANCE, 1 - t * COMPOSITION_RARITY_MAX_DROP)
+  };
+}
 
-  // scale noise coverage based on difficulty (more land at higher difficulty)
-  // ~95% ocean at easy (diff 1), ~90% ocean at hard (diff 6); archipelago feel
-  var landThreshold = Math.max(0.70, 0.76 - difficulty * 0.01);  // higher = less land
+function generateChunkHeightmap(worldSeed, difficulty, cx, cy) {
+  _noiseSeed = worldSeed | 0;
+  var size = GRID_RES + 1;
+  var data = new Float32Array(size * size);
+  var half = CHUNK_SIZE * 0.5;
+  var centerX = chunkCenter(cx);
+  var centerZ = chunkCenter(cy);
+
+  // distance-scaled land threshold: farther chunks trend slightly rougher
+  var centerMetrics = distanceMetrics(centerX, centerZ);
+  var farLandBias = centerMetrics.t * 0.02;
+  var landThreshold = Math.max(0.67, 0.76 - difficulty * 0.01 - farLandBias);
 
   for (var iy = 0; iy < size; iy++) {
     for (var ix = 0; ix < size; ix++) {
-      var worldX = (ix / GRID_RES) * MAP_SIZE - half;
-      var worldZ = (iy / GRID_RES) * MAP_SIZE - half;
+      var worldX = centerX + (ix / GRID_RES) * CHUNK_SIZE - half;
+      var worldZ = centerZ + (iy / GRID_RES) * CHUNK_SIZE - half;
 
-      // base noise
       var n = fbm(worldX * NOISE_SCALE, worldZ * NOISE_SCALE);
+      var h = (n - landThreshold) * 2;
 
-      // remap: shift so threshold is at sea level
-      var h = (n - landThreshold) * 2;  // -1..1 range roughly
-
-      // no border — open ocean fading to horizon
-
-      // clear center area for player spawn
-      var distFromCenter = Math.sqrt(worldX * worldX + worldZ * worldZ);
-      if (distFromCenter < SPAWN_CLEAR_RADIUS) {
-        var clearFactor = 1 - distFromCenter / SPAWN_CLEAR_RADIUS;
+      // keep the global origin clear for spawn only
+      var originDist = Math.sqrt(worldX * worldX + worldZ * worldZ);
+      if (originDist < SPAWN_CLEAR_RADIUS) {
+        var clearFactor = 1 - originDist / SPAWN_CLEAR_RADIUS;
         clearFactor = clearFactor * clearFactor;
-        h = h - clearFactor * 3;  // push below sea level
+        h -= clearFactor * 3;
       }
 
       data[iy * size + ix] = h;
     }
   }
 
-  // smooth heightmap for rounder, more natural island profiles
   gaussianBlur(data, size, 2);
-
   return { data: data, size: size };
 }
 
-// --- flood fill to ensure all water is navigable ---
-function ensureNavigable(heightmap) {
-  var size = heightmap.size;
-  var data = heightmap.data;
-  // find the center cell (guaranteed water)
-  var cx = Math.floor(size / 2);
-  var cy = Math.floor(size / 2);
+function sampleChunkHeight(chunk, globalX, globalZ) {
+  if (!chunk || !chunk.heightmap) return -1;
+  var size = chunk.heightmap.size;
+  var data = chunk.heightmap.data;
+  var half = CHUNK_SIZE * 0.5;
+  var minX = chunkCenter(chunk.cx) - half;
+  var minZ = chunkCenter(chunk.cy) - half;
 
-  // BFS from center to mark all reachable water
-  var visited = new Uint8Array(size * size);
-  var queue = [cx + cy * size];
-  visited[cx + cy * size] = 1;
+  var u = (globalX - minX) / CHUNK_SIZE * GRID_RES;
+  var v = (globalZ - minZ) / CHUNK_SIZE * GRID_RES;
 
-  while (queue.length > 0) {
-    var idx = queue.shift();
-    var y = Math.floor(idx / size);
-    var x = idx - y * size;
-    var neighbors = [
-      [x - 1, y], [x + 1, y], [x, y - 1], [x, y + 1]
-    ];
-    for (var i = 0; i < neighbors.length; i++) {
-      var nx = neighbors[i][0];
-      var ny = neighbors[i][1];
-      if (nx < 0 || nx >= size || ny < 0 || ny >= size) continue;
-      var ni = ny * size + nx;
-      if (visited[ni]) continue;
-      if (data[ni] <= SEA_LEVEL) {
-        visited[ni] = 1;
-        queue.push(ni);
-      }
-    }
-  }
-
-  // any water cell NOT visited is a landlocked pocket — fill with land
-  // (alternatively, lower unreachable land to make it water, but filling is simpler)
-  for (var i = 0; i < data.length; i++) {
-    if (data[i] <= SEA_LEVEL && !visited[i]) {
-      // this water pocket is unreachable — raise it to land
-      data[i] = 0.3;
-    }
-  }
-}
-
-// --- query heightmap at world position ---
-function sampleHeight(terrain, worldX, worldZ) {
-  var half = MAP_SIZE / 2;
-  var u = (worldX + half) / MAP_SIZE * GRID_RES;
-  var v = (worldZ + half) / MAP_SIZE * GRID_RES;
-  var size = terrain.heightmap.size;
-  var data = terrain.heightmap.data;
-
-  var ix = Math.floor(u);
-  var iy = Math.floor(v);
-  ix = Math.max(0, Math.min(size - 2, ix));
-  iy = Math.max(0, Math.min(size - 2, iy));
+  var ix = clamp(Math.floor(u), 0, size - 2);
+  var iy = clamp(Math.floor(v), 0, size - 2);
   var fx = u - ix;
   var fy = v - iy;
 
@@ -199,125 +205,716 @@ function sampleHeight(terrain, worldX, worldZ) {
   return hx0 + (hx1 - hx0) * fy;
 }
 
-// --- heightmap-specific queries for port placement (used during async load window) ---
-export function sampleHeightmap(terrain, worldX, worldZ) {
-  if (!terrain || !terrain.heightmap) return -1;
-  return sampleHeight(terrain, worldX, worldZ);
-}
-
-export function isHeightmapLand(terrain, worldX, worldZ) {
-  if (!terrain || !terrain.heightmap) return false;
-  return sampleHeight(terrain, worldX, worldZ) > SEA_LEVEL;
-}
-
-// --- public: check if a world position is on land ---
-export function isLand(terrain, worldX, worldZ) {
-  if (!terrain) return false;
-  if (terrain.useVisualCollision) return pointInVisualLand(terrain, worldX, worldZ, COLLISION_RADIUS);
-  return false;
-}
-
-// --- public: get terrain height at world position ---
-export function getTerrainHeight(terrain, worldX, worldZ) {
-  if (!terrain) return -1;
-  if (terrain.useVisualCollision) return pointInVisualLand(terrain, worldX, worldZ, COLLISION_RADIUS) ? 1 : -1;
-  return -1;
-}
-
-// --- public: collide a moving entity with terrain ---
-// Returns { collided, newX, newZ, normalX, normalZ } — pushes entity out of land
-export function collideWithTerrain(terrain, posX, posZ, prevX, prevZ) {
-  if (!terrain) return { collided: false, newX: posX, newZ: posZ, normalX: 0, normalZ: 0 };
-  if (terrain.useVisualCollision) {
-    var vcol = resolveVisualCollision(terrain, posX, posZ, prevX, prevZ);
-    if (vcol) return vcol;
+function gatherMaterialTextures(material, outSet) {
+  if (!material) return;
+  for (var k in material) {
+    if (!Object.prototype.hasOwnProperty.call(material, k)) continue;
+    var v = material[k];
+    if (v && v.isTexture) outSet.add(v);
   }
-  return { collided: false, newX: posX, newZ: posZ, normalX: 0, normalZ: 0 };
 }
 
-// --- public: check line-of-sight between two points ---
-// Returns true if terrain blocks the line
-export function terrainBlocksLine(terrain, x1, z1, x2, z2) {
-  if (!terrain) return false;
-  if (terrain.useVisualCollision) {
-    var vdx = x2 - x1;
-    var vdz = z2 - z1;
-    var vdist = Math.sqrt(vdx * vdx + vdz * vdz);
-    var vsteps = Math.ceil(vdist / 2.0);
-    if (vsteps < 2) vsteps = 2;
-    for (var vi = 1; vi < vsteps; vi++) {
-      var vt = vi / vsteps;
-      var vx = x1 + vdx * vt;
-      var vz = z1 + vdz * vt;
-      if (pointInVisualLand(terrain, vx, vz, VISUAL_COLLIDER_PAD)) return true;
+function collectChunkResources(group) {
+  var geometrySet = new Set();
+  var materialSet = new Set();
+  var textureSet = new Set();
+
+  if (!group) return { geometries: [], materials: [], textures: [] };
+
+  group.traverse(function (o) {
+    if (o.geometry) geometrySet.add(o.geometry);
+    if (!o.material) return;
+    if (Array.isArray(o.material)) {
+      for (var i = 0; i < o.material.length; i++) {
+        var m = o.material[i];
+        if (!m) continue;
+        materialSet.add(m);
+        gatherMaterialTextures(m, textureSet);
+      }
+    } else {
+      materialSet.add(o.material);
+      gatherMaterialTextures(o.material, textureSet);
     }
+  });
+
+  return {
+    geometries: Array.from(geometrySet),
+    materials: Array.from(materialSet),
+    textures: Array.from(textureSet)
+  };
+}
+
+function isSharedTemplateResource(resource) {
+  return !!(resource && resource.userData && resource.userData.__glbSharedTemplate);
+}
+
+function retainResource(refMap, resource) {
+  if (!resource || !resource.uuid) return;
+  if (isSharedTemplateResource(resource)) return;
+  var entry = refMap.get(resource.uuid);
+  if (entry) {
+    entry.count++;
+  } else {
+    refMap.set(resource.uuid, { resource: resource, count: 1 });
+  }
+}
+
+function releaseResource(refMap, resource) {
+  if (!resource || !resource.uuid) return false;
+  if (isSharedTemplateResource(resource)) return false;
+  var entry = refMap.get(resource.uuid);
+  if (!entry) return true;
+  entry.count--;
+  if (entry.count <= 0) {
+    refMap.delete(resource.uuid);
+    return true;
   }
   return false;
 }
 
-// --- public: create terrain for a zone ---
-export function createTerrain(seed, difficulty) {
-  var heightmap = generateHeightmap(seed, difficulty);
-  ensureNavigable(heightmap);
+function retainChunkResources(terrain, chunk) {
+  if (!chunk || chunk.resourcesTracked) return;
+  if (!chunk.resources) chunk.resources = collectChunkResources(chunk.group);
 
-  var mesh = new THREE.Group();
+  var i;
+  for (i = 0; i < chunk.resources.geometries.length; i++) {
+    retainResource(terrain.resourceRefs.geometry, chunk.resources.geometries[i]);
+  }
+  for (i = 0; i < chunk.resources.materials.length; i++) {
+    retainResource(terrain.resourceRefs.material, chunk.resources.materials[i]);
+  }
+  for (i = 0; i < chunk.resources.textures.length; i++) {
+    retainResource(terrain.resourceRefs.texture, chunk.resources.textures[i]);
+  }
 
-  var terrain = {
-    mesh: mesh,
-    heightmap: heightmap,
-    seed: seed,
-    difficulty: difficulty,
+  chunk.resourcesTracked = true;
+}
+
+function buildChunkGcEntries(chunk) {
+  var entries = [];
+  if (!chunk || !chunk.resources) return entries;
+  var i;
+  for (i = 0; i < chunk.resources.geometries.length; i++) {
+    entries.push({ type: "geometry", resource: chunk.resources.geometries[i] });
+  }
+  for (i = 0; i < chunk.resources.materials.length; i++) {
+    entries.push({ type: "material", resource: chunk.resources.materials[i] });
+  }
+  for (i = 0; i < chunk.resources.textures.length; i++) {
+    entries.push({ type: "texture", resource: chunk.resources.textures[i] });
+  }
+  return entries;
+}
+
+function disposeGcEntry(terrain, entry) {
+  if (!entry || !entry.resource) return;
+  var refMap = terrain.resourceRefs[entry.type];
+  var shouldDispose = releaseResource(refMap, entry.resource);
+  if (shouldDispose && entry.resource.dispose) {
+    entry.resource.dispose();
+    terrain.debug.disposedResources++;
+  }
+}
+
+function setChunkLocalPosition(terrain, chunk) {
+  if (!terrain || !chunk || !chunk.group) return;
+  var globalX = chunkCenter(chunk.cx);
+  var globalZ = chunkCenter(chunk.cy);
+  chunk.group.position.set(globalX - terrain.originOffsetX, 0, globalZ - terrain.originOffsetZ);
+}
+
+function collectTerrainColliders(terrain) {
+  var colliders = [];
+  terrain.chunks.forEach(function (chunk) {
+    if (chunk.state !== "active" || !chunk.useVisualCollision || !chunk.visualColliders) return;
+    for (var i = 0; i < chunk.visualColliders.length; i++) colliders.push(chunk.visualColliders[i]);
+  });
+  return colliders;
+}
+
+function getChunkAtGlobal(terrain, globalX, globalZ) {
+  var cx = toChunkCoord(globalX);
+  var cy = toChunkCoord(globalZ);
+  return terrain.chunks.get(chunkKey(cx, cy)) || null;
+}
+
+function ensureChunk(terrain, cx, cy) {
+  var key = chunkKey(cx, cy);
+  var existing = terrain.chunks.get(key);
+  if (existing) return existing;
+
+  var group = new THREE.Group();
+  var worldSeed = terrain.worldSeed | 0;
+  var chunkSeed = hashInt3(worldSeed, cx, cy);
+  var centerX = chunkCenter(cx);
+  var centerZ = chunkCenter(cy);
+  var metrics = distanceMetrics(centerX, centerZ);
+
+  var chunk = {
+    key: key,
+    cx: cx,
+    cy: cy,
+    group: group,
+    seed: chunkSeed,
+    worldSeed: worldSeed,
+    metrics: metrics,
+    heightmap: generateChunkHeightmap(worldSeed, terrain.difficulty, cx, cy),
     visualMode: "composite-field",
     compositePlacedCount: 0,
     compositeInstanceCount: 0,
     placedModelCount: 0,
     visualColliders: [],
+    minimapMarkers: [],
     useVisualCollision: false,
-    minimapMarkers: []
+    resources: null,
+    resourcesTracked: false,
+    gcEntries: null,
+    gcPrepared: false,
+    ready: false,
+    state: "loading"
   };
 
-  addCompositeFieldVisual(mesh, terrain, seed + difficulty * 101).then(function (res) {
-    terrain.compositePlacedCount = res ? (res.itemsPlaced || 0) : 0;
-    terrain.compositeInstanceCount = res ? (res.instancesPlaced || 0) : 0;
-    terrain.placedModelCount = terrain.compositePlacedCount;
+  setChunkLocalPosition(terrain, chunk);
+  terrain.mesh.add(group);
+  terrain.chunks.set(key, chunk);
+  terrain.debug.chunksCreated++;
 
-    if (terrain.placedModelCount <= 0) {
-      terrain.visualMode = "composite-fallback-tiered";
-      addTieredIslandFieldVisual(mesh, terrain, heightmap, seed).then(function (placed) {
-        terrain.placedModelCount = placed;
-        terrain.useVisualCollision = placed > 0;
-      });
-      return;
-    }
-    terrain.useVisualCollision = true;
+  console.log("[WORLD] chunk create", {
+    chunk: key,
+    active: terrain.chunks.size,
+    created: terrain.debug.chunksCreated,
+    destroyed: terrain.debug.chunksDestroyed
   });
+
+  var compositeChance = metrics.compositionChance;
+  var roll = seedToUnit(hashInt3(chunkSeed, 0x63d83595, 0x7f4a7c15));
+  var shouldGenerateVisuals = roll <= compositeChance;
+
+  function finalizeChunk() {
+    if (chunk.ready) return;
+    chunk.ready = true;
+    chunk.useVisualCollision = !!(chunk.visualColliders && chunk.visualColliders.length > 0);
+    retainChunkResources(terrain, chunk);
+
+    if (chunk.state === "queued") {
+      prepareChunkForGc(terrain, chunk);
+    } else {
+      chunk.state = "active";
+    }
+  }
+
+  if (!shouldGenerateVisuals) {
+    chunk.visualMode = "sparse-open-water";
+    chunk.useVisualCollision = false;
+    finalizeChunk();
+    return chunk;
+  }
+
+  addCompositeFieldVisual(group, chunk, chunkSeed + terrain.difficulty * 101)
+    .then(function (res) {
+      chunk.compositePlacedCount = res ? (res.itemsPlaced || 0) : 0;
+      chunk.compositeInstanceCount = res ? (res.instancesPlaced || 0) : 0;
+      chunk.placedModelCount = chunk.compositePlacedCount;
+
+      if (chunk.placedModelCount <= 0) {
+        chunk.visualMode = "composite-fallback-tiered";
+        return addTieredIslandFieldVisual(group, chunk, chunk.heightmap, chunkSeed).then(function (placed) {
+          chunk.placedModelCount = placed || 0;
+        });
+      }
+      return null;
+    })
+    .catch(function () {
+      // Keep this chunk navigable even if visual generation fails.
+      chunk.visualMode = "composite-failed-open-water";
+    })
+    .finally(function () {
+      finalizeChunk();
+    });
+
+  return chunk;
+}
+
+function prepareChunkForGc(terrain, chunk) {
+  if (!chunk || chunk.gcPrepared || chunk.state === "disposed") return;
+  if (!chunk.resourcesTracked) retainChunkResources(terrain, chunk);
+
+  chunk.gcEntries = buildChunkGcEntries(chunk);
+  chunk.gcPrepared = true;
+  chunk.state = "queued";
+
+  if (chunk.group && chunk.group.parent) {
+    chunk.group.parent.remove(chunk.group);
+  }
+  // Stop participating in collision/minimap immediately.
+  chunk.useVisualCollision = false;
+  chunk.visualColliders = [];
+  chunk.minimapMarkers = [];
+
+  terrain.gcQueue.push(chunk);
+}
+
+function enqueueChunkForGc(terrain, chunk) {
+  if (!chunk || chunk.state === "queued" || chunk.state === "disposed") return;
+  chunk.state = "queued";
+  if (chunk.ready) {
+    prepareChunkForGc(terrain, chunk);
+  }
+}
+
+function finalizeChunkDisposal(terrain, chunk) {
+  if (!chunk || chunk.state === "disposed") return;
+
+  terrain.chunks.delete(chunk.key);
+  chunk.state = "disposed";
+  chunk.group = null;
+  chunk.heightmap = null;
+  chunk.resources = null;
+  chunk.gcEntries = null;
+  chunk.visualColliders = null;
+  chunk.minimapMarkers = null;
+
+  terrain.debug.chunksDestroyed++;
+
+  console.log("[WORLD] chunk destroy", {
+    chunk: chunk.key,
+    active: terrain.chunks.size,
+    created: terrain.debug.chunksCreated,
+    destroyed: terrain.debug.chunksDestroyed,
+    disposedResources: terrain.debug.disposedResources
+  });
+}
+
+function processGcQueue(terrain) {
+  var budget = terrain.gcResourceBudget;
+
+  while (budget > 0 && terrain.gcQueue.length > 0) {
+    var chunk = terrain.gcQueue[0];
+    if (!chunk || !chunk.gcEntries) {
+      terrain.gcQueue.shift();
+      if (chunk) finalizeChunkDisposal(terrain, chunk);
+      continue;
+    }
+
+    if (chunk.gcEntries.length === 0) {
+      terrain.gcQueue.shift();
+      finalizeChunkDisposal(terrain, chunk);
+      continue;
+    }
+
+    var entry = chunk.gcEntries.pop();
+    disposeGcEntry(terrain, entry);
+    budget--;
+  }
+}
+
+function gatherChunksAroundGlobal(terrain, globalX, globalZ, range) {
+  var cx = toChunkCoord(globalX);
+  var cy = toChunkCoord(globalZ);
+  var rad = Math.max(1, Math.ceil((range || CHUNK_SIZE * 0.5) / CHUNK_SIZE) + 1);
+  var chunks = [];
+
+  for (var x = cx - rad; x <= cx + rad; x++) {
+    for (var y = cy - rad; y <= cy + rad; y++) {
+      var ch = terrain.chunks.get(chunkKey(x, y));
+      if (!ch || ch.state !== "active" || !ch.useVisualCollision || !ch.visualColliders || ch.visualColliders.length === 0) continue;
+      chunks.push(ch);
+    }
+  }
+  return chunks;
+}
+
+function pointInColliders(chunks, x, z, pad) {
+  var p = pad || 0;
+  for (var ci = 0; ci < chunks.length; ci++) {
+    var colliders = chunks[ci].visualColliders;
+    for (var i = 0; i < colliders.length; i++) {
+      var c = colliders[i];
+      if (x >= c.minX - p && x <= c.maxX + p && z >= c.minZ - p && z <= c.maxZ + p) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function resolveCollisionFromColliders(chunks, posX, posZ) {
+  var pad = COLLISION_RADIUS + VISUAL_COLLIDER_PAD;
+  var nx = posX;
+  var nz = posZ;
+  var collided = false;
+  var lastNX = 0;
+  var lastNZ = 0;
+
+  for (var it = 0; it < 4; it++) {
+    var any = false;
+    for (var ci = 0; ci < chunks.length; ci++) {
+      var colliders = chunks[ci].visualColliders;
+      for (var i = 0; i < colliders.length; i++) {
+        var c = colliders[i];
+        var minX = c.minX - pad;
+        var maxX = c.maxX + pad;
+        var minZ = c.minZ - pad;
+        var maxZ = c.maxZ + pad;
+        if (nx < minX || nx > maxX || nz < minZ || nz > maxZ) continue;
+
+        any = true;
+        collided = true;
+
+        var leftDist = Math.abs(nx - minX);
+        var rightDist = Math.abs(maxX - nx);
+        var downDist = Math.abs(nz - minZ);
+        var upDist = Math.abs(maxZ - nz);
+        var minDist = Math.min(leftDist, rightDist, downDist, upDist);
+
+        if (minDist === leftDist) { nx = minX - 0.02; lastNX = -1; lastNZ = 0; }
+        else if (minDist === rightDist) { nx = maxX + 0.02; lastNX = 1; lastNZ = 0; }
+        else if (minDist === downDist) { nz = minZ - 0.02; lastNX = 0; lastNZ = -1; }
+        else { nz = maxZ + 0.02; lastNX = 0; lastNZ = 1; }
+      }
+    }
+    if (!any) break;
+  }
+
+  if (!collided) return null;
+  return { collided: true, newX: nx, newZ: nz, normalX: lastNX, normalZ: lastNZ };
+}
+
+function computeAvoidanceFromChunks(chunks, worldX, worldZ, range) {
+  var out = { factor: 0, awayX: 0, awayZ: 0, distance: Infinity };
+  if (!chunks || chunks.length === 0) return out;
+
+  var avoidRange = range || 14;
+  var bestDist = Infinity;
+  var bestDx = 0;
+  var bestDz = 0;
+
+  for (var ci = 0; ci < chunks.length; ci++) {
+    var colliders = chunks[ci].visualColliders;
+    for (var i = 0; i < colliders.length; i++) {
+      var c = colliders[i];
+      var nx = clamp(worldX, c.minX, c.maxX);
+      var nz = clamp(worldZ, c.minZ, c.maxZ);
+      var dx = worldX - nx;
+      var dz = worldZ - nz;
+      var inside = (worldX >= c.minX && worldX <= c.maxX && worldZ >= c.minZ && worldZ <= c.maxZ);
+      var d = Math.sqrt(dx * dx + dz * dz);
+
+      if (inside) {
+        var ccx = (c.minX + c.maxX) * 0.5;
+        var ccz = (c.minZ + c.maxZ) * 0.5;
+        dx = worldX - ccx;
+        dz = worldZ - ccz;
+        d = 0;
+      }
+
+      if (d < bestDist) {
+        bestDist = d;
+        bestDx = dx;
+        bestDz = dz;
+      }
+    }
+  }
+
+  if (!isFinite(bestDist) || bestDist >= avoidRange) return out;
+
+  var len = Math.sqrt(bestDx * bestDx + bestDz * bestDz);
+  if (len < 0.0001) {
+    bestDx = 0;
+    bestDz = -1;
+    len = 1;
+  }
+
+  out.awayX = bestDx / len;
+  out.awayZ = bestDz / len;
+  var t = 1 - bestDist / avoidRange;
+  out.factor = clamp(t * t, 0, 1);
+  out.distance = bestDist;
+  return out;
+}
+
+function buildDesiredChunkSet(terrain, globalX, globalZ, heading) {
+  var desired = new Set();
+  var cx = toChunkCoord(globalX);
+  var cy = toChunkCoord(globalZ);
+
+  // Base active bubble around player.
+  for (var dx = -STREAM_RADIUS; dx <= STREAM_RADIUS; dx++) {
+    for (var dy = -STREAM_RADIUS; dy <= STREAM_RADIUS; dy++) {
+      desired.add(chunkKey(cx + dx, cy + dy));
+    }
+  }
+
+  // Preload a forward corridor to hide pop-in while sailing.
+  var dirX = Math.sin(heading || 0);
+  var dirZ = Math.cos(heading || 0);
+  for (var step = 1; step <= PRELOAD_AHEAD; step++) {
+    var ax = cx + Math.round(dirX * step);
+    var ay = cy + Math.round(dirZ * step);
+    for (var sx = -1; sx <= 1; sx++) {
+      for (var sy = -1; sy <= 1; sy++) {
+        desired.add(chunkKey(ax + sx, ay + sy));
+      }
+    }
+  }
+
+  return { desired: desired, centerX: cx, centerY: cy };
+}
+
+function forceGcIfNeeded(terrain, centerX, centerY, desiredSet) {
+  if (terrain.chunks.size <= ACTIVE_CHUNK_HARD_LIMIT) return;
+
+  var candidates = [];
+  terrain.chunks.forEach(function (chunk) {
+    if (!chunk || chunk.state !== "active") return;
+    if (desiredSet.has(chunk.key)) return;
+    var dx = chunk.cx - centerX;
+    var dy = chunk.cy - centerY;
+    candidates.push({ chunk: chunk, d2: dx * dx + dy * dy });
+  });
+
+  candidates.sort(function (a, b) { return b.d2 - a.d2; });
+
+  var idx = 0;
+  while (terrain.chunks.size - terrain.gcQueue.length > ACTIVE_CHUNK_SOFT_LIMIT && idx < candidates.length) {
+    enqueueChunkForGc(terrain, candidates[idx].chunk);
+    terrain.debug.forcedGcCount++;
+    idx++;
+  }
+}
+
+export function createTerrain(seed, difficulty) {
+  var mesh = new THREE.Group();
+
+  var terrain = {
+    mesh: mesh,
+    seed: seed,
+    worldSeed: seed | 0,
+    difficulty: difficulty,
+    chunks: new Map(),
+    gcQueue: [],
+    gcResourceBudget: GC_RESOURCE_BUDGET,
+    originOffsetX: 0,
+    originOffsetZ: 0,
+    resourceRefs: {
+      geometry: new Map(),
+      material: new Map(),
+      texture: new Map()
+    },
+    debug: {
+      chunksCreated: 0,
+      chunksDestroyed: 0,
+      disposedResources: 0,
+      forcedGcCount: 0
+    },
+    getDensityAt: function (worldX, worldZ) {
+      var globalX = worldX + terrain.originOffsetX;
+      var globalZ = worldZ + terrain.originOffsetZ;
+      return distanceMetrics(globalX, globalZ);
+    },
+    getDebugState: function () {
+      return {
+        seed: terrain.worldSeed,
+        activeChunks: terrain.chunks.size,
+        queuedGc: terrain.gcQueue.length,
+        created: terrain.debug.chunksCreated,
+        destroyed: terrain.debug.chunksDestroyed,
+        disposedResources: terrain.debug.disposedResources,
+        forcedGc: terrain.debug.forcedGcCount,
+        originOffsetX: terrain.originOffsetX,
+        originOffsetZ: terrain.originOffsetZ
+      };
+    }
+  };
+
+  // bootstrap around spawn so first frame has content
+  updateTerrainStreaming(terrain, 0, 0, 0, 0);
 
   return terrain;
 }
 
-// --- public: remove terrain from scene ---
-export function removeTerrain(terrain, scene) {
-  if (!terrain || !terrain.mesh) return;
-  scene.remove(terrain.mesh);
-  terrain.mesh.traverse(function (o) {
-    if (o.geometry) o.geometry.dispose();
-    if (!o.material) return;
-    if (Array.isArray(o.material)) {
-      for (var i = 0; i < o.material.length; i++) if (o.material[i] && o.material[i].dispose) o.material[i].dispose();
-    } else if (o.material.dispose) {
-      o.material.dispose();
+export function updateTerrainStreaming(terrain, playerX, playerZ, playerHeading) {
+  if (!terrain) return;
+
+  var globalX = playerX + terrain.originOffsetX;
+  var globalZ = playerZ + terrain.originOffsetZ;
+
+  var desiredInfo = buildDesiredChunkSet(terrain, globalX, globalZ, playerHeading || 0);
+  var desiredSet = desiredInfo.desired;
+
+  desiredSet.forEach(function (key) {
+    var parts = key.split(",");
+    var cx = parseInt(parts[0], 10);
+    var cy = parseInt(parts[1], 10);
+    ensureChunk(terrain, cx, cy);
+  });
+
+  terrain.chunks.forEach(function (chunk) {
+    if (!chunk || chunk.state === "queued" || chunk.state === "disposed") return;
+
+    var dx = Math.abs(chunk.cx - desiredInfo.centerX);
+    var dy = Math.abs(chunk.cy - desiredInfo.centerY);
+    var keep = dx <= KEEP_RADIUS && dy <= KEEP_RADIUS;
+    if (!keep) {
+      enqueueChunkForGc(terrain, chunk);
+    }
+  });
+
+  forceGcIfNeeded(terrain, desiredInfo.centerX, desiredInfo.centerY, desiredSet);
+  processGcQueue(terrain);
+}
+
+export function shiftTerrainOrigin(terrain, shiftX, shiftZ) {
+  if (!terrain || (!shiftX && !shiftZ)) return;
+
+  terrain.originOffsetX += shiftX;
+  terrain.originOffsetZ += shiftZ;
+
+  terrain.chunks.forEach(function (chunk) {
+    if (!chunk || chunk.state === "disposed") return;
+    if (chunk.group) {
+      chunk.group.position.x -= shiftX;
+      chunk.group.position.z -= shiftZ;
+    }
+
+    if (chunk.visualColliders) {
+      for (var i = 0; i < chunk.visualColliders.length; i++) {
+        var c = chunk.visualColliders[i];
+        c.minX -= shiftX;
+        c.maxX -= shiftX;
+        c.minZ -= shiftZ;
+        c.maxZ -= shiftZ;
+      }
+    }
+
+    if (chunk.minimapMarkers) {
+      for (var m = 0; m < chunk.minimapMarkers.length; m++) {
+        chunk.minimapMarkers[m].x -= shiftX;
+        chunk.minimapMarkers[m].z -= shiftZ;
+      }
     }
   });
 }
 
-// --- public: find a valid (water) spawn position near a point ---
+// --- heightmap queries (used for port placement and coastline checks) ---
+export function sampleHeightmap(terrain, worldX, worldZ) {
+  if (!terrain) return -1;
+
+  var globalX = worldX + terrain.originOffsetX;
+  var globalZ = worldZ + terrain.originOffsetZ;
+  var cx = toChunkCoord(globalX);
+  var cy = toChunkCoord(globalZ);
+  var chunk = ensureChunk(terrain, cx, cy);
+  if (!chunk || !chunk.heightmap) return -1;
+
+  return sampleChunkHeight(chunk, globalX, globalZ);
+}
+
+export function isHeightmapLand(terrain, worldX, worldZ) {
+  if (!terrain) return false;
+  return sampleHeightmap(terrain, worldX, worldZ) > SEA_LEVEL;
+}
+
+// --- collision / LOS queries ---
+export function isLand(terrain, worldX, worldZ) {
+  if (!terrain) return false;
+
+  var globalX = worldX + terrain.originOffsetX;
+  var globalZ = worldZ + terrain.originOffsetZ;
+  ensureChunk(terrain, toChunkCoord(globalX), toChunkCoord(globalZ));
+
+  var chunks = gatherChunksAroundGlobal(terrain, globalX, globalZ, COLLISION_RADIUS + 2);
+  return pointInColliders(chunks, worldX, worldZ, COLLISION_RADIUS);
+}
+
+export function getTerrainHeight(terrain, worldX, worldZ) {
+  if (!terrain) return -1;
+  return isLand(terrain, worldX, worldZ) ? 1 : -1;
+}
+
+export function collideWithTerrain(terrain, posX, posZ, prevX, prevZ) {
+  if (!terrain) {
+    return { collided: false, newX: posX, newZ: posZ, normalX: 0, normalZ: 0 };
+  }
+
+  var globalX = posX + terrain.originOffsetX;
+  var globalZ = posZ + terrain.originOffsetZ;
+  ensureChunk(terrain, toChunkCoord(globalX), toChunkCoord(globalZ));
+
+  var chunks = gatherChunksAroundGlobal(terrain, globalX, globalZ, 6);
+  var col = resolveCollisionFromColliders(chunks, posX, posZ);
+  if (col) return col;
+
+  return { collided: false, newX: posX, newZ: posZ, normalX: 0, normalZ: 0 };
+}
+
+export function terrainBlocksLine(terrain, x1, z1, x2, z2) {
+  if (!terrain) return false;
+
+  var midX = (x1 + x2) * 0.5 + terrain.originOffsetX;
+  var midZ = (z1 + z2) * 0.5 + terrain.originOffsetZ;
+  var dist = Math.sqrt((x2 - x1) * (x2 - x1) + (z2 - z1) * (z2 - z1));
+  var chunks = gatherChunksAroundGlobal(terrain, midX, midZ, dist * 0.5 + 8);
+
+  var steps = Math.max(2, Math.ceil(dist / 2));
+  for (var i = 1; i < steps; i++) {
+    var t = i / steps;
+    var sx = x1 + (x2 - x1) * t;
+    var sz = z1 + (z2 - z1) * t;
+    if (pointInColliders(chunks, sx, sz, VISUAL_COLLIDER_PAD)) return true;
+  }
+  return false;
+}
+
+export function getTerrainAvoidance(terrain, worldX, worldZ, range) {
+  if (!terrain) return { factor: 0, awayX: 0, awayZ: 0, distance: Infinity };
+
+  var globalX = worldX + terrain.originOffsetX;
+  var globalZ = worldZ + terrain.originOffsetZ;
+  var r = range || 14;
+  var chunks = gatherChunksAroundGlobal(terrain, globalX, globalZ, r + 4);
+  return computeAvoidanceFromChunks(chunks, worldX, worldZ, r);
+}
+
+// --- disposal ---
+export function removeTerrain(terrain, scene) {
+  if (!terrain || !terrain.mesh) return;
+  scene.remove(terrain.mesh);
+
+  // Dispose everything eagerly on full teardown.
+  terrain.chunks.forEach(function (chunk) {
+    if (!chunk) return;
+    if (!chunk.resources) chunk.resources = collectChunkResources(chunk.group);
+
+    for (var gi = 0; gi < chunk.resources.geometries.length; gi++) {
+      var g = chunk.resources.geometries[gi];
+      if (isSharedTemplateResource(g)) continue;
+      if (g && g.dispose) g.dispose();
+    }
+    for (var mi = 0; mi < chunk.resources.materials.length; mi++) {
+      var m = chunk.resources.materials[mi];
+      if (isSharedTemplateResource(m)) continue;
+      if (m && m.dispose) m.dispose();
+    }
+    for (var ti = 0; ti < chunk.resources.textures.length; ti++) {
+      var tx = chunk.resources.textures[ti];
+      if (isSharedTemplateResource(tx)) continue;
+      if (tx && tx.dispose) tx.dispose();
+    }
+  });
+
+  terrain.chunks.clear();
+  terrain.gcQueue = [];
+}
+
+// --- spawn helpers ---
 export function findWaterPosition(terrain, nearX, nearZ, minDist, maxDist) {
   if (!terrain) {
-    var angle = nextRandom() * Math.PI * 2;
-    var dist = minDist + nextRandom() * (maxDist - minDist);
-    return { x: nearX + Math.sin(angle) * dist, z: nearZ + Math.cos(angle) * dist };
+    var a = nextRandom() * Math.PI * 2;
+    var d = minDist + nextRandom() * (maxDist - minDist);
+    return { x: nearX + Math.sin(a) * d, z: nearZ + Math.cos(a) * d };
   }
-  // try random positions until we find water
+
   for (var attempt = 0; attempt < 50; attempt++) {
     var angle = nextRandom() * Math.PI * 2;
     var dist = minDist + nextRandom() * (maxDist - minDist);
@@ -327,47 +924,40 @@ export function findWaterPosition(terrain, nearX, nearZ, minDist, maxDist) {
       return { x: x, z: z };
     }
   }
-  // fallback: return center (always water)
-  return { x: 0, z: 0 };
+
+  return { x: nearX, z: nearZ };
 }
 
-// --- public: get edge proximity factor (0 = safe, 1 = at hard limit) ---
+// --- boundary is intentionally disabled for infinite world ---
 export function getEdgeFactor(worldX, worldZ) {
-  var dist = Math.sqrt(worldX * worldX + worldZ * worldZ);
-  if (dist <= EDGE_FOG_START) return 0;
-  return Math.min(1, (dist - EDGE_FOG_START) / (EDGE_HARD_LIMIT - EDGE_FOG_START));
+  return 0;
 }
 
-// --- public: apply map edge push-back to a position ---
-// Returns { posX, posZ, pushed } — nudges entity toward center when near edge
 export function applyEdgeBoundary(posX, posZ) {
-  var dist = Math.sqrt(posX * posX + posZ * posZ);
-  if (dist <= EDGE_PUSH_START) return { posX: posX, posZ: posZ, pushed: false };
-
-  var factor = Math.min(1, (dist - EDGE_PUSH_START) / (EDGE_HARD_LIMIT - EDGE_PUSH_START));
-  factor = factor * factor;  // ease-in: gentle at first, strong near limit
-
-  // push toward center
-  var pushStrength = factor * 15;  // max push force
-  var nx = posX / dist;
-  var nz = posZ / dist;
-  var newX = posX - nx * pushStrength * 0.016;  // ~1 frame at 60fps
-  var newZ = posZ - nz * pushStrength * 0.016;
-
-  // hard clamp at absolute limit
-  var newDist = Math.sqrt(newX * newX + newZ * newZ);
-  if (newDist > EDGE_HARD_LIMIT) {
-    newX = newX / newDist * EDGE_HARD_LIMIT;
-    newZ = newZ / newDist * EDGE_HARD_LIMIT;
-  }
-
-  return { posX: newX, posZ: newZ, pushed: true };
+  return { posX: posX, posZ: posZ, pushed: false };
 }
 
 export function getTerrainMinimapMarkers(terrain) {
-  if (!terrain || !terrain.minimapMarkers) return [];
-  return terrain.minimapMarkers;
+  if (!terrain) return [];
+  var markers = [];
+  terrain.chunks.forEach(function (chunk) {
+    if (!chunk || chunk.state !== "active" || !chunk.minimapMarkers) return;
+    for (var i = 0; i < chunk.minimapMarkers.length; i++) {
+      markers.push(chunk.minimapMarkers[i]);
+    }
+  });
+  return markers;
 }
 
-export { _getTerrainAvoidance as getTerrainAvoidance };
-export { createColliderDebugOverlay, removeColliderDebugOverlay };
+// --- debug overlay helpers ---
+export function createColliderDebugOverlay(terrain, scene) {
+  if (!terrain) return;
+  var proxy = {
+    visualColliders: collectTerrainColliders(terrain)
+  };
+  return createCompositeColliderDebugOverlay(proxy, scene);
+}
+
+export function removeColliderDebugOverlay(scene) {
+  removeCompositeColliderDebugOverlay(scene);
+}

--- a/game/js/terrainComposite.js
+++ b/game/js/terrainComposite.js
@@ -22,6 +22,7 @@ var MAP_SIZE = 400;
 var TERRAIN_HEIGHT = 4;
 
 var _compositePackPromise = null;
+var _worldPosTmp = new THREE.Vector3();
 
 function seededRand(seed) {
   var s = (seed >>> 0) || 1;
@@ -238,6 +239,12 @@ function addMinimapMarker(terrain, type, x, z, size, modelPath) {
   terrain.minimapMarkers.push({ type: type || "island", x: x, z: z, size: size || 1, modelPath: modelPath || "" });
 }
 
+function addMinimapMarkerForObject(terrain, type, obj, size, modelPath) {
+  if (!obj) return;
+  obj.getWorldPosition(_worldPosTmp);
+  addMinimapMarker(terrain, type, _worldPosTmp.x, _worldPosTmp.z, size, modelPath);
+}
+
 function shouldAddCompositeCollider(item) {
   return item && item.type === "island";
 }
@@ -367,10 +374,10 @@ export async function addCompositeFieldVisual(root, terrain, seed) {
         holder.scale.setScalar(worldScale);
         root.add(holder);
         if (shouldAddCompositeCollider(item)) addVisualColliderFromObject(terrain, holder, item.modelPath);
-        addMinimapMarker(
+        addMinimapMarkerForObject(
           terrain,
           getCompositeMarkerTypeByScale(item.type, worldScale),
-          holder.position.x, holder.position.z,
+          holder,
           worldScale, item.modelPath
         );
         itemsPlaced++;
@@ -437,7 +444,7 @@ export async function addTieredIslandFieldVisual(root, terrain, heightmap, seed)
       holder.scale.setScalar(minScale + rng() * (maxScale - minScale));
       root.add(holder);
       addVisualColliderFromObject(terrain, holder, SMALL_ISLAND_MODEL);
-      addMinimapMarker(terrain, markerType, cand.x, cand.z, holder.scale.x, SMALL_ISLAND_MODEL);
+      addMinimapMarkerForObject(terrain, markerType, holder, holder.scale.x, SMALL_ISLAND_MODEL);
       placed.push({ x: cand.x, z: cand.z });
       placedNow++;
     }

--- a/game/js/worldDebugView.js
+++ b/game/js/worldDebugView.js
@@ -226,6 +226,7 @@ function drawSnapshot(snapshot) {
   drawPlayer(snapshot.player);
 
   var terrain = snapshot.terrain || {};
+  var stream = terrain.streamSettings || {};
   infoEl.textContent =
     "seed " + (terrain.seed !== undefined ? terrain.seed : "n/a") +
     " | active " + (terrain.activeChunks || 0) +
@@ -236,6 +237,13 @@ function drawSnapshot(snapshot) {
     "\nstate: loading " + chunkCounts.loading + " | active " + chunkCounts.active + " | queued " + chunkCounts.queued +
     " | markers " + markers.length +
     " | enemies " + enemies.length +
+    "\nstream: r " + (stream.streamRadius !== undefined ? stream.streamRadius : "?") +
+    " | keep " + (stream.keepRadius !== undefined ? stream.keepRadius : "?") +
+    " | ahead " + (stream.preloadAhead !== undefined ? stream.preloadAhead : "?") +
+    " | budget " + (stream.chunkCreateBudget !== undefined ? stream.chunkCreateBudget : "?") +
+    " | soft/hard " + (stream.activeChunkSoftLimit !== undefined ? stream.activeChunkSoftLimit : "?") + "/" + (stream.activeChunkHardLimit !== undefined ? stream.activeChunkHardLimit : "?") +
+    " | desired " + (terrain.desiredChunkCount || 0) +
+    " | created/frame " + (terrain.createdThisFrame || 0) +
     "\ncontrols: F2 toggle, +/- zoom, mouse wheel zoom, drag to pan, follow toggle";
 }
 

--- a/game/js/worldDebugView.js
+++ b/game/js/worldDebugView.js
@@ -1,0 +1,466 @@
+// worldDebugView.js — live chunk/land debug overlay for infinite-world streaming
+import { isMobile } from "./mobile.js";
+import { T, FONT } from "./theme.js";
+
+var panel = null;
+var canvas = null;
+var canvasWrap = null;
+var ctx = null;
+var infoEl = null;
+var zoomLabel = null;
+var followBtn = null;
+var toggleBtn = null;
+
+var visible = false;
+var followPlayer = true;
+var zoom = isMobile() ? 0.08 : 0.12; // pixels per world unit
+var centerX = 0;
+var centerZ = 0;
+var drag = null;
+var lastSnapshot = null;
+
+var MIN_ZOOM = 0.005;
+var MAX_ZOOM = 1.0;
+
+function clamp(v, lo, hi) {
+  return Math.max(lo, Math.min(hi, v));
+}
+
+function chunkStateColor(state) {
+  if (state === "active") return { fill: "rgba(66,200,122,0.26)", stroke: "rgba(88,235,145,0.92)" };
+  if (state === "loading") return { fill: "rgba(70,146,235,0.20)", stroke: "rgba(120,190,255,0.9)" };
+  if (state === "queued") return { fill: "rgba(255,156,88,0.18)", stroke: "rgba(255,182,122,0.86)" };
+  return { fill: "rgba(150,150,150,0.12)", stroke: "rgba(180,180,180,0.6)" };
+}
+
+function markerColor(type) {
+  if (type === "port") return "#4aa3ff";
+  if (type === "tree") return "#4fd676";
+  if (type === "island_big") return "#dbc98f";
+  if (type === "island_mid") return "#ccb881";
+  return "#b8a46f";
+}
+
+function worldToCanvasX(worldX) {
+  return canvas.width * 0.5 + (worldX - centerX) * zoom;
+}
+
+function worldToCanvasY(worldZ) {
+  return canvas.height * 0.5 + (worldZ - centerZ) * zoom;
+}
+
+function canvasToWorldX(xPx) {
+  return centerX + (xPx - canvas.width * 0.5) / zoom;
+}
+
+function canvasToWorldZ(yPx) {
+  return centerZ + (yPx - canvas.height * 0.5) / zoom;
+}
+
+function refreshControls() {
+  if (zoomLabel) zoomLabel.textContent = "Zoom " + zoom.toFixed(3) + " px/u";
+  if (followBtn) {
+    followBtn.textContent = followPlayer ? "FOLLOW ON" : "FOLLOW OFF";
+    followBtn.style.opacity = followPlayer ? "1.0" : "0.75";
+  }
+}
+
+function syncCanvasSize() {
+  if (!canvas) return;
+  var rect = canvas.getBoundingClientRect();
+  var w = Math.max(320, Math.round(rect.width));
+  var h = Math.max(200, Math.round(rect.height));
+  if (canvas.width !== w || canvas.height !== h) {
+    canvas.width = w;
+    canvas.height = h;
+  }
+}
+
+function drawGrid(chunkSize) {
+  var halfWorldX = canvas.width * 0.5 / zoom;
+  var halfWorldZ = canvas.height * 0.5 / zoom;
+
+  var minWX = centerX - halfWorldX;
+  var maxWX = centerX + halfWorldX;
+  var minWZ = centerZ - halfWorldZ;
+  var maxWZ = centerZ + halfWorldZ;
+
+  var startX = Math.floor(minWX / chunkSize) * chunkSize;
+  var endX = Math.ceil(maxWX / chunkSize) * chunkSize;
+  var startZ = Math.floor(minWZ / chunkSize) * chunkSize;
+  var endZ = Math.ceil(maxWZ / chunkSize) * chunkSize;
+
+  for (var x = startX; x <= endX; x += chunkSize) {
+    var sx = worldToCanvasX(x);
+    var major = (Math.round(x / chunkSize) % 4) === 0;
+    ctx.strokeStyle = major ? "rgba(255,215,140,0.28)" : "rgba(255,215,140,0.13)";
+    ctx.lineWidth = major ? 1.1 : 0.8;
+    ctx.beginPath();
+    ctx.moveTo(sx, 0);
+    ctx.lineTo(sx, canvas.height);
+    ctx.stroke();
+  }
+
+  for (var z = startZ; z <= endZ; z += chunkSize) {
+    var sy = worldToCanvasY(z);
+    var majorZ = (Math.round(z / chunkSize) % 4) === 0;
+    ctx.strokeStyle = majorZ ? "rgba(255,215,140,0.28)" : "rgba(255,215,140,0.13)";
+    ctx.lineWidth = majorZ ? 1.1 : 0.8;
+    ctx.beginPath();
+    ctx.moveTo(0, sy);
+    ctx.lineTo(canvas.width, sy);
+    ctx.stroke();
+  }
+
+  var ox = worldToCanvasX(0);
+  var oy = worldToCanvasY(0);
+  ctx.strokeStyle = "rgba(255,182,76,0.85)";
+  ctx.lineWidth = 1.4;
+  ctx.beginPath();
+  ctx.moveTo(ox, 0);
+  ctx.lineTo(ox, canvas.height);
+  ctx.stroke();
+  ctx.beginPath();
+  ctx.moveTo(0, oy);
+  ctx.lineTo(canvas.width, oy);
+  ctx.stroke();
+}
+
+function drawPlayer(player) {
+  if (!player) return;
+  var px = worldToCanvasX(player.x);
+  var py = worldToCanvasY(player.z);
+  ctx.save();
+  ctx.translate(px, py);
+  ctx.rotate(-player.heading || 0);
+  ctx.fillStyle = "#f9f0ce";
+  ctx.strokeStyle = "#d4a44a";
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(0, -8);
+  ctx.lineTo(-5, 6);
+  ctx.lineTo(5, 6);
+  ctx.closePath();
+  ctx.fill();
+  ctx.stroke();
+  ctx.restore();
+}
+
+function drawSnapshot(snapshot) {
+  ctx.fillStyle = "rgba(8,12,20,0.92)";
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  if (!snapshot) {
+    ctx.fillStyle = "rgba(220,210,180,0.9)";
+    ctx.font = "14px " + FONT;
+    ctx.fillText("No world data yet (start a run).", 14, 26);
+    return;
+  }
+
+  var chunkSize = snapshot.chunkSize || 400;
+  drawGrid(chunkSize);
+
+  var chunkCounts = { loading: 0, active: 0, queued: 0 };
+  var chunks = snapshot.chunks || [];
+  for (var i = 0; i < chunks.length; i++) {
+    var ch = chunks[i];
+    if (!ch) continue;
+    if (ch.state === "active") chunkCounts.active++;
+    else if (ch.state === "queued") chunkCounts.queued++;
+    else if (ch.state === "loading") chunkCounts.loading++;
+
+    var worldX = ch.cx * chunkSize;
+    var worldZ = ch.cy * chunkSize;
+    var half = chunkSize * 0.5;
+    var x0 = worldToCanvasX(worldX - half);
+    var y0 = worldToCanvasY(worldZ - half);
+    var sizePx = chunkSize * zoom;
+    if (x0 > canvas.width || y0 > canvas.height || x0 + sizePx < 0 || y0 + sizePx < 0) continue;
+
+    var col = chunkStateColor(ch.state);
+    ctx.fillStyle = col.fill;
+    ctx.strokeStyle = col.stroke;
+    ctx.lineWidth = 1;
+    ctx.fillRect(x0, y0, sizePx, sizePx);
+    ctx.strokeRect(x0, y0, sizePx, sizePx);
+
+    if ((ch.placedModelCount || 0) > 0) {
+      ctx.fillStyle = "rgba(217,192,121,0.18)";
+      ctx.fillRect(x0 + 1, y0 + 1, sizePx - 2, sizePx - 2);
+    }
+    if (sizePx >= 42) {
+      ctx.fillStyle = "rgba(250,240,210,0.92)";
+      ctx.font = "11px " + FONT;
+      ctx.fillText(ch.cx + "," + ch.cy, x0 + 4, y0 + 13);
+      if ((ch.placedModelCount || 0) > 0) {
+        ctx.fillStyle = "rgba(238,204,122,0.95)";
+        ctx.fillText("land " + ch.placedModelCount, x0 + 4, y0 + 26);
+      }
+    }
+  }
+
+  var markers = snapshot.markers || [];
+  for (var m = 0; m < markers.length; m++) {
+    var mk = markers[m];
+    var mx = worldToCanvasX(mk.x);
+    var my = worldToCanvasY(mk.z);
+    if (mx < -3 || my < -3 || mx > canvas.width + 3 || my > canvas.height + 3) continue;
+    ctx.fillStyle = markerColor(mk.type);
+    ctx.beginPath();
+    ctx.arc(mx, my, 2.1, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  var enemies = snapshot.enemies || [];
+  for (var e = 0; e < enemies.length; e++) {
+    var en = enemies[e];
+    var ex = worldToCanvasX(en.x);
+    var ey = worldToCanvasY(en.z);
+    if (ex < -5 || ey < -5 || ex > canvas.width + 5 || ey > canvas.height + 5) continue;
+    ctx.fillStyle = "#ff6c5c";
+    ctx.beginPath();
+    ctx.arc(ex, ey, 3.3, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  drawPlayer(snapshot.player);
+
+  var terrain = snapshot.terrain || {};
+  infoEl.textContent =
+    "seed " + (terrain.seed !== undefined ? terrain.seed : "n/a") +
+    " | active " + (terrain.activeChunks || 0) +
+    " | queued " + (terrain.queuedGc || 0) +
+    " | created " + (terrain.created || 0) +
+    " | destroyed " + (terrain.destroyed || 0) +
+    " | disposed " + (terrain.disposedResources || 0) +
+    "\nstate: loading " + chunkCounts.loading + " | active " + chunkCounts.active + " | queued " + chunkCounts.queued +
+    " | markers " + markers.length +
+    " | enemies " + enemies.length +
+    "\ncontrols: F2 toggle, +/- zoom, mouse wheel zoom, drag to pan, follow toggle";
+}
+
+function requestRedraw() {
+  if (!visible || !ctx) return;
+  syncCanvasSize();
+  drawSnapshot(lastSnapshot);
+}
+
+function applyZoomFactor(factor, anchorX, anchorY) {
+  if (!canvas) return;
+  var prevZoom = zoom;
+  var nextZoom = clamp(zoom * factor, MIN_ZOOM, MAX_ZOOM);
+  if (Math.abs(nextZoom - prevZoom) < 1e-8) return;
+
+  if (anchorX !== undefined && anchorY !== undefined) {
+    var worldAX = canvasToWorldX(anchorX);
+    var worldAZ = canvasToWorldZ(anchorY);
+    zoom = nextZoom;
+    centerX = worldAX - (anchorX - canvas.width * 0.5) / zoom;
+    centerZ = worldAZ - (anchorY - canvas.height * 0.5) / zoom;
+  } else {
+    zoom = nextZoom;
+  }
+  refreshControls();
+  requestRedraw();
+}
+
+function setVisible(v) {
+  visible = !!v;
+  if (panel) panel.style.display = visible ? "flex" : "none";
+  if (toggleBtn) toggleBtn.style.display = visible ? "none" : "block";
+  if (visible) requestRedraw();
+}
+
+export function createWorldDebugView() {
+  if (panel) return;
+  var mobile = isMobile();
+
+  toggleBtn = document.createElement("button");
+  toggleBtn.className = "world-debug-toggle-btn";
+  toggleBtn.textContent = "WORLD DEBUG";
+  toggleBtn.style.cssText = [
+    "position:fixed",
+    mobile ? "left:10px" : "left:14px",
+    mobile ? "bottom:10px" : "bottom:14px",
+    "z-index:250",
+    "padding:7px 10px",
+    "font-family:" + FONT,
+    "font-size:" + (mobile ? "11px" : "12px"),
+    "letter-spacing:0.7px",
+    "color:" + T.gold,
+    "background:rgba(20,16,12,0.86)",
+    "border:1px solid " + T.borderGold,
+    "border-radius:6px",
+    "cursor:pointer",
+    "opacity:0.78"
+  ].join(";");
+  toggleBtn.addEventListener("click", function () { setVisible(!visible); });
+  document.body.appendChild(toggleBtn);
+
+  panel = document.createElement("div");
+  panel.style.cssText = [
+    "position:fixed",
+    "inset:0",
+    "z-index:320",
+    mobile ? "padding:8px" : "padding:12px",
+    "background:rgba(6,9,15,0.96)",
+    "font-family:" + FONT,
+    "display:none",
+    "flex-direction:column",
+    "gap:8px",
+    "box-sizing:border-box",
+    "user-select:none"
+  ].join(";");
+
+  var header = document.createElement("div");
+  header.style.cssText = "display:flex;align-items:center;justify-content:space-between;gap:8px;margin-bottom:6px";
+  var title = document.createElement("div");
+  title.textContent = "WORLD STREAM DEBUG SCREEN";
+  title.style.cssText = "color:" + T.gold + ";font-size:" + (mobile ? "12px" : "14px") + ";letter-spacing:1.2px;font-weight:bold";
+  var closeBtn = document.createElement("button");
+  closeBtn.textContent = "CLOSE (F2)";
+  closeBtn.style.cssText = "padding:5px 9px;border:1px solid " + T.borderGold + ";background:rgba(40,24,12,0.75);color:" + T.text + ";border-radius:4px;cursor:pointer;font-size:11px";
+  closeBtn.addEventListener("click", function () { setVisible(false); });
+  header.appendChild(title);
+  header.appendChild(closeBtn);
+  panel.appendChild(header);
+
+  var controls = document.createElement("div");
+  controls.style.cssText = "display:flex;align-items:center;gap:6px;flex-wrap:wrap";
+  followBtn = document.createElement("button");
+  followBtn.style.cssText = "padding:4px 8px;border:1px solid " + T.borderGold + ";background:rgba(40,24,12,0.75);color:" + T.text + ";border-radius:4px;cursor:pointer;font-size:11px";
+  followBtn.addEventListener("click", function () {
+    followPlayer = !followPlayer;
+    if (followPlayer && lastSnapshot && lastSnapshot.player) {
+      centerX = lastSnapshot.player.x;
+      centerZ = lastSnapshot.player.z;
+    }
+    refreshControls();
+    requestRedraw();
+  });
+
+  var recenterBtn = document.createElement("button");
+  recenterBtn.textContent = "ORIGIN";
+  recenterBtn.style.cssText = "padding:4px 8px;border:1px solid " + T.borderGold + ";background:rgba(40,24,12,0.75);color:" + T.text + ";border-radius:4px;cursor:pointer;font-size:11px";
+  recenterBtn.addEventListener("click", function () {
+    centerX = 0;
+    centerZ = 0;
+    followPlayer = false;
+    refreshControls();
+    requestRedraw();
+  });
+
+  var minusBtn = document.createElement("button");
+  minusBtn.textContent = "-";
+  minusBtn.style.cssText = "padding:4px 8px;border:1px solid " + T.borderGold + ";background:rgba(40,24,12,0.75);color:" + T.text + ";border-radius:4px;cursor:pointer;font-size:12px;font-weight:bold";
+  minusBtn.addEventListener("click", function () { applyZoomFactor(1 / 1.18); });
+  var plusBtn = document.createElement("button");
+  plusBtn.textContent = "+";
+  plusBtn.style.cssText = "padding:4px 8px;border:1px solid " + T.borderGold + ";background:rgba(40,24,12,0.75);color:" + T.text + ";border-radius:4px;cursor:pointer;font-size:12px;font-weight:bold";
+  plusBtn.addEventListener("click", function () { applyZoomFactor(1.18); });
+
+  zoomLabel = document.createElement("div");
+  zoomLabel.style.cssText = "margin-left:4px;color:" + T.textDim + ";font-size:11px";
+  controls.appendChild(followBtn);
+  controls.appendChild(recenterBtn);
+  controls.appendChild(minusBtn);
+  controls.appendChild(plusBtn);
+  controls.appendChild(zoomLabel);
+  panel.appendChild(controls);
+
+  canvasWrap = document.createElement("div");
+  canvasWrap.style.cssText = "flex:1;min-height:220px;border:1px solid " + T.borderGold + ";border-radius:8px;overflow:hidden";
+
+  canvas = document.createElement("canvas");
+  canvas.width = mobile ? 360 : 960;
+  canvas.height = mobile ? 220 : 520;
+  canvas.style.cssText = "width:100%;height:100%;display:block;background:#0d1119;cursor:grab";
+  ctx = canvas.getContext("2d");
+  canvasWrap.appendChild(canvas);
+  panel.appendChild(canvasWrap);
+
+  infoEl = document.createElement("div");
+  infoEl.style.cssText = "white-space:pre-line;color:" + T.textDim + ";font-size:11px;line-height:1.35;border:1px solid " + T.borderGold + ";border-radius:6px;padding:6px;background:rgba(20,16,12,0.6)";
+  panel.appendChild(infoEl);
+
+  canvas.addEventListener("wheel", function (e) {
+    e.preventDefault();
+    applyZoomFactor(e.deltaY < 0 ? 1.15 : (1 / 1.15), e.offsetX, e.offsetY);
+  }, { passive: false });
+
+  canvas.addEventListener("mousedown", function (e) {
+    followPlayer = false;
+    drag = {
+      x: e.clientX,
+      y: e.clientY,
+      centerX: centerX,
+      centerZ: centerZ
+    };
+    canvas.style.cursor = "grabbing";
+    refreshControls();
+  });
+
+  window.addEventListener("mousemove", function (e) {
+    if (!drag) return;
+    var dx = e.clientX - drag.x;
+    var dy = e.clientY - drag.y;
+    centerX = drag.centerX - dx / zoom;
+    centerZ = drag.centerZ - dy / zoom;
+    requestRedraw();
+  });
+
+  window.addEventListener("mouseup", function () {
+    drag = null;
+    if (canvas) canvas.style.cursor = "grab";
+  });
+
+  window.addEventListener("resize", function () {
+    if (!visible) return;
+    requestRedraw();
+  });
+
+  window.addEventListener("keydown", function (e) {
+    if (e.key === "Escape" && visible) {
+      setVisible(false);
+      e.preventDefault();
+    }
+  });
+
+  document.body.appendChild(panel);
+  refreshControls();
+}
+
+export function isWorldDebugVisible() {
+  return visible;
+}
+
+export function toggleWorldDebugView(forceValue) {
+  if (forceValue === true || forceValue === false) setVisible(forceValue);
+  else setVisible(!visible);
+}
+
+export function zoomWorldDebugView(factor) {
+  applyZoomFactor(factor || 1.0);
+}
+
+export function getWorldDebugState() {
+  return {
+    visible: visible,
+    zoom: zoom,
+    followPlayer: followPlayer,
+    centerX: centerX,
+    centerZ: centerZ
+  };
+}
+
+export function updateWorldDebugView(snapshot) {
+  if (snapshot) {
+    lastSnapshot = snapshot;
+    if (followPlayer && snapshot.player) {
+      centerX = snapshot.player.x;
+      centerZ = snapshot.player.z;
+    }
+  }
+  if (!visible || !ctx) return;
+  drawSnapshot(lastSnapshot);
+}


### PR DESCRIPTION
## Summary
- add persisted world-stream settings (radius/keep/preload, chunk create budget, soft/hard chunk caps)
- switch desired chunk scheduling to prioritize current tile first, then expand outward by distance rings
- throttle chunk creation per frame to prevent over-generation at low zoom/mobile
- ensure desired/preload chunks are protected from immediate GC while still culling non-desired far chunks
- expose stream controls in Settings (`WORLD STREAM`) with reset defaults
- extend world debug overlay with live stream config + desired/created-per-frame counters

## Why
- procedural world generation was creating too many chunks at once, especially when zoomed out, causing sluggish performance on mobile
- rendering should prioritize the player’s current tile and outward neighbors for better responsiveness

## Validation
- `node --check game/js/terrain.js`
- `node --check game/js/settingsMenu.js`
- `node --check game/js/worldDebugView.js`
- `node --check game/js/main.js`
- Playwright runs produced screenshots/state captures, including active in-combat terrain snapshot with stream telemetry (`output/web-game/iter37-stream-bruteforce/state-0.json`)
